### PR TITLE
[Bug]Solve issue #547 avoid crash application

### DIFF
--- a/src/processors/data-processor.js
+++ b/src/processors/data-processor.js
@@ -422,11 +422,14 @@ export function processGeojson(rawData) {
   // getting all feature fields
   const allData = normalizedGeojson.features.reduce((accu, f, i) => {
     if (f.geometry) {
-      Object.keys(f.properties).forEach(key => {
-        if(typeof f.properties[key] === "object"){
-          f.properties[key] = JSON.stringify(f.properties[key]);
-        }
-      });
+      // check if properties contains object and stringfy this
+      if(typeof f.properties === 'object' && f.properties !== null){
+        Object.keys(f.properties).forEach(key => {
+          if(typeof f.properties[key] === 'object'){
+            f.properties[key] = JSON.stringify(f.properties[key]);
+          }
+        });
+      }
       accu.push({
         // add feature to _geojson field
         _geojson: f,

--- a/src/processors/data-processor.js
+++ b/src/processors/data-processor.js
@@ -422,6 +422,11 @@ export function processGeojson(rawData) {
   // getting all feature fields
   const allData = normalizedGeojson.features.reduce((accu, f, i) => {
     if (f.geometry) {
+      Object.keys(f.properties).forEach(key => {
+        if(typeof f.properties[key] === "object"){
+          f.properties[key] = JSON.stringify(f.properties[key]);
+        }
+      });
       accu.push({
         // add feature to _geojson field
         _geojson: f,


### PR DESCRIPTION
Add type check in geojson-processor to avoid crash when geojson contains an object in any properties. 


Signed-off-by: Matheus Monte <clark.monte1@gmail.com>