### PR TITLE
Remove hyperlink with "Advanced Usage"

### DIFF
--- a/docs/api-reference/overview.md
+++ b/docs/api-reference/overview.md
@@ -11,7 +11,7 @@
 
 -  [Get Started][get-started]
 
--  [Advanced Usage][advanced-usage]
+-  Advanced Usage
     - [Using reducer plugin][reducer-plugin]
     - [Custom reducer initial state][custom-initial-state]
     - [Using updaters to modify kepler.gl state][using-updaters]


### PR DESCRIPTION
In the present state, clicking on "Advanced Usage" gives a 404, advanced-usage.md doesn't exist in the parent directory either.