### PR TITLE
[Bug] Readjust the position of the map popover when it extends beyond the right and top edges of screen

### DIFF
--- a/src/components/map/map-popover.js
+++ b/src/components/map/map-popover.js
@@ -143,13 +143,13 @@ export class MapPopover extends Component {
     const {mapState} = this.props;
     const {width, height} = this.state;
     const pos = {};
-    if (x + leftOffset + width > mapState.innerWidth) {
-      pos.right = mapState.innerWidth - x + leftOffset;
+    if (x + leftOffset + width > mapState.width) {
+      pos.right = mapState.width - x + leftOffset;
     } else {
       pos.left = x + leftOffset;
     }
 
-    if (y + topOffset + height > mapState.innerHeight) {
+    if (y + topOffset + height > mapState.height) {
       pos.bottom = 10;
     } else {
       pos.top = y + topOffset;


### PR DESCRIPTION
Fixes this bug reported by eriearth:

> ![image](https://user-images.githubusercontent.com/6504944/40458293-28fc6b94-5eb0-11e8-8035-6994d890d9bd.png)
> Tooltip don't seen to read/ detect the end of a webpage. Tooltip continues to display to the right (in my case) instead of flipping to the left where there is still more browser space.
