### PR TITLE
Update link to the GitHub repo

### DIFF
--- a/bindings/kepler.gl-jupyter/setup.py
+++ b/bindings/kepler.gl-jupyter/setup.py
@@ -156,7 +156,7 @@ setup_args = {
 
     'author': 'Shan He',
     'author_email': 'shan@uber.com',
-    'url': 'https://github.com/keplergl/kepler.gl/bindings/kepler.gl-jupyter',
+    'url': 'https://github.com/keplergl/kepler.gl/tree/master/bindings/kepler.gl-jupyter',
     'keywords': [
         'ipython',
         'jupyter',


### PR DESCRIPTION
Update [the link on the pypi.org webpage](https://pypi.org/project/keplergl/) to redirect to the GitHub repo properly.