### PR TITLE
[Bug] remove isMouseOver state from MapPopover

### DIFF
--- a/src/components/map/map-popover.js
+++ b/src/components/map/map-popover.js
@@ -21,10 +21,9 @@
 import React, {PureComponent} from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-import {Pin} from 'components/common/icons';
 import LayerHoverInfoFactory from './layer-hover-info';
 import CoordinateInfoFactory from './coordinate-info';
+import {Pin} from 'components/common/icons';
 
 const MAX_WIDTH = 500;
 const MAX_HEIGHT = 600;
@@ -97,7 +96,6 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
     constructor(props) {
       super(props);
       this.state = {
-        isMouseOver: false,
         width: 380,
         height: 160
       };
@@ -148,7 +146,6 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
 
     render() {
       const {x, y, freezed, coordinate, layerHoverProp} = this.props;
-      const hidden = !this.state.isMouseOver;
 
       const style =
         Number.isFinite(x) && Number.isFinite(y) ? this._getPosition(x, y) : {};
@@ -158,16 +155,10 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
           ref={comp => {
             this.popover = comp;
           }}
-          className={classnames('map-popover', {hidden})}
+          className="map-popover"
           style={{
             ...style,
             maxWidth: MAX_WIDTH
-          }}
-          onMouseEnter={() => {
-            this.setState({isMouseOver: true});
-          }}
-          onMouseLeave={() => {
-            this.setState({isMouseOver: false});
           }}
         >
           {freezed ? (


### PR DESCRIPTION
- map popover no longer needs `isMouerOver` state to persist when user mouse over it. Now User can click on the feature to pin mouse popover

- The `hidden` class doesn't do anyting in kepler.gl, but juyter notebook css has a hidden class that prevented popover to be shown

#576 