### PR TITLE
[Bug] Logic issue in Layer.registerVisConfig preventing custom boolean properties

### DIFF
--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -485,7 +485,7 @@ export default class Layer {
           LAYER_VIS_CONFIGS[layerVisConfigs[item]].defaultValue;
         this.visConfigSettings[item] = LAYER_VIS_CONFIGS[layerVisConfigs[item]];
       } else if (
-        ['type', 'defaultValue'].every(p => layerVisConfigs[item][p])
+        ['type', 'defaultValue'].every(p => layerVisConfigs[item].hasOwnProperty(p))
       ) {
         // if provided customized visConfig, and has type && defaultValue
         // TODO: further check if customized visConfig is valid


### PR DESCRIPTION
Fixed small logic issue in base-layer.js => registerVisConfig. The if statement checking for custom visConfig props skips over booleans with the defaultValue of 'false', evaluating the statement as falsey.

**Before**
`if (['type', 'defaultValue'].every(p => layerVisConfigs[item][p])`

**After**
`if (['type', 'defaultValue'].every(p => layerVisConfigs[item].hasOwnProperty(p))`

#644 

Signed-off-by: Harrison Hutcheon <hahman12@gmail.com>