### PR TITLE
Fix time range slider bleed out of container while resizing

### DIFF
--- a/src/components/common/range-slider.js
+++ b/src/components/common/range-slider.js
@@ -193,10 +193,11 @@ export default class RangeSlider extends Component {
     const plotWidth =  width - sliderHandleWidth;
 
     return (
-      <div className="kg-range-slider" style={{width: '100%', padding: '0 6px'}}
-         ref={comp => {
-           this.sliderContainer = comp;
-         }}>
+      <div
+        className="kg-range-slider" style={{width: '100%', padding: `0 ${sliderHandleWidth / 2}px`}}
+        ref={comp => {
+          this.sliderContainer = comp;
+        }}>
         {histogram && histogram.length ? (
           <RangePlot
             histogram={histogram}

--- a/src/components/common/time-range-slider.js
+++ b/src/components/common/time-range-slider.js
@@ -33,6 +33,7 @@ import RangeSlider from './range-slider';
 import TimeSliderMarker from './time-slider-marker';
 
 const defaultTimeFormat = val => moment.utc(val).format('MM/DD/YY hh:mma');
+const animationControlWidth = 140;
 
 const StyledSliderContainer = styled.div`
   margin-top: ${props => props.isEnlarged ? '12px' : '0px'};
@@ -139,19 +140,21 @@ export default class TimeRangeSlider extends Component {
             resetAnimation={this._resetAnimation}
             startAnimation={this._startAnimation}
           /> : null}
-          <RangeSlider
-            range={domain}
-            value0={value[0]}
-            value1={value[1]}
-            histogram={this.props.histogram}
-            lineChart={this.props.lineChart}
-            plotType={this.props.plotType}
-            isEnlarged={isEnlarged}
-            showInput={false}
-            step={this.props.step}
-            onChange={this._sliderUpdate}
-            xAxis={TimeSliderMarker}
-          />
+          <div style={{width: isEnlarged ? `calc(100% - ${animationControlWidth}px)` : '100%'}}>
+            <RangeSlider
+              range={domain}
+              value0={value[0]}
+              value1={value[1]}
+              histogram={this.props.histogram}
+              lineChart={this.props.lineChart}
+              plotType={this.props.plotType}
+              isEnlarged={isEnlarged}
+              showInput={false}
+              step={this.props.step}
+              onChange={this._sliderUpdate}
+              xAxis={TimeSliderMarker}
+            />
+          </div>
         </StyledSliderContainer>
       </div>
     );

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -282,7 +282,7 @@ function KeplerGlFactory(
               uiState={uiState}
               visStateActions={visStateActions}
               sidePanelWidth={
-                DIMENSIONS.sidePanel.width - DIMENSIONS.sidePanel.margin
+                DIMENSIONS.sidePanel.width + DIMENSIONS.sidePanel.margin
               }
               containerW={containerW}
             />


### PR DESCRIPTION
use width=calc(100% - animateionControlWidth) to control time range slider width
![ezgif com-optimize 6](https://user-images.githubusercontent.com/3605556/39210997-2b5787aa-47bf-11e8-9805-3869df861b1a.gif)

