### PR TITLE
[Bug] Fix prettier

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "eslint-config-uber-es2015",
     "eslint-config-prettier",
     "prettier",
+    "plugin:prettier/recommended",
     "prettier/react"
   ],
   "env": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,7 @@
 {
   "extends": [
-    "eslint-config-uber-jsx",
-    "eslint-config-uber-es2015",
-    "eslint-config-prettier",
+    "uber-jsx",
+    "uber-es2015",
     "prettier",
     "plugin:prettier/recommended",
     "prettier/react"

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
 {
   "extends": [
-    "eslint-config-prettier",
-    "eslint-config-uber-es2015",
     "eslint-config-uber-jsx",
+    "eslint-config-uber-es2015",
+    "eslint-config-prettier",
     "prettier",
     "prettier/react"
   ],
@@ -25,6 +25,7 @@
     "react/no-multi-comp": 0,
     "prefer-spread": 1,
     "prefer-template": 1,
+    "prettier/prettier": "error",
     "quote-props": 1,
     "spaced-comment": 1,
     "max-params": 0,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
   "bracketSpacing": false,
-  "singleQuote": true,
-  "trailingComma": "none",
+  "printWidth": 100,
   "semi": true,
-  "printWidth": 80
+  "singleQuote": true,
+  "trailingComma": "none"
 }

--- a/contributing/DEVELOPERS.md
+++ b/contributing/DEVELOPERS.md
@@ -107,7 +107,7 @@ To generate a coverage report
 yarn cover
 ```
 
-<!-- ## <a name="rules"></a> Coding Rules -->
+## <a name="rules"></a> Coding Rules
 
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
 
@@ -115,6 +115,12 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 * All public API methods **must be documented** with using jsdoc. To see how we document our APIs, please check
   out the existing source code and see the section about [writing documentation](#documentation)
 
+This project use Eslint together Prettier. The linter should automatically inform you if you break any rules (like incorrect indenting, line breaking or if you forget a semicolon). Before doing a pull request, make sure to run the linter.
+
+```shell
+# To run the linter
+yarn lint
+```
 
 ## <a name="commits"></a> Git Commit Guidelines
 

--- a/package.json
+++ b/package.json
@@ -199,7 +199,7 @@
     "json-loader": "^0.5.4",
     "nyc": "^11.4.1",
     "ocular-dev-tools": "^0.0.30",
-    "prettier": "^1.7.0",
+    "prettier": "1.18.2",
     "progress-bar-webpack-plugin": "^1.9.3",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "eslint-config-uber-es2015": "^3.1.2",
     "eslint-config-uber-jsx": "^3.3.3",
     "eslint-plugin-babel": "^5.3.0",
-    "eslint-plugin-prettier": "^3.1.0",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.13.0",
     "gl": "^4.2.2",
     "jsdom": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "enzyme": "^3.9.0",
     "enzyme-adapter-react-16": "^1.10.0",
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.3.0",
+    "eslint-config-prettier": "^6.3.0",
     "eslint-config-uber-es2015": "^3.1.2",
     "eslint-config-uber-jsx": "^3.3.3",
     "eslint-plugin-babel": "^5.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5622,7 +5622,7 @@ eslint-plugin-babel@^5.3.0:
   dependencies:
     eslint-rule-composer "^0.3.0"
 
-eslint-plugin-prettier@^3.1.0:
+eslint-plugin-prettier@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
   integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10646,10 +10646,10 @@ prettier@1.14.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.3.tgz#90238dd4c0684b7edce5f83b0fb7328e48bd0895"
   integrity sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==
 
-prettier@^1.7.0:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@1.18.2:
+  version "1.18.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
+  integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
 
 pretty-error@^2.0.2:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5588,10 +5588,10 @@ eslint-config-prettier@^2.9.0:
   dependencies:
     get-stdin "^5.0.1"
 
-eslint-config-prettier@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz#c55c1fcac8ce4518aeb77906984e134d9eb5a4f0"
-  integrity sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==
+eslint-config-prettier@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.3.0.tgz#e73b48e59dc49d950843f3eb96d519e2248286a3"
+  integrity sha512-EWaGjlDAZRzVFveh2Jsglcere2KK5CJBhkNSa1xs3KfMUGdRiT7lG089eqPdvlzWHpAqaekubOsOMu8W8Yk71A==
   dependencies:
     get-stdin "^6.0.0"
 


### PR DESCRIPTION
As discussed in PR #334 

Kepler.gl has Prettier as a dependency for controlling coding style. However, it has not been correctly integrated and Prettiers coding style rules has because of that not been applied as intended. #334 solved this but has become outdated (it linted all files, but the files has change so much that it can no longer be merged). As agreed in the discussed in PR #334 , this PR will replace the old #334 .

This PR does a few things:
- Upgrades Prettier
- Locks the prettier version as recommend by the Prettier docs
- Correctly extend eslint
- Upgrades eslint-config-prettier
- Upgrades eslint-plugin-prettier
- Add linting information to the docs

Eslint should now mark when the programmer make code styling choices that breaks the Prettier rules.

This PR has not run the linter on all files since it would cause problems merging and/or rebasing the big PRs that heshan0131 and Giuseppe are working on right now. However, after this PR is merged, running the standard linter (including `yarn lint` and `yarn test`) will run with the Prettier rules applied.