### PR TITLE
[Enhancement] Add `pluginName=Keplergl` url parameter to Mapbox API requests

### DIFF
--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -33,6 +33,8 @@ import {StyledMapContainer} from 'components/common/styled-components';
 // Overlay type
 import {generateMapboxLayers, updateMapboxLayers} from '../layers/mapbox-utils';
 
+import {transformRequest} from 'utils/mapbox-utils';
+
 // default-settings
 import {LAYER_BLENDINGS} from 'constants/default-settings';
 
@@ -426,16 +428,7 @@ export default function MapContainerFactory(MapPopover, MapControl) {
         preserveDrawingBuffer: true,
         mapboxApiAccessToken,
         onViewportChange: updateMap,
-        transformRequest: (url, resourceType) => {
-          let transformedUrl = url;
-          if ( url.slice(8,22) === 'api.mapbox.com' || url.slice(10,26) === 'tiles.mapbox.com' ) {
-            // Add parameter to identify kepler.gl Mapbox app traffic
-            transformedUrl = [url.slice(0, url.indexOf("?")+1), "pluginName=Keplergl&", url.slice(url.indexOf("?")+1)].join('');
-          }
-          return {
-            url: transformedUrl
-          }
-        }
+        transformRequest
       };
 
       return (

--- a/src/components/modals/add-map-style-modal.js
+++ b/src/components/modals/add-map-style-modal.js
@@ -26,6 +26,9 @@ import MapboxGLMap from 'react-map-gl';
 import {findDOMNode} from 'react-dom';
 import {StyledModalContent, InputLight, StyledMapContainer} from 'components/common/styled-components';
 
+// Utils
+import {transformRequest} from 'utils/mapbox-utils';
+
 const MapH = 190;
 const MapW = 264;
 const ErrorMsg = {
@@ -164,17 +167,8 @@ class AddMapStyleModal extends Component {
     ...mapState,
     preserveDrawingBuffer: true,
     mapboxApiAccessToken: this.props.mapboxApiAccessToken,
-    transformRequest: (url, resourceType) => {
-      let transformedUrl = url;
-      if ( url.slice(8,22) === 'api.mapbox.com' || url.slice(10,26) === 'tiles.mapbox.com' ) {
-        // Add parameter to identify kepler.gl Mapbox app traffic
-        transformedUrl = [url.slice(0, url.indexOf("?")+1), "pluginName=Keplergl&", url.slice(url.indexOf("?")+1)].join('');
-      }
-      return {
-        url: transformedUrl
-      }
-    }
-  }
+    transformRequest
+  };
 
     return (
       <div className="add-map-style-modal">

--- a/src/utils/mapbox-utils.js
+++ b/src/utils/mapbox-utils.js
@@ -1,0 +1,8 @@
+export const transformRequest = (url, resourceType) => {
+  const isMapboxRequest = url.slice(8, 22) === 'api.mapbox.com' ||
+    url.slice(10, 26) === 'tiles.mapbox.com';
+
+  return {
+    url: isMapboxRequest ? url.replace('?', '?pluginName=Keplergl&') : url
+  };
+};


### PR DESCRIPTION
Adds a URL parameter `pluginName=Keplergl` to all Mapbox API requests made from the mapboxgl.map object cc/ @heshan0131 @chrisirhc 

Example transformed API request:

* Tiles:  https://b.tiles.mapbox.com/v4/mapbox.mapbox-terrain-v2,mapbox.mapbox-streets-v7,eklimcz.00zz64mq/9/81/198.vector.pbf?pluginName=Keplergl&access_token=my-token
* Non-Mapbox API requests (requests not to `api.mapbox.com` or `*.tiles.mapbox.com`) remain unchanged

## Known issue

When adding a custom Mapbox style, the map options for `transformRequest` are not maintained.  Map options for `transformRequest` are maintained when selecting from the list of Kepler.gl styles `muted light`, `light,` etc.  

@heshan0131 is the map initialization handled for custom Mapbox GL style sheets differently than Uber-sourced styles?

Tests are failing on Travis but pass locally running with `yarn run test`.  Not sure why.

## To Do:

- [x] Determine why the `transformRequest` map options are not maintained when using a custom map style
- [x] Fix tests