### PR TITLE
[Bug] Fix h3 layer wrap

### DIFF
--- a/src/layers/grid-layer/grid-layer.js
+++ b/src/layers/grid-layer/grid-layer.js
@@ -97,6 +97,7 @@ export default class GridLayer extends AggregationLayer {
       new DeckGLGridLayer({
         ...data,
         ...layerInteraction,
+        wrapLongitude: false,
         id: this.id,
         idx,
         cellSize,

--- a/src/layers/h3-hexagon-layer/h3-hexagon-layer.js
+++ b/src/layers/h3-hexagon-layer/h3-hexagon-layer.js
@@ -281,6 +281,7 @@ export default class HexagonIdLayer extends Layer {
       new H3HexagonLayer({
         ...layerInteraction,
         ...data,
+        wrapLongitude: false,
         id: this.id,
         idx,
         pickable: true,

--- a/src/layers/hexagon-layer/hexagon-layer.js
+++ b/src/layers/hexagon-layer/hexagon-layer.js
@@ -79,6 +79,7 @@ export default class HexagonLayer extends AggregationLayer {
       new EnhancedHexagonLayer({
         ...data,
         ...layerInteraction,
+        wrapLongitude: false,
         id: this.id,
         idx,
 


### PR DESCRIPTION
- disable wrapLongitude in geometry instance layers
- issue: https://github.com/keplergl/kepler.gl/issues/754

__Before__
<img width="811" alt="Screen Shot 2019-09-30 at 2 23 17 PM" src="https://user-images.githubusercontent.com/3092244/65905100-e9910500-e38d-11e9-85ad-739ca91e4a9c.png">

__After__
![Screen Shot 2020-01-17 at 3 04 37 PM](https://user-images.githubusercontent.com/3605556/72652306-1536fb80-393b-11ea-9d68-9be96b6cf62e.png)

Signed-off-by: Shan He <heshan0131@gmail.com>