### PR TITLE
[Enhancement] Independently customize Geojson layer fill stroke opacity

### DIFF
--- a/src/components/side-panel.js
+++ b/src/components/side-panel.js
@@ -276,12 +276,12 @@ export default function SidePanelFactory(
                 {activeSidePanel === 'map' && (
                   <MapManager {...mapManagerActions} mapStyle={this.props.mapStyle} />
                 )}
-                {customPanels.length && customPanels.find(p => p.id === activeSidePanel) && (
+                {customPanels.length && customPanels.find(p => p.id === activeSidePanel) ? (
                   <CustomPanels
                     {...getCustomPanelProps(this.props)}
                     activeSidePanel={activeSidePanel}
                   />
-                )}
+                ) : null}
               </div>
             </SidePanelContent>
           </Sidebar>

--- a/src/components/side-panel/layer-panel/layer-configurator.js
+++ b/src/components/side-panel/layer-panel/layer-configurator.js
@@ -607,7 +607,7 @@ export default function LayerConfiguratorFactory(SourceDataSelector) {
                   channel={layer.visualChannels.color}
                   {...layerChannelConfigProps}
                 />
-                <VisConfigSlider {...LAYER_VIS_CONFIGS.opacity} {...visConfiguratorProps} />
+                <VisConfigSlider {...layer.visConfigSettings.opacity} {...visConfiguratorProps} />
               </ConfigGroupCollapsibleContent>
             </LayerConfigGroup>
           ) : null}
@@ -632,6 +632,10 @@ export default function LayerConfiguratorFactory(SourceDataSelector) {
               <ChannelByValueSelector
                 channel={layer.visualChannels.strokeColor}
                 {...layerChannelConfigProps}
+              />
+              <VisConfigSlider
+                {...layer.visConfigSettings.strokeOpacity}
+                {...visConfiguratorProps}
               />
             </ConfigGroupCollapsibleContent>
           </LayerConfigGroup>

--- a/test/browser/layer-tests/geojson-layer-specs.js
+++ b/test/browser/layer-tests/geojson-layer-specs.js
@@ -534,7 +534,8 @@ test('#GeojsonLayer -> renderLayer', t => {
             geojson: '_geojson'
           },
           visConfig: {
-            strokeColor: [4, 5, 6]
+            strokeColor: [4, 5, 6],
+            strokeOpacity: 0.1
           }
         }
       },
