### PR TITLE
[bug] Use correct npm registry url, fix travis ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "reselect": "^3.0.1",
     "styled-components": "^2.2.4",
     "supercluster": "^3.0.0",
-    "type-analyzer": "https://registry.npmjs.org/uber-web/-/type-analyzer-0.1.4.tgz",
+    "type-analyzer": "https://registry.npmjs.org/type-analyzer/-/type-analyzer-0.1.4.tgz",
     "uber-licence": "^3.1.1",
     "wellknown": "^0.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7247,9 +7247,9 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
 
-"type-analyzer@https://registry.npmjs.org/uber-web/-/type-analyzer-0.1.4.tgz":
+"type-analyzer@https://registry.npmjs.org/type-analyzer/-/type-analyzer-0.1.4.tgz":
   version "0.1.4"
-  resolved "https://registry.npmjs.org/uber-web/-/type-analyzer-0.1.4.tgz#4592d5792831d0fb061a68feb870d7d171c287aa"
+  resolved "https://registry.npmjs.org/type-analyzer/-/type-analyzer-0.1.4.tgz#4592d5792831d0fb061a68feb870d7d171c287aa"
 
 type-check@~0.3.1, type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
https://github.com/uber/kepler.gl/issues/57
- Install react-onclickoutside from `https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz`
- Install type-analyzer from `https://registry.npmjs.org/type-analyzer/-/type-analyzer-0.1.4.tgz`