### PR TITLE
[fix] Correct Custom Theme Example Link

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ yarn --ignore-engines && yarn start
 
 - ### [replace-component][replace-component]
   Example showing how to replace kepler.gl default components using `injectComponents` method.
-  
+
 - ### [custom-theme][custom-theme]
   Customize kepler.gl theme by override current style properties.
 
@@ -33,4 +33,4 @@ yarn --ignore-engines && yarn start
 [open-modal]: open-modal
 [umd-client]: umd-client
 [replace-component]: replace-component
-[custom-reducer]: custom-theme
+[custom-theme]: custom-theme


### PR DESCRIPTION
There is an error in markdown link of the custom theme example in examples README.md