### PR TITLE
[Bug] Remove sqrt, log from default color aggregation for count

### DIFF
--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -124,7 +124,7 @@ class App extends Component {
     //   window.setTimeout(this._showBanner, 3000);
     // }
     // load sample data
-    // this._loadSampleData();
+    this._loadSampleData();
     // Notifications
     // this._loadMockNotifications();
   }

--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -124,7 +124,7 @@ class App extends Component {
     //   window.setTimeout(this._showBanner, 3000);
     // }
     // load sample data
-    this._loadSampleData();
+    // this._loadSampleData();
     // Notifications
     // this._loadMockNotifications();
   }

--- a/examples/demo-app/src/app.js
+++ b/examples/demo-app/src/app.js
@@ -124,7 +124,7 @@ class App extends Component {
     //   window.setTimeout(this._showBanner, 3000);
     // }
     // load sample data
-    // this._loadSampleData();
+    this._loadSampleData();
     // Notifications
     // this._loadMockNotifications();
   }
@@ -167,7 +167,7 @@ class App extends Component {
   _loadSampleData() {
     this._loadPointData();
     // this._loadGeojsonData();
-    this._loadTripGeoJson();
+    // this._loadTripGeoJson();
     // this._loadIconData();
     // this._loadGeojsonData();
     // this._loadH3HexagonData();

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -169,7 +169,7 @@ export default class ColorLegend extends Component {
   }
 }
 
-const LegendRow = ({label = '', displayLabel, color, idx}) => (
+export const LegendRow = ({label = '', displayLabel, color, idx}) => (
   <g transform={`translate(0, ${idx * (ROW_H + GAP)})`}>
     <rect width={RECT_W} height={ROW_H} style={{fill: color}} />
     <text x={RECT_W + 8} y={ROW_H - 1}>

--- a/src/components/common/color-legend.js
+++ b/src/components/common/color-legend.js
@@ -82,6 +82,14 @@ const getOrdinalLegends = scale => {
 };
 
 const getQuantLegends = (scale, labelFormat) => {
+  if (typeof scale.invertExtent !== 'function') {
+    // only quantile, quantize, threshold scale has invertExtent method
+    return {
+      data: [],
+      labels: []
+    };
+  }
+
   const labels = scale.range().map(d => {
     const invert = scale.invertExtent(d);
     return `${labelFormat(invert[0])} to ${labelFormat(invert[1])}`;

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -1052,6 +1052,7 @@ export const ChannelByValueSelector = ({
 export const AggrScaleSelector = ({channel, layer, onChange}) => {
   const {scale, key} = channel;
   const scaleOptions = layer.getScaleOptions(key);
+
   return Array.isArray(scaleOptions) && scaleOptions.length > 1 ? (
     <DimensionScaleSelector
       label={`${key} Scale`}

--- a/src/constants/default-settings.js
+++ b/src/constants/default-settings.js
@@ -415,7 +415,7 @@ export const  notSupportAggrOpts = {
  */
 export const DEFAULT_AGGREGATION = {
   [CHANNEL_SCALES.colorAggr]: {
-    [AGGREGATION_TYPES.count]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile, SCALE_TYPES.sqrt, SCALE_TYPES.log]
+    [AGGREGATION_TYPES.count]: [SCALE_TYPES.quantize, SCALE_TYPES.quantile]
   },
   [CHANNEL_SCALES.sizeAggr]: {
     [AGGREGATION_TYPES.count]: [SCALE_TYPES.linear, SCALE_TYPES.sqrt, SCALE_TYPES.log]

--- a/test/browser/components/common/color-legend-test.js
+++ b/test/browser/components/common/color-legend-test.js
@@ -1,0 +1,87 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+import test from 'tape';
+import {mountWithTheme} from 'test/helpers/component-utils';
+
+import ColorLegend, {LegendRow} from 'components/common/color-legend';
+
+test('Components -> ColorLegend.render', t => {
+  t.doesNotThrow(() => {
+    mountWithTheme(<ColorLegend />);
+  }, 'Show not fail without props');
+
+  const width = 180;
+  const fieldType = 'real';
+  const domain = [0, 20];
+  const scaleType = 'quantize';
+  const range = [
+    '#5A1846',
+    '#900C3F',
+    '#C70039',
+    '#E3611C',
+    '#F1920E',
+    '#FFC300'
+  ];
+  const displayLabel = true;
+
+  const props = {
+    scaleType,
+    displayLabel,
+    domain,
+    fieldType,
+    range,
+    width
+  };
+
+  let wrapper = mountWithTheme(<ColorLegend {...props} />);
+  t.equal(wrapper.find(LegendRow).length, 6, 'Should render 6 legends');
+  const row1 = wrapper
+    .find(LegendRow)
+    .at(0)
+    .find('rect')
+    .at(0)
+    .html();
+
+  t.ok(row1.indexOf('fill: #5A1846'), 'should render color rect');
+
+  props.scaleType = 'quantile';
+  wrapper = mountWithTheme(<ColorLegend {...props} />);
+  t.equal(wrapper.find(LegendRow).length, 6, 'Should render 6 legends');
+
+  props.scaleType = 'log';
+  wrapper = mountWithTheme(<ColorLegend {...props} />);
+  t.equal(wrapper.find(LegendRow).length, 0, 'Should render 0 legends');
+
+  props.displayLabel = false;
+  props.scaleType = 'quantile';
+  wrapper = mountWithTheme(<ColorLegend {...props} />);
+
+  const row1Txt = wrapper
+    .find(LegendRow)
+    .at(0)
+    .find('text')
+    .at(0)
+    .text();
+  t.equal(row1Txt, '', 'should not render text')
+
+  t.end();
+});

--- a/test/browser/components/common/index.js
+++ b/test/browser/components/common/index.js
@@ -19,3 +19,4 @@
 // THE SOFTWARE.
 
 import './file-uploader-test';
+import './color-legend-test';


### PR DESCRIPTION
- using Sqrt, log scale in color legend causes app to crash
- Remove sqrt, log from default color aggregation for count
Signed-off-by: Shan He <heshan0131@gmail.com>