### PR TITLE
Explicitly pass window.fetch to Dropbox to suppress warning

### DIFF
--- a/examples/demo-app/src/utils/cloud-providers/dropbox.js
+++ b/examples/demo-app/src/utils/cloud-providers/dropbox.js
@@ -29,7 +29,7 @@ const DOMAIN = 'www.dropbox.com';
 const APP_NAME= 'Kepler.gl%20(managed%20by%20Uber%20Technologies%2C%20Inc.)';
 const KEPLER_DROPBOX_FOLDER_LINK = `//${DOMAIN}/home/Apps/${APP_NAME}`;
 const CORS_FREE_DOMAIN = 'dl.dropboxusercontent.com';
-const dropbox = new Dropbox();
+const dropbox = new Dropbox({fetch: window.fetch});
 
 /**
  * Set the auth toke to be used with dropbox client


### PR DESCRIPTION
![Screenshot 2019-07-22 12 53 20](https://user-images.githubusercontent.com/931368/61649550-b2acbd80-ac7f-11e9-9eaf-d4c08cb4150c.png)

Dropbox SDK [added a warning](https://github.com/dropbox/dropbox-sdk-js/commit/061d355da7ecafa2ce9b810825701d385dfefd78) to deprecate relying on the global `window.fetch`. This PR suppresses that warning.