### PR TITLE
Switch from callback refs to createRef

### DIFF
--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -60,7 +60,7 @@ const StyledUploadMessage = styled.div`
   color: ${props => props.theme.textColorLT};
   font-size: 14px;
   margin-bottom: 12px;
-  
+
   ${media.portable`
     font-size: 12px;
   `}
@@ -89,7 +89,7 @@ const StyledFileDrop = styled.div`
     color: ${props => props.theme.linkBtnColor};
     padding-right: 4px;
   }
-  
+
   ${media.portable`
     padding: 16px 4px 0;
   `};
@@ -104,7 +104,7 @@ const MsgWrapper = styled.div`
 const StyledDragNDropIcon = styled.div`
   color: ${fileIconColor};
   margin-bottom: 48px;
-  
+
   ${media.portable`
     margin-bottom: 16px;
   `};
@@ -170,6 +170,8 @@ export default class FileUpload extends Component {
     files: [],
     errorFiles: []
   };
+
+  frame = createRef();
 
   _isValidFileType = filename => {
     const {validFileExt} = this.props;
@@ -237,7 +239,7 @@ export default class FileUpload extends Component {
     return (
       <StyledFileUpload
         className="file-uploader"
-        ref={cmp => (this.frame = cmp)}
+        ref={this.frame}
       >
         <input
           className="filter-upload__input"
@@ -246,7 +248,7 @@ export default class FileUpload extends Component {
         />
         {FileDrop ? (
           <FileDrop
-            frame={this.frame}
+            frame={this.frame.current}
             targetAlwaysVisible
             onDragOver={() => this._toggleDragState(true)}
             onDragLeave={() => this._toggleDragState(false)}

--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -246,7 +246,7 @@ export default class FileUpload extends Component {
           type="file"
           onChange={this._onChange}
         />
-        {FileDrop ? (
+        {FileDrop && this.frame.current ? (
           <FileDrop
             frame={this.frame.current}
             targetAlwaysVisible

--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -246,9 +246,9 @@ export default class FileUpload extends Component {
           type="file"
           onChange={this._onChange}
         />
-        {FileDrop && this.frame.current ? (
+        {FileDrop ? (
           <FileDrop
-            frame={this.frame.current}
+            frame={this.frame.current || document}
             targetAlwaysVisible
             onDragOver={() => this._toggleDragState(true)}
             onDragLeave={() => this._toggleDragState(false)}

--- a/src/components/common/file-uploader/upload-button.js
+++ b/src/components/common/file-uploader/upload-button.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -41,9 +41,11 @@ export default class UploadButton extends Component {
     onUpload: PropTypes.func.isRequired
   };
 
+  _fileInput = createRef();
+
   _onClick = () => {
-    this._fileInput.value = null;
-    this._fileInput.click();
+    this._fileInput.current.value = null;
+    this._fileInput.current.click();
   };
 
   _onChange = ({target: {files}}) => {
@@ -59,7 +61,7 @@ export default class UploadButton extends Component {
       <Wrapper>
         <input
           type="file"
-          ref={ref => {this._fileInput = ref}}
+          ref={this._fileInput}
           style={{display: 'none'}}
           onChange={this._onChange}
         />

--- a/src/components/common/item-selector/typeahead.js
+++ b/src/components/common/item-selector/typeahead.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import fuzzy from 'fuzzy';
 import classNames from 'classnames';
@@ -168,10 +168,10 @@ export default class Typeahead extends Component {
     });
 
     // call focus on entry or div to trigger key events listener
-    if (this.entry) {
-      this.entry.focus();
+    if (this.entry.current) {
+      this.entry.current.focus();
     } else {
-      this.root.focus();
+      this.root.current.focus();
     }
   }
 
@@ -183,6 +183,9 @@ export default class Typeahead extends Component {
 
     this.setState({searchResults});
   }
+
+  root = createRef();
+  entry = createRef();
 
   _shouldSkipSearch(input) {
     const emptyValue = !input || input.trim().length === 0;
@@ -207,8 +210,8 @@ export default class Typeahead extends Component {
   }
 
   focus() {
-    if (this.entry) {
-      this.entry.focus();
+    if (this.entry.current) {
+      this.entry.current.focus();
     }
   }
 
@@ -285,7 +288,7 @@ export default class Typeahead extends Component {
   // use () => {} to avoid binding 'this'
   _onTextEntryUpdated = () => {
     if (this.props.searchable) {
-      const value = this.entry.value;
+      const value = this.entry.current.value;
 
       this.setState({
         searchResults: this.getOptionsForValue(value, this.props.options),
@@ -480,9 +483,7 @@ export default class Typeahead extends Component {
     return (
       <TypeaheadWrapper
         className={classList}
-        ref={comp => {
-          this.root = comp;
-        }}
+        ref={this.root}
         tabIndex="0"
         onKeyDown={this._onKeyDown}
         onKeyPress={this.props.onKeyPress}
@@ -493,9 +494,7 @@ export default class Typeahead extends Component {
         {this.props.searchable ? (
         <InputBox>
           <TypeaheadInput
-            ref={comp => {
-              this.entry = comp;
-            }}
+            ref={this.entry}
             type="text"
             disabled={this.props.disabled}
             {...this.props.inputProps}

--- a/src/components/common/range-brush.js
+++ b/src/components/common/range-brush.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {event, select} from 'd3-selection';
@@ -52,7 +52,7 @@ export default class RangeBrush extends Component {
     this.brushing = false;
     this.moving = false;
 
-    this.root = select(this.rootContainer);
+    this.root = select(this.rootContainer.current);
     this.brush = brushX()
       .on('start', () => {
         this.brushing = true;
@@ -96,6 +96,8 @@ export default class RangeBrush extends Component {
     }
   }
 
+  rootContainer = createRef();
+
   _reset() {
     const [minValue, maxValue] = this.props.range;
     this._onBrush(minValue, maxValue);
@@ -126,9 +128,8 @@ export default class RangeBrush extends Component {
     return (
       <StyledG
         className="kg-range-slider__brush"
-        ref={comp => {
-          this.rootContainer = comp;
-      }}/>
+        ref={this.rootContainer}
+      />
     );
   }
 };

--- a/src/components/common/range-slider.js
+++ b/src/components/common/range-slider.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -40,7 +40,7 @@ const SliderWrapper = styled.div`
   position: relative;
 `;
 
-const RangeInputWrapper =styled.div`
+const RangeInputWrapper = styled.div`
   margin-top: 6px;
   display: flex;
   justify-content: space-between;
@@ -84,6 +84,10 @@ export default class RangeSlider extends Component {
   componentDidUpdate() {
     this._resize();
   }
+
+  sliderContainer = createRef();
+  inputValue0 = createRef();
+  inputValue1 = createRef();
 
   _setValueFromProps = props => {
     const {value0, value1} = props;
@@ -134,7 +138,7 @@ export default class RangeSlider extends Component {
   };
 
   _resize() {
-    const width = this.sliderContainer.offsetWidth;
+    const width = this.sliderContainer.current.offsetWidth;
     if (width !== this.state.width) {
       this.setState({width});
     }
@@ -142,6 +146,7 @@ export default class RangeSlider extends Component {
 
   _renderInput(key) {
     const setRange = key === 'value0' ? this._setRangeVal0 : this._setRangeVal1;
+    const ref = key === 'value0' ? this.inputValue0 : this.inputValue1;
     const update = e => {
       if (!setRange(e.target.value)) {
         this.setState({[key]: this.state[key]});
@@ -152,9 +157,7 @@ export default class RangeSlider extends Component {
       <SliderInput
         className="kg-range-slider__input"
         type="number"
-        ref={comp => {
-          this[`input-${key}`] = comp;
-        }}
+        ref={ref}
         id={`slider-input-${key}`}
         key={key}
         value={this.state[key]}
@@ -164,7 +167,7 @@ export default class RangeSlider extends Component {
         onKeyPress={e => {
           if (e.key === 'Enter') {
             update(e);
-            this[`input-${key}`].blur();
+            ref.current.blur();
           }
         }}
         onBlur={update}
@@ -197,9 +200,8 @@ export default class RangeSlider extends Component {
     return (
       <div
         className="kg-range-slider" style={{width: '100%', padding: `0 ${sliderHandleWidth / 2}px`}}
-        ref={comp => {
-          this.sliderContainer = comp;
-        }}>
+        ref={this.sliderContainer}
+      >
         {histogram && histogram.length ? (
           <RangePlot
             histogram={histogram}

--- a/src/components/common/slider/slider.js
+++ b/src/components/common/slider/slider.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import styled from 'styled-components';
@@ -82,14 +82,10 @@ export default class Slider extends Component {
     showTooltip: false
   };
 
-  ref = undefined;
-
-  _saveRef = ref => {
-    this.ref = ref;
-  };
+  ref = createRef();
 
   _getBaseDistance() {
-    return this.props.vertical ? this.ref.offsetHeight : this.ref.offsetWidth;
+    return this.props.vertical ? this.ref.current.offsetHeight : this.ref.current.offsetWidth;
   }
 
   _getValDelta(x) {
@@ -174,7 +170,7 @@ export default class Slider extends Component {
     return (
       <SliderWrapper
         className={classnames('kg-slider', {...classSet})}
-        ref={this._saveRef}
+        ref={this.ref}
         isRanged={isRanged}
         vertical={vertical}
       >

--- a/src/components/common/time-slider-marker.js
+++ b/src/components/common/time-slider-marker.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import {scaleUtc} from 'd3-scale';
 import {select} from 'd3-selection';
@@ -79,6 +79,8 @@ export default class TimeSliderMarker extends Component {
     }
   }
 
+  xAxis = createRef();
+
   domainSelector = props => props.domain;
   widthSelector = props => props.width;
   scaleSelector = createSelector(
@@ -101,12 +103,8 @@ export default class TimeSliderMarker extends Component {
       .tickSize(8)
       .tickPadding(6);
 
-    const svg = select(this.svgContainer);
-
-    svg
-      .select('.x.axis')
-      .call(xAxis)
-      .selectAll('text');
+    select(this.xAxis.current)
+      .call(xAxis);
   }
 
   render() {
@@ -115,11 +113,8 @@ export default class TimeSliderMarker extends Component {
         className="time-slider-marker"
         width={this.props.width}
         height={height}
-        ref={comp => {
-          this.svgContainer = comp;
-        }}
       >
-        <g className="x axis" transform="translate(0, 0)" />
+        <g ref={this.xAxis} transform="translate(0, 0)" />
       </TimeSliderContainer>
     );
   }

--- a/src/components/common/time-slider-marker.js
+++ b/src/components/common/time-slider-marker.js
@@ -114,7 +114,7 @@ export default class TimeSliderMarker extends Component {
         width={this.props.width}
         height={height}
       >
-        <g ref={this.xAxis} transform="translate(0, 0)" />
+        <g className="x axis" ref={this.xAxis} transform="translate(0, 0)" />
       </TimeSliderContainer>
     );
   }

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import {console as Console} from 'global/window';
 import {bindActionCreators} from 'redux';
 import styled, {ThemeProvider, withTheme}  from 'styled-components';
@@ -124,6 +124,8 @@ function KeplerGlFactory(
         this._handleResize(nextProps);
       }
     }
+
+    root = createRef();
 
     /* selector */
     themeSelector = props => props.theme;
@@ -297,9 +299,7 @@ function KeplerGlFactory(
             }}
             className="kepler-gl"
             id={`kepler-gl__${id}`}
-            ref={node => {
-              this.root = node;
-            }}
+            ref={this.root}
           >
             <NotificationPanel {...notificationPanelFields} />
             {!uiState.readOnly && <SidePanel {...sideFields} />}
@@ -338,7 +338,7 @@ function KeplerGlFactory(
               visStateActions={visStateActions}
               uiStateActions={uiStateActions}
               mapStyleActions={mapStyleActions}
-              rootNode={this.root}
+              rootNode={this.root.current}
               containerW={containerW}
               containerH={mapState.height}
             />

--- a/src/components/map/map-popover.js
+++ b/src/components/map/map-popover.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {PureComponent} from 'react';
+import React, {PureComponent, createRef} from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import LayerHoverInfoFactory from './layer-hover-info';
@@ -109,8 +109,10 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
       this._setContainerSize();
     }
 
+    popover = createRef();
+
     _setContainerSize() {
-      const node = this.popover;
+      const node = this.popover.current;
       if (!node) {
         return;
       }
@@ -152,9 +154,7 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
 
       return (
         <StyledMapPopover
-          ref={comp => {
-            this.popover = comp;
-          }}
+          ref={this.popover}
           className="map-popover"
           style={{
             ...style,

--- a/src/components/plot-container.js
+++ b/src/components/plot-container.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 // libraries
-import React, {Component} from 'react';
+import React, {Component, createRef} from 'react';
 import PropTypes from 'prop-types';
 import {createSelector} from 'reselect';
 import styled from 'styled-components';
@@ -79,6 +79,8 @@ export default function PlotContainerFactory(MapContainer) {
       }
     }
 
+    plottingAreaRef = createRef();
+
     mapStyleSelector = props => props.mapFields.mapStyle;
     resolutionSelector = props => props.exportImageSetting.resolution;
     scaledMapStyleSelector = createSelector(
@@ -101,13 +103,11 @@ export default function PlotContainerFactory(MapContainer) {
     };
 
     _retrieveNewScreenshot = () => {
-
-      if (this.plottingAreaRef) {
-
+      if (this.plottingAreaRef.current) {
         this.props.startExportingImage();
         const filter = node => node.className !== 'mapboxgl-control-container';
 
-        convertToPng(this.plottingAreaRef, {filter}).then(dataUri => {
+        convertToPng(this.plottingAreaRef.current, {filter}).then(dataUri => {
           this.props.setExportImageDataUri(dataUri);
         })
         .catch(err => {
@@ -152,9 +152,7 @@ export default function PlotContainerFactory(MapContainer) {
           style={{position: 'absolute', top: -9999, left: -9999}}
         >
           <div
-            ref={element => {
-              this.plottingAreaRef = element;
-            }}
+            ref={this.plottingAreaRef}
             style={{
               width: exportImageSize.width,
               height: exportImageSize.height


### PR DESCRIPTION
`createRef` is the preferred way of interacting with the DOM in React. This updates all callback refs to use the newer API.