### PR TITLE
[Feat] add stdev and variance aggregators

### DIFF
--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -346,7 +346,9 @@ export const AGGREGATION_TYPES = {
   maximum: 'maximum',
   minimum: 'minimum',
   median: 'median',
+  stdev: 'stdev',
   sum: 'sum',
+  variance: 'variance',
   // ordinal
   mode: 'mode',
   countUnique: 'count unique'
@@ -364,7 +366,9 @@ export const linearFieldAggrScaleFunctions = {
     [AGGREGATION_TYPES.maximum]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
     [AGGREGATION_TYPES.minimum]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
     [AGGREGATION_TYPES.median]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
-    [AGGREGATION_TYPES.sum]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile]
+    [AGGREGATION_TYPES.stdev]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
+    [AGGREGATION_TYPES.sum]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile],
+    [AGGREGATION_TYPES.variance]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile]
   },
 
   [CHANNEL_SCALES.sizeAggr]: {
@@ -372,7 +376,9 @@ export const linearFieldAggrScaleFunctions = {
     [AGGREGATION_TYPES.maximum]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log],
     [AGGREGATION_TYPES.minimum]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log],
     [AGGREGATION_TYPES.median]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log],
-    [AGGREGATION_TYPES.sum]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log]
+    [AGGREGATION_TYPES.stdev]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log],
+    [AGGREGATION_TYPES.sum]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log],
+    [AGGREGATION_TYPES.variance]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log]
   }
 };
 

--- a/src/utils/aggregate-utils.js
+++ b/src/utils/aggregate-utils.js
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import {min, max, mean, median, sum} from 'd3-array';
+import {deviation, min, max, mean, median, sum, variance} from 'd3-array';
 import {AGGREGATION_TYPES} from 'constants/default-settings';
 
 const getFrenquency = data => data.reduce((uniques, val) => {
@@ -53,8 +53,12 @@ export function aggregate(data, technique) {
       return min(data);
     case AGGREGATION_TYPES.median:
       return median(data);
+    case AGGREGATION_TYPES.stdev:
+      return deviation(data);
     case AGGREGATION_TYPES.sum:
       return sum(data);
+    case AGGREGATION_TYPES.variance:
+      return variance(data);
     default:
       return data.length;
   }


### PR DESCRIPTION
Make use of D3 deviation and variance functions to add stdev and variance options to the list of available data aggregators.

This fails `yarn test-node`, however master also fails with the same error.