### PR TITLE
[Bug] Filter invalid H3 IDs

### DIFF
--- a/src/layers/h3-hexagon-layer/h3-hexagon-layer.js
+++ b/src/layers/h3-hexagon-layer/h3-hexagon-layer.js
@@ -23,7 +23,7 @@ import memoize from 'lodash.memoize';
 import Layer from '../base-layer';
 import {GeoJsonLayer, H3HexagonLayer} from 'deck.gl';
 import EnhancedColumnLayer from 'deckgl-layers/column-layer/enhanced-column-layer';
-import {getVertices, getCentroid, idToPolygonGeo} from './h3-utils';
+import {getVertices, getCentroid, idToPolygonGeo, h3IsValid} from './h3-utils';
 import H3HexagonLayerIcon from './h3-hexagon-layer-icon';
 import {CHANNEL_SCALES, HIGHLIGH_COLOR_3D} from 'constants/default-settings';
 
@@ -224,14 +224,14 @@ export default class HexagonIdLayer extends Layer {
 
     allData.forEach((d, index) => {
       const id = getHexId(d);
-      if (typeof id !== 'string' || !id.length) {
+      if (!h3IsValid(id)) {
         return;
       }
       // find hexagonVertices
       // only need 1 instance of hexagonVertices
       if (!hexagonVertices) {
-        hexagonVertices = id && getVertices({id});
-        hexagonCenter = id && getCentroid({id});
+        hexagonVertices = getVertices({id});
+        hexagonCenter = getCentroid({id});
       }
 
       // save a reference of centroids to dataToFeature

--- a/src/layers/h3-hexagon-layer/h3-utils.js
+++ b/src/layers/h3-hexagon-layer/h3-utils.js
@@ -18,8 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {h3GetResolution, h3ToGeo, h3ToGeoBoundary, geoToH3} from 'h3-js';
-export {h3GetResolution};
+import {h3GetResolution, h3IsValid, h3ToGeo, h3ToGeoBoundary, geoToH3} from 'h3-js';
+export {h3GetResolution, h3IsValid};
 
 // get vertices should return [lon, lat]
 export function getVertices({id}) {


### PR DESCRIPTION
Similarly to how the point layer filters invalid coordinates, the H3 layer behaves strangely if given datasets that have invalid hexagon IDs (an easy test is the ID `0`).