### PR TITLE
(bugfix) Ensure all colors returned from get3DBuildingColor are RGB arrays

### DIFF
--- a/src/reducers/map-style-updaters.js
+++ b/src/reducers/map-style-updaters.js
@@ -189,7 +189,7 @@ function findLayerFillColor(layer) {
 function get3DBuildingColor(style) {
   // set building color to be the same as the background color.
   if (!style.style) {
-    return DEFAULT_BLDG_COLOR;
+    return hexToRgb(DEFAULT_BLDG_COLOR);
   }
 
   const backgroundLayer = (style.style.layers || []).find(
@@ -288,7 +288,8 @@ export const mapStyleChangeUpdater = (state, {payload: styleType}) => {
   );
 
   const threeDBuildingColor = state.custom3DBuildingColor ? state.threeDBuildingColor :
-  get3DBuildingColor(state.mapStyles[styleType]);
+    get3DBuildingColor(state.mapStyles[styleType]);
+
   return {
     ...state,
     styleType,


### PR DESCRIPTION
`<ColorBlock />` expects a color array (https://github.com/keplergl/kepler.gl/blob/master/src/components/side-panel/layer-panel/color-selector.js#L35) but is receiving a string, thus causing a crash.

<img width="526" alt="Screen Shot 2019-12-19 at 3 14 17 PM" src="https://user-images.githubusercontent.com/6504944/71217346-52dc3200-2272-11ea-8017-6ee65b6b7bda.png">


Error:
<img width="454" alt="Screen Shot 2019-12-19 at 3 14 30 PM" src="https://user-images.githubusercontent.com/6504944/71217331-45bf4300-2272-11ea-8cf1-ed1fe69dc9ba.png">


Signed-off-by: Jon Sadka <jonsadka@uber.com>