### PR TITLE
[Bug] Fix time widget position when loaded in a  modal

### DIFF
--- a/src/components/filters/time-widget.js
+++ b/src/components/filters/time-widget.js
@@ -30,7 +30,7 @@ import {TIME_ANIMATION_SPEED} from 'utils/filter-utils';
 const innerPdSide = 32;
 
 const WidgetContainer = styled.div`
-  position: fixed;
+  position: absolute;
   padding: 20px;
   bottom: 0;
   right: 0;


### PR DESCRIPTION
- Change position: fix to absolute

![screen shot 2018-05-10 at 1 17 32 pm](https://user-images.githubusercontent.com/3605556/39892435-7c97844c-5455-11e8-98c5-f2be0631c1d3.png)