@@ -554,6 +555,54 @@ test('#GeojsonLayer -> renderLayer', t => {
         // polygon fill attributes;
         const {attributes} = deckLayers[1].state.attributeManager;
         const indices = attributes.indices.value;
+
+        const {props: fillLayerProp} = deckLayers[1];
+        const {props: strokeLayerProp} = deckLayers[2];
+
+        const expectedFillLayerProp = {
+          extruded: false,
+          elevationScale: 5,
+          filled: false,
+          wireframe: false,
+          opacity: 0.8,
+          parameters: {depthTest: false},
+          visible: true,
+          autoHighlight: false,
+          wrapLongitude: false,
+          id: 'test_layer_1-polygons-fill',
+          filterRange: [
+            [0, 8],
+            [0, 0],
+            [0, 0],
+            [0, 0]
+          ]
+        };
+
+        const expectedStrokeLayerProp = {
+          widthScale: 128,
+          rounded: false,
+          miterLimit: 2,
+          opacity: 0.1,
+          visible: true,
+          wrapLongitude: false,
+          id: 'test_layer_1-polygons-stroke'
+        };
+
+        Object.keys(expectedFillLayerProp).forEach(key => {
+          t.deepEqual(
+            fillLayerProp[key],
+            expectedFillLayerProp[key],
+            `should have correct fillLayerProp.${key}`
+          );
+        });
+
+        Object.keys(expectedStrokeLayerProp).forEach(key => {
+          t.deepEqual(
+            strokeLayerProp[key],
+            expectedStrokeLayerProp[key],
+            `should have correct strokeLayerProp.${key}`
+          );
+        });
 
         // test instanceFilterValues
         const expectedFilterValues = new Float32Array([

--- a/test/browser/layer-tests/hexagon-layer-specs.js
+++ b/test/browser/layer-tests/hexagon-layer-specs.js
@@ -327,11 +327,7 @@ test('#HexagonLayer -> renderLayer', t => {
         const expectedProps = {
           coverage: layer.config.visConfig.coverage,
           radius: layer.config.visConfig.worldUnitSize * 1000,
-          colorRange: [
-            [8, 8, 8],
-            [9, 9, 9],
-            [7, 7, 7]
-          ],
+          colorRange: [[8, 8, 8], [9, 9, 9], [7, 7, 7]],
           colorScaleType: layer.config.colorScale,
           elevationScaleType: layer.config.sizeScale,
           elevationScale: layer.config.visConfig.elevationScale,
@@ -339,14 +335,8 @@ test('#HexagonLayer -> renderLayer', t => {
           lowerPercentile: layer.config.visConfig.percentile[0]
         };
 
-        const expectedColorBins = [
-          {i: 2, value: 1, counts: 1},
-          {i: 1, value: 2, counts: 2}
-        ];
-        const expectedElevationBins = [
-          {i: 2, value: 1, counts: 1},
-          {i: 1, value: 2, counts: 2}
-        ];
+        const expectedColorBins = [{i: 2, value: 1, counts: 1}, {i: 1, value: 2, counts: 2}];
+        const expectedElevationBins = [{i: 2, value: 1, counts: 1}, {i: 1, value: 2, counts: 2}];
 
         t.deepEqual(
           hexCellLayer.props.data,

--- a/test/fixtures/state-saved-v0.js
+++ b/test/fixtures/state-saved-v0.js
@@ -1373,7 +1373,8 @@ mergedLayer4.config = {
     stroked: false,
     filled: true,
     enable3d: false,
-    wireframe: false
+    wireframe: false,
+    strokeOpacity: 0.8
   },
   animation: {enabled: false}
 };

--- a/test/fixtures/state-saved-v1-1.js
+++ b/test/fixtures/state-saved-v1-1.js
@@ -962,6 +962,7 @@ mergedLayer0.config = {
     stroked: true,
     filled: true,
     strokeColor: [181, 18, 65],
+    strokeOpacity: 0.8,
     enable3d: true,
     wireframe: false
   },
@@ -2745,7 +2746,8 @@ mergedLayer1.config = {
     filled: false,
     enable3d: false,
     wireframe: false,
-    strokeColor: [221, 178, 124]
+    strokeColor: [221, 178, 124],
+    strokeOpacity: 0.8
   },
   animation: {enabled: false}
 };

--- a/test/helpers/mock-state.js
+++ b/test/helpers/mock-state.js
@@ -576,7 +576,8 @@ export const expectedSavedLayer2 = {
       stroked: true,
       filled: true,
       enable3d: false,
-      wireframe: false
+      wireframe: false,
+      strokeOpacity: 0.8
     },
     textLabel: [DEFAULT_TEXT_LABEL]
   },
@@ -611,6 +612,7 @@ export const expectedLoadedLayer2 = {
       colorRange: DEFAULT_COLOR_RANGE,
       strokeColorRange: DEFAULT_COLOR_RANGE,
       strokeColor: [11, 11, 11],
+      strokeOpacity: 0.8,
       radius: 10,
       sizeRange: [0, 10],
       radiusRange: [0, 50],


### PR DESCRIPTION
[Before]
<img width="740" alt="Screen Shot 2020-02-20 at 7 00 51 PM" src="https://user-images.githubusercontent.com/3605556/75000529-7149df80-5413-11ea-88df-7ceee4b15700.png">

[After]
<img width="796" alt="Screen Shot 2020-02-20 at 6 56 36 PM" src="https://user-images.githubusercontent.com/3605556/75000415-1dd79180-5413-11ea-81c5-b989c6d88d02.png">
