### PR TITLE
[Bug] Fixed dropbox upload functionality on firefox

### DIFF
--- a/examples/demo-app/src/actions.js
+++ b/examples/demo-app/src/actions.js
@@ -359,10 +359,11 @@ export function exportFileToCloud(handlerName = 'dropbox') {
     // extract data from kepler
     const data = KeplerGlSchema.save(getState().demo.keplerGl.map);
     const newBlob = new Blob([JSON.stringify(data)], {type: 'application/json'});
-    const file = new File([newBlob], `/keplergl_${generateHashId(6)}.json`);
+    const fileName = `/keplergl_${generateHashId(6)}.json`;
+    const file = new File([newBlob], fileName);
     // We are gonna pass the correct auth token to init the cloud provider
     dispatch(setPushingFile(true, {filename: file.name, status: 'uploading', metadata: null}));
-    authHandler.uploadFile({blob: file, isPublic: true, authHandler})
+    authHandler.uploadFile({blob: file, name: fileName, isPublic: true, authHandler})
     // need to perform share as well
       .then(
         response => {

--- a/examples/demo-app/src/utils/cloud-providers/dropbox.js
+++ b/examples/demo-app/src/utils/cloud-providers/dropbox.js
@@ -77,7 +77,7 @@ function getAccessTokenFromLocation(location) {
  */
 function uploadFile({blob, name, isPublic = true}) {
   const promise = dropbox.filesUpload({
-    path: blob.name || name,
+    path: name || blob.name,
     contents: blob
   });
 

--- a/examples/demo-app/webpack.config.js
+++ b/examples/demo-app/webpack.config.js
@@ -73,7 +73,8 @@ const CONFIG = {
   // Optional: Enables reading mapbox and dropbox client token from environment variable
   plugins: [
     new webpack.EnvironmentPlugin([
-      'MapboxAccessToken'
+      'MapboxAccessToken',
+      'DropboxClientId'
     ])
   ]
 };


### PR DESCRIPTION
This PR fixes: #744 

Currently, when we build the dropbox upload request we read the file name from the given blob bu unfortunately the blob name contains __":"__ as prefix.

In this PR we pass the file name to the upload method.

Signed-off-by: Giuseppe Macri <gmacri@uber.com>