### PR TITLE
[Bug] Add prop.disabled to LayerConfigGroup

### DIFF
--- a/src/components/side-panel/layer-panel/layer-config-group.js
+++ b/src/components/side-panel/layer-panel/layer-config-group.js
@@ -70,6 +70,10 @@ export const StyledLayerConfigGroup = styled.div`
   padding-left: 18px;
   margin-bottom: 12px;
 
+  &.disabled {
+    opacity: 0.3;
+    pointer-events: none;
+  }
   &.collapsed {
     .layer-config-group__header__collapsible {
       overflow: visible;
@@ -119,7 +123,8 @@ class LayerConfigGroup extends Component {
     collapsible: false,
     expanded: false,
     onChange: () => {},
-    description: null
+    description: null,
+    disabled: false
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -143,14 +148,15 @@ class LayerConfigGroup extends Component {
       layer,
       onChange,
       collapsible,
-      description
+      description,
+      disabled
     } = this.props;
 
     const {collapsed} = this.state;
 
     return (
       <StyledLayerConfigGroup
-        className={classnames('layer-config-group', {collapsed})}
+        className={classnames('layer-config-group', {collapsed, disabled})}
       >
         <StyledConfigGroupHeader
           className="layer-config-group__header"

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -736,10 +736,11 @@ export default function LayerConfiguratorFactory(SourceDataSelector) {
           </LayerConfigGroup>
 
           {/* Elevation */}
-          {featureTypes.polygon && visConfig.filled ? (
+          {featureTypes.polygon ? (
             <LayerConfigGroup
               {...visConfiguratorProps}
               {...LAYER_VIS_CONFIGS.enable3d}
+              disabled={!visConfig.filled}
               collapsible
             >
               <VisConfigSlider


### PR DESCRIPTION
- Geojson Layer: Do not hide height config when filll color is disabled
Signed-off-by: Shan He <heshan0131@gmail.com>

Before: Height config is missing when Filll color is disabled
<img width="288" alt="Screen Shot 2020-01-10 at 8 40 38 PM" src="https://user-images.githubusercontent.com/3605556/72198904-7f0a4f00-33e9-11ea-9657-dbf4c1d3a699.png">


After: Show height config but disabled it
![height-toggle](https://user-images.githubusercontent.com/3605556/72198899-571aeb80-33e9-11ea-8f5a-9154f97b30c7.gif)
