### PR TITLE
Correct checking fields format properties in dataset schema

### DIFF
--- a/src/schemas/dataset-schema.js
+++ b/src/schemas/dataset-schema.js
@@ -82,7 +82,7 @@ class DatasetSchema extends Schema {
     // recalculate field type
     // because we have updated type-analyzer
     // we need to add format to each field
-    const needCalculateMeta = !fields[0].format;
+    const needCalculateMeta = fields[0] && !fields[0].hasOwnProperty('format');
 
     if (needCalculateMeta) {
       const fieldOrder = fields.map(f => f.name);

--- a/test/fixtures/state-saved-v1-2.js
+++ b/test/fixtures/state-saved-v1-2.js
@@ -5023,7 +5023,7 @@ export const stateSavedV1_2 = {
           {name: 'meta_data', type: 'real', format: ''},
           {name: 'start_ts', type: 'timestamp', format: 'x'},
           {name: 'end_ts', type: 'timestamp', format: 'x'},
-          {name: 'time string', type: 'timestamp', format: 'M/D/YYYY H:m'}
+          {name: 'time string', type: 'timestamp', format: 'YYYY/M/D H:m'}
         ]
       }
     }


### PR DESCRIPTION
use .hasOwnProperty to check existence of 'format' in saved fields