### PR TITLE
[Bug] Fixed loading urls with query params

### DIFF
--- a/examples/demo-app/src/actions.js
+++ b/examples/demo-app/src/actions.js
@@ -30,7 +30,7 @@ import {
 import {LOADING_METHODS_NAMES} from './constants/default-settings';
 import {CLOUD_PROVIDERS} from './utils/cloud-providers';
 import {generateHashId} from './utils/strings';
-import { parseUri } from './utils/url';
+import {parseUri} from './utils/url';
 import KeplerGlSchema from 'kepler.gl/schemas';
 
 // CONSTANTS

--- a/examples/demo-app/src/actions.js
+++ b/examples/demo-app/src/actions.js
@@ -30,6 +30,7 @@ import {
 import {LOADING_METHODS_NAMES} from './constants/default-settings';
 import {CLOUD_PROVIDERS} from './utils/cloud-providers';
 import {generateHashId} from './utils/strings';
+import { parseUri } from './utils/url';
 import KeplerGlSchema from 'kepler.gl/schemas';
 
 // CONSTANTS
@@ -135,14 +136,14 @@ function detectResponseError(response) {
 export function loadRemoteMap(options) {
   return dispatch => {
     dispatch(setLoadingMapStatus(true));
+    // breakdown url into url+query params
     loadRemoteRawData(options.dataUrl).then(
       // In this part we turn the response into a FileBlob
       // so we can use it to call loadFiles
-      file => {
+      ([file, url]) => {
+        const {file: filename} = parseUri(url);
         dispatch(loadFiles([
-          /* eslint-disable no-undef */
-          new File([file], options.dataUrl)
-          /* eslint-enable no-undef */
+          new File([file], filename)
         ])).then(
           () => dispatch(setLoadingMapStatus(false))
         );
@@ -178,7 +179,7 @@ function loadRemoteRawData(url) {
         reject(responseError);
         return;
       }
-      resolve(result.response)
+      resolve([result.response, url])
     })
   });
 }

--- a/examples/demo-app/src/utils/url.js
+++ b/examples/demo-app/src/utils/url.js
@@ -39,3 +39,45 @@ export function parseQueryString(query) {
 export function getMapPermalink(mapLink) {
   return `${window.location.protocol}//${window.location.host}/${MAP_URI}${mapLink}`
 }
+
+// from http://blog.stevenlevithan.com/archives/parseuri
+/**
+ * Allows to break down a url into multiple params
+ * @param str
+ */
+export function parseUri (str) {
+  const o = parseUri.options;
+  const m = o.parser[o.strictMode ? "strict" : "loose"].exec(str);
+  const uri = {};
+  let i = 14;
+
+  while (i--) uri[o.key[i]] = m[i] || "";
+
+  uri[o.q.name] = {};
+  uri[o.key[12]].replace(o.q.parser, ($0, $1, $2) => {
+    if ($1) uri[o.q.name][$1] = $2;
+  });
+
+  return uri;
+}
+
+parseUri.options = {
+  strictMode: false,
+  key: [
+    'source','protocol',
+    'authority','userInfo',
+    'user','password',
+    'host','port',
+    'relative','path',
+    'directory','file',
+    'query','anchor'
+  ],
+  q:   {
+    name:   'queryKey',
+    parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+  },
+  parser: {
+    strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+    loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
+  }
+};


### PR DESCRIPTION


It won't remove the current logic, URLs must still include '.csv' and '.json' but it will allow the usage of query parameters

Signed-off-by: Giuseppe Macri <gmacri@uber.com>