### PR TITLE
[Bug] check new layers based on new dataset id

### DIFF
--- a/src/reducers/vis-state-updaters.js
+++ b/src/reducers/vis-state-updaters.js
@@ -887,7 +887,6 @@ export const receiveMapConfigUpdater = (state, {payload: {config = {}, options =
 
   // reset config if keepExistingConfig is falsy
   let mergedState = !keepExistingConfig ? resetMapConfigUpdater(state) : state;
-
   mergedState = mergeFilters(mergedState, filters);
   mergedState = mergeLayers(mergedState, layers);
   mergedState = mergeInteractions(mergedState, interactionConfig);
@@ -1071,15 +1070,20 @@ export const updateVisDataUpdater = (state, action) => {
   // merge state with saved splitMaps
   mergedState = mergeSplitMaps(mergedState, splitMapsToBeMerged);
 
-  if (mergedState.layers.length === state.layers.length) {
+  let newLayers = mergedState.layers.filter(
+    l => l.config.dataId in newDateEntries
+  );
+
+  if (!newLayers.length) {
     // no layer merged, find defaults
     mergedState = addDefaultLayers(mergedState, newDateEntries);
   }
 
   if (mergedState.splitMaps.length) {
-    const newLayers = mergedState.layers.filter(
+    newLayers = mergedState.layers.filter(
       l => l.config.dataId in newDateEntries
     );
+
     // if map is split, add new layers to splitMaps
     mergedState = {
       ...mergedState,

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -677,26 +677,6 @@ test('#visStateReducer -> UPDATE_VIS_DATA.1 -> No data', t => {
 test('#visStateReducer -> UPDATE_VIS_DATA.2 -> to empty state', t => {
   const oldState = InitialVisState;
 
-  // const testState1 = reducer(
-  //   oldState,
-  //   VisStateActions.updateVisData({
-  //     data: mockRawData,
-  //     info: {id: 'smoothie', label: 'exciting dataset 1'}
-  //   })
-  // );
-
-  // t.deepEqual(
-  //   Object.keys(testState1.datasets),
-  //   ['smoothie'],
-  //   'should save data to smoothie'
-  // );
-
-  // t.equal(
-  //   testState1.layers.length,
-  //   4,
-  //   'should create 4 default layers'
-  // );
-
   const newState = reducer(
     oldState,
     VisStateActions.updateVisData([

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-statements */
 // Copyright (c) 2019 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -621,7 +622,7 @@ test('#visStateReducer -> REMOVE_LAYER', t => {
   t.end();
 });
 
-test('#visStateReducer -> UPDATE_VIS_DATA.1', t => {
+test('#visStateReducer -> UPDATE_VIS_DATA.1 -> No data', t => {
   const oldState = {
     datasets: {},
     layers: [{name: 'a'}, {name: 'b'}],
@@ -673,22 +674,28 @@ test('#visStateReducer -> UPDATE_VIS_DATA.1', t => {
 });
 
 /* eslint-disable max-statements */
-test('#visStateReducer -> UPDATE_VIS_DATA.2', t => {
+test('#visStateReducer -> UPDATE_VIS_DATA.2 -> to empty state', t => {
   const oldState = InitialVisState;
 
-  const testState1 = reducer(
-    oldState,
-    VisStateActions.updateVisData({
-      data: mockRawData,
-      info: {id: 'smoothie', label: 'exciting dataset 1'}
-    })
-  );
+  // const testState1 = reducer(
+  //   oldState,
+  //   VisStateActions.updateVisData({
+  //     data: mockRawData,
+  //     info: {id: 'smoothie', label: 'exciting dataset 1'}
+  //   })
+  // );
 
-  t.deepEqual(
-    Object.keys(testState1.datasets),
-    ['smoothie'],
-    'should save data to smoothie'
-  );
+  // t.deepEqual(
+  //   Object.keys(testState1.datasets),
+  //   ['smoothie'],
+  //   'should save data to smoothie'
+  // );
+
+  // t.equal(
+  //   testState1.layers.length,
+  //   4,
+  //   'should create 4 default layers'
+  // );
 
   const newState = reducer(
     oldState,
@@ -823,7 +830,7 @@ test('#visStateReducer -> UPDATE_VIS_DATA.2', t => {
   t.end();
 });
 
-test('#visStateReducer -> UPDATE_VIS_DATA.3', t => {
+test('#visStateReducer -> UPDATE_VIS_DATA.3 -> merge w/ existing state', t => {
   const mockLayer = new PointLayer({
     dataId: 'snowflake',
     columns: {
@@ -967,7 +974,7 @@ test('#visStateReducer -> UPDATE_VIS_DATA.3', t => {
   t.end();
 });
 
-test('#visStateReducer -> UPDATE_VIS_DATA.4.Geojson', t => {
+test('#visStateReducer -> UPDATE_VIS_DATA.4.Geojson -> geojson data', t => {
   const initialVisState = CloneDeep(INITIAL_VIS_STATE);
 
   const {fields, rows} = processGeojson(CloneDeep(geojsonData));
@@ -1064,6 +1071,69 @@ test('#visStateReducer -> UPDATE_VIS_DATA.4.Geojson', t => {
     expectedLayerData.data,
     'should save geojson to datasets'
   );
+
+  t.end();
+});
+
+test('#visStateReducer -> UPDATE_VIS_DATA.4.Geojson -> with config', t => {
+  const initialVisState = CloneDeep(INITIAL_VIS_STATE);
+
+  const {fields, rows} = processGeojson(CloneDeep(geojsonData));
+
+  const payload = [
+    {
+      info: {
+        id: 'milkshake',
+        label: 'king milkshake'
+      },
+      data: {fields, rows}
+    }
+  ];
+
+  // receive data
+  const initialState = reducer(
+    initialVisState,
+    VisStateActions.updateVisData(payload)
+  );
+
+  t.equal(initialState.layers.length, 1, 'should create 1 layer');
+
+  // add data and config again
+
+    // data
+  const datasets = [{
+    info: {
+      id: 'milkshake2',
+      label: 'king milkshake'
+    },
+    data: {fields, rows}
+  }];
+
+  const config = {
+    visState: {
+      layers: [
+        {
+          id: 'test_layer_2',
+          type: 'geojson',
+          config: {
+            dataId: 'milkshake2',
+            columns: {
+              geojson: '_geojson'
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  const testState = reducer(
+    initialState,
+    VisStateActions.updateVisData(datasets, {}, config)
+  );
+
+  t.deepEqual(Object.keys(testState.datasets), ['milkshake2'], 'should reset state, and load dataset');
+  t.equal(testState.layers.length, 1, 'should create 1 layer');
+  t.equal(testState.layers[0].id, 'test_layer_2', 'should merge 1 layer from config');
 
   t.end();
 });
@@ -1210,13 +1280,19 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
 
   const layer2 = new PointLayer({
     dataId: 'milkshake',
-    id: 'b',
+    id: 'c',
+    isVisible: false
+  });
+
+  const layer3 = new PointLayer({
+    dataId: 'milkshake',
+    id: 'd',
     isVisible: false
   });
 
   const oldState = {
     ...InitialVisState,
-    layers: [layer0, layer1, layer2],
+    layers: [layer0, layer1, layer2, layer3],
     splitMaps: [
       {
         layers: {
@@ -1241,7 +1317,7 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
       }
     },
     layerData: [],
-    layerOrder: [2, 1, 0]
+    layerOrder: [2, 1, 0, 3]
   };
 
   const newState = reducer(
@@ -1255,7 +1331,7 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
   );
 
   // first visible layer should be point
-  const id1 = newState.layers[3].id;
+  const id1 = newState.layers[4].id;
   const expectedSplitMaps = [
     {
       layers: {
@@ -1275,18 +1351,18 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
 
   t.equal(
     newState.layers.length,
-    7,
+    8,
     'should create 1 arc 1 line and 2 point layers'
   );
   t.deepEqual(
     newState.layerOrder,
-    [3, 4, 5, 6, 2, 1, 0],
+    [4, 5, 6, 7, 2, 1, 0, 3],
     'should move new layers to front'
   );
   t.deepEqual(
     newState.splitMaps,
     expectedSplitMaps,
-    'should add new layers to splitmaps'
+    'should add new layers to split maps'
   );
 
   t.end();


### PR DESCRIPTION
- Bug: when add data with a preset config to a map that already has layers.  If `oldState.layers.length` happens to equal to `mergedState.layers.length`, kepler thinks no new layers has been merged, therefore create default layers.
- Fixe: Check if any new layers are merged from config based on new dataset id
#719 
Signed-off-by: Shan He <heshan0131@gmail.com>