### PR TITLE
[Enhancement] Use preserved state to apply keplerGlInit. when mint=false

### DIFF
--- a/src/components/map/layer-hover-info.js
+++ b/src/components/map/layer-hover-info.js
@@ -17,6 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+
 import React from 'react';
 import styled from 'styled-components';
 import {CenterFlexbox} from 'components/common/styled-components';

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -254,6 +254,7 @@ export const SCALE_FUNC = {
   sqrt: require('d3-scale').scaleSqrt,
   point: require('d3-scale').scalePoint
 };
+
 export const ALL_FIELD_TYPES = keyMirror({
   boolean: null,
   date: null,

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -254,7 +254,6 @@ export const SCALE_FUNC = {
   sqrt: require('d3-scale').scaleSqrt,
   point: require('d3-scale').scalePoint
 };
-
 export const ALL_FIELD_TYPES = keyMirror({
   boolean: null,
   date: null,

--- a/src/reducers/root.js
+++ b/src/reducers/root.js
@@ -31,15 +31,18 @@ const initialCoreState = {};
 export function provideInitialState(initialState) {
   const coreReducer = coreReducerFactory(initialState);
 
-  const handleRegisterEntry = (state, {payload: {id, mint, mapboxApiAccessToken, mapboxApiUrl, mapStylesReplaceDefault}}) => ({
-    // register a new entry to voyager reducer
+  const handleRegisterEntry = (state, {payload: {id, mint, mapboxApiAccessToken, mapboxApiUrl, mapStylesReplaceDefault}}) => {
+
     // by default, always create a mint state even if the same id already exist
     // if state.id exist and mint=false, keep the existing state
-    ...state,
-    [id]: state[id] && mint === false ? state[id] : {
-      ...coreReducer(undefined, keplerGlInit({mapboxApiAccessToken, mapboxApiUrl, mapStylesReplaceDefault}))
+    const previousState = state[id] && mint === false ? state[id] : undefined;
+
+    return {
+      // register entry to kepler.gl passing in mapbox config to mapStyle
+      ...state,
+      [id]: coreReducer(previousState, keplerGlInit({mapboxApiAccessToken, mapboxApiUrl, mapStylesReplaceDefault}))
     }
-  });
+  };
 
   const handleDeleteEntry = (state, {payload: id}) =>
     Object.keys(state).reduce(


### PR DESCRIPTION
- When mint=false, kepler.gl will use the existing state instance. However, this also causes the `mapboxApiAccessToken` `mapboxApiUrl` and `mapStylesReplaceDefault` not being store in the reducer.
- We will call `keplerGlInit` on existing state as well. The `INIT` action is only listened by `map-style` reducer and is only used to store the 3 props above.

Signed-off-by: Shan He <heshan0131@gmail.com>