### PR TITLE
[Enhancement] Expose LayerHoverInfoFactory and CoordinateInfoFactory

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -69,6 +69,8 @@ export {default as MapStyleSelectorFactory} from './side-panel/map-style-panel/m
 // // map container factories
 export {default as MapPopoverFactory} from './map/map-popover';
 export {default as MapControlFactory} from './map/map-control';
+export {default as LayerHoverInfoFactory} from './map/layer-hover-info';
+export {default as CoordinateInfoFactory} from './map/coordinate-info';
 
 // // modal container factories
 export {default as DeleteDatasetModalFactory} from './modals/delete-data-modal';


### PR DESCRIPTION
Export LayerHoverInfoFactory and CoordinateInfoFactory so that minor
tweaks to MapPopover can be injected. This change allows a
CustomMapPopover injected via injectComponents to have
LayerHoverInfoFactory and CoordinateInfoFactory as deps, which is
desirable as we may want to use those components in our CustomMapPopover
as well.