### PR TITLE
Introduce KeplerTable class

### DIFF
--- a/src/reducers/vis-state-updaters.js
+++ b/src/reducers/vis-state-updaters.js
@@ -48,7 +48,8 @@ import {
   updateFilterDataId
 } from 'utils/filter-utils';
 import {assignGpuChannel, setFilterGpuMode} from 'utils/gpu-filter-utils';
-import {createNewDataEntry, sortDatasetByColumn} from 'utils/dataset-utils';
+import {createNewDataEntry} from 'utils/dataset-utils';
+import {sortDatasetByColumn} from 'utils/table-utils/kepler-table';
 import {set, toArray} from 'utils/utils';
 
 import {calculateLayerData, findDefaultLayer} from 'utils/layer-utils/layer-utils';

--- a/src/utils/dataset-utils.js
+++ b/src/utils/dataset-utils.js
@@ -20,11 +20,9 @@
 
 import {hexToRgb} from './color-utils';
 import uniq from 'lodash.uniq';
-import {TRIP_POINT_FIELDS, SORT_ORDER} from 'constants/default-settings';
-import {generateHashId} from './utils';
 import {validateInputData} from 'processors/data-processor';
-import {getGpuFilterProps} from 'utils/gpu-filter-utils';
-import {ascending, descending} from 'd3-array';
+import {KeplerTable} from 'utils/table-utils/kepler-table';
+
 // apply a color for each dataset
 // to use as label colors
 const datasetColors = [
@@ -71,125 +69,17 @@ function getNewDatasetColor(datasets) {
   return color;
 }
 
-export function createNewDataEntry({info = {}, data}, datasets = {}) {
+export function createNewDataEntry({info, data}, datasets = {}) {
   const validatedData = validateInputData(data);
   if (!validatedData) {
     return {};
   }
 
-  const allData = validatedData.rows;
-  const datasetInfo = {
-    id: generateHashId(4),
-    label: 'new dataset',
-    ...info
-  };
-  const dataId = datasetInfo.id;
+  info = info || {};
+  const color = info.color || getNewDatasetColor(datasets);
 
-  // add tableFieldIndex and id to fields
-  // TODO: don't need id and name and tableFieldIndex anymore
-  // Add value accessor instead
-  const fields = validatedData.fields.map((f, i) => ({
-    ...f,
-    id: f.name,
-    tableFieldIndex: i + 1
-  }));
-
-  const allIndexes = allData.map((_, i) => i);
+  const keplerTable = new KeplerTable({info, data: validatedData, color});
   return {
-    [dataId]: {
-      ...datasetInfo,
-      color: datasetInfo.color || getNewDatasetColor(datasets),
-      id: dataId,
-      allData,
-      allIndexes,
-      filteredIndex: allIndexes,
-      filteredIndexForDomain: allIndexes,
-      fieldPairs: findPointFieldPairs(fields),
-      fields,
-      gpuFilter: getGpuFilterProps([], dataId, fields)
-    }
-  };
-}
-
-export function removeSuffixAndDelimiters(layerName, suffix) {
-  return layerName
-    .replace(new RegExp(suffix, 'ig'), '')
-    .replace(/[_,.]+/g, ' ')
-    .trim();
-}
-
-/**
- * Find point fields pairs from fields
- *
- * @param {Array} fields
- * @returns {Array} found point fields
- */
-export function findPointFieldPairs(fields) {
-  const allNames = fields.map(f => f.name.toLowerCase());
-
-  // get list of all fields with matching suffixes
-  return allNames.reduce((carry, fieldName, idx) => {
-    // This search for pairs will early exit if found.
-    for (const suffixPair of TRIP_POINT_FIELDS) {
-      // match first suffix```
-      if (fieldName.endsWith(suffixPair[0])) {
-        // match second suffix
-        const otherPattern = new RegExp(`${suffixPair[0]}\$`);
-        const partner = fieldName.replace(otherPattern, suffixPair[1]);
-
-        const partnerIdx = allNames.findIndex(d => d === partner);
-        if (partnerIdx > -1) {
-          const defaultName = removeSuffixAndDelimiters(fieldName, suffixPair[0]);
-
-          carry.push({
-            defaultName,
-            pair: {
-              lat: {
-                fieldIdx: idx,
-                value: fields[idx].name
-              },
-              lng: {
-                fieldIdx: partnerIdx,
-                value: fields[partnerIdx].name
-              }
-            },
-            suffix: suffixPair
-          });
-          return carry;
-        }
-      }
-    }
-    return carry;
-  }, []);
-}
-
-export function sortDatasetByColumn(dataset, column, mode) {
-  const {allIndexes, fields, allData} = dataset;
-  const fieldIndex = fields.findIndex(f => f.name === column);
-  if (fieldIndex < 0) {
-    return dataset;
-  }
-
-  const sortBy = SORT_ORDER[mode] || SORT_ORDER.ASCENDING;
-
-  if (sortBy === SORT_ORDER.UNSORT) {
-    return {
-      ...dataset,
-      sortColumn: {},
-      sortOrder: null
-    };
-  }
-
-  const sortFunction = sortBy === SORT_ORDER.ASCENDING ? ascending : descending;
-  const sortOrder = allIndexes
-    .slice()
-    .sort((a, b) => sortFunction(allData[a][fieldIndex], allData[b][fieldIndex]));
-
-  return {
-    ...dataset,
-    sortColumn: {
-      [column]: sortBy
-    },
-    sortOrder
+    [keplerTable.id]: keplerTable
   };
 }

--- a/src/utils/table-utils/kepler-table.js
+++ b/src/utils/table-utils/kepler-table.js
@@ -1,0 +1,172 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to tdahe following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import {TRIP_POINT_FIELDS, SORT_ORDER} from 'constants/default-settings';
+// import {validateInputData} from 'processors/data-processor';
+import {generateHashId} from 'utils/utils';
+import {getGpuFilterProps} from 'utils/gpu-filter-utils';
+import {getFieldDomain} from 'utils/filter-utils';
+import {ascending, descending} from 'd3-array';
+
+export class KeplerTable {
+  constructor({info = {}, data, color}) {
+    // TODO - what to do if validation fails? Can kepler handle exceptions?
+    // const validatedData = validateInputData(data);
+    // if (!validatedData) {
+    //   return this;
+    // }
+
+    const allData = data.rows;
+    const datasetInfo = {
+      id: generateHashId(4),
+      label: 'new dataset',
+      ...info
+    };
+    const dataId = datasetInfo.id;
+
+    // add tableFieldIndex and id to fields
+    // TODO: don't need id and name and tableFieldIndex anymore
+    // Add value accessor instead
+    const fields = data.fields.map((f, i) => ({
+      ...f,
+      id: f.name,
+      tableFieldIndex: i + 1
+    }));
+
+    const allIndexes = allData.map((_, i) => i);
+
+    Object.assign(this, {
+      ...datasetInfo,
+      id: dataId,
+      color,
+      allData,
+      allIndexes,
+      filteredIndex: allIndexes,
+      filteredIndexForDomain: allIndexes,
+      fieldPairs: findPointFieldPairs(fields),
+      fields,
+      gpuFilter: getGpuFilterProps([], dataId, fields)
+    });
+  }
+
+  getColumnField(columnName) {
+    // TODO - id or name?
+    return this.fields.find(field => field.name === columnName);
+  }
+
+  /**
+   * Calculate field domain based on field type and data
+   *
+   * @param {Array<Array>} allData
+   * @param {Object} field
+   * @returns {Object} with domain as key
+   */
+  getColumnDomain(columnName) {
+    const {allData} = this;
+    const field = this.getColumnField(columnName);
+
+    return getFieldDomain(allData, field);
+  }
+}
+
+// HELPER FUNCTIONS (MAINLY EXPORTED FOR TEST...)
+
+export function removeSuffixAndDelimiters(layerName, suffix) {
+  return layerName
+    .replace(new RegExp(suffix, 'ig'), '')
+    .replace(/[_,.]+/g, ' ')
+    .trim();
+}
+
+/**
+ * Find point fields pairs from fields
+ *
+ * @param {Array} fields
+ * @returns {Array} found point fields
+ */
+export function findPointFieldPairs(fields) {
+  const allNames = fields.map(f => f.name.toLowerCase());
+
+  // get list of all fields with matching suffixes
+  return allNames.reduce((carry, fieldName, idx) => {
+    // This search for pairs will early exit if found.
+    for (const suffixPair of TRIP_POINT_FIELDS) {
+      // match first suffix```
+      if (fieldName.endsWith(suffixPair[0])) {
+        // match second suffix
+        const otherPattern = new RegExp(`${suffixPair[0]}\$`);
+        const partner = fieldName.replace(otherPattern, suffixPair[1]);
+
+        const partnerIdx = allNames.findIndex(d => d === partner);
+        if (partnerIdx > -1) {
+          const defaultName = removeSuffixAndDelimiters(fieldName, suffixPair[0]);
+
+          carry.push({
+            defaultName,
+            pair: {
+              lat: {
+                fieldIdx: idx,
+                value: fields[idx].name
+              },
+              lng: {
+                fieldIdx: partnerIdx,
+                value: fields[partnerIdx].name
+              }
+            },
+            suffix: suffixPair
+          });
+          return carry;
+        }
+      }
+    }
+    return carry;
+  }, []);
+}
+
+export function sortDatasetByColumn(dataset, column, mode) {
+  const {allIndexes, fields, allData} = dataset;
+  const fieldIndex = fields.findIndex(f => f.name === column);
+  if (fieldIndex < 0) {
+    return dataset;
+  }
+
+  const sortBy = SORT_ORDER[mode] || SORT_ORDER.ASCENDING;
+
+  if (sortBy === SORT_ORDER.UNSORT) {
+    return {
+      ...dataset,
+      sortColumn: {},
+      sortOrder: null
+    };
+  }
+
+  const sortFunction = sortBy === SORT_ORDER.ASCENDING ? ascending : descending;
+  const sortOrder = allIndexes
+    .slice()
+    .sort((a, b) => sortFunction(allData[a][fieldIndex], allData[b][fieldIndex]));
+
+  return {
+    ...dataset,
+    sortColumn: {
+      [column]: sortBy
+    },
+    sortOrder
+  };
+}

--- a/test/node/utils/layer-utils-test.js
+++ b/test/node/utils/layer-utils-test.js
@@ -20,7 +20,8 @@
 
 import test from 'tape';
 import {findDefaultLayer} from 'utils/layer-utils/layer-utils';
-import {findPointFieldPairs, createNewDataEntry} from 'utils/dataset-utils';
+import {createNewDataEntry} from 'utils/dataset-utils';
+import {findPointFieldPairs} from 'utils/table-utils/kepler-table';
 import {processCsvData, processGeojson} from 'processors/data-processor';
 import {GEOJSON_FIELDS} from 'constants/default-settings';
 import {LayerClasses, KeplerGlLayers} from 'layers';


### PR DESCRIPTION
# Starts implementing RFC #1109 

This has remaining one failing test case in a reducer dealing with split maps - it is a little hard to follow the logic around what it is doing there, but the error indicates that it might be trying to apply a spread operator to the class instance.

```
  Failed Tests: There was 1 failure

    #visStateReducer -> UPDATE_VIS_DATA.1 -> No data

      ✖ TypeError: Invalid attempt to spread non-iterable instance

```