### PR TITLE
[Feat] add zoom to coordinate tooltip

### DIFF
--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -287,28 +287,31 @@ export default function MapContainerFactory(MapPopover, MapControl, Editor) {
           layerHoverProp.compareType = interactionConfig.tooltip.config.compareType;
         }
       }
+      const commonProp = {
+        onClose: this._onCloseMapPopover,
+        mapW: mapState.width,
+        mapH: mapState.height,
+        zoom: mapState.zoom
+      };
+
       return (
         <div>
           {hasTooltip && (
             <MapPopover
               {...pinnedPosition}
+              {...commonProp}
               layerHoverProp={layerPinnedProp}
               coordinate={interactionConfig.coordinate.enabled && (pinned || {}).coordinate}
               frozen={Boolean(hasTooltip)}
-              onClose={this._onCloseMapPopover}
-              mapW={mapState.width}
-              mapH={mapState.height}
               isBase={compareMode}
             />
           )}
           {hasComparisonTooltip && (
             <MapPopover
               {...position}
+              {...commonProp}
               layerHoverProp={layerHoverProp}
               coordinate={interactionConfig.coordinate.enabled && coordinate}
-              onClose={this._onCloseMapPopover}
-              mapW={mapState.width}
-              mapH={mapState.height}
             />
           )}
         </div>

--- a/src/components/map/coordinate-info.js
+++ b/src/components/map/coordinate-info.js
@@ -28,7 +28,7 @@ import {StyledLayerName} from './layer-hover-info';
 const DECIMAL = 6;
 
 const CoordinateInfoFactory = () => {
-  const CoordinateInfo = ({coordinate}) => (
+  const CoordinateInfo = ({coordinate, zoom}) => (
     <div>
       <StyledLayerName className="map-popover__layer-name">
         <CursorClick height="12px" />
@@ -39,6 +39,7 @@ const CoordinateInfoFactory = () => {
           <tr className="row">
             <td className="row__value">{preciseRound(coordinate[1], DECIMAL)},</td>
             <td className="row__value">{preciseRound(coordinate[0], DECIMAL)}</td>
+            <td className="row__value">{preciseRound(zoom, DECIMAL)}</td>
           </tr>
         </tbody>
       </table>

--- a/src/components/map/coordinate-info.js
+++ b/src/components/map/coordinate-info.js
@@ -26,6 +26,7 @@ import {StyledLayerName} from './layer-hover-info';
 // 6th decimal is worth up to 0.11 m
 // https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude
 const DECIMAL = 6;
+const DECIMAL_Z = 1;
 
 const CoordinateInfoFactory = () => {
   const CoordinateInfo = ({coordinate, zoom}) => (
@@ -38,8 +39,8 @@ const CoordinateInfoFactory = () => {
         <tbody>
           <tr className="row">
             <td className="row__value">{preciseRound(coordinate[1], DECIMAL)},</td>
-            <td className="row__value">{preciseRound(coordinate[0], DECIMAL)}</td>
-            <td className="row__value">{preciseRound(zoom, DECIMAL)}</td>
+            <td className="row__value">{preciseRound(coordinate[0], DECIMAL)},</td>
+            <td className="row__value">{preciseRound(zoom, DECIMAL_Z)}z</td>
           </tr>
         </tbody>
       </table>

--- a/src/components/map/map-popover.js
+++ b/src/components/map/map-popover.js
@@ -114,6 +114,7 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
       frozen: PropTypes.bool,
       x: PropTypes.number,
       y: PropTypes.number,
+      z: PropTypes.number,
       mapW: PropTypes.number.isRequired,
       mapH: PropTypes.number.isRequired,
       onClose: PropTypes.func.isRequired,
@@ -183,7 +184,7 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
     };
 
     render() {
-      const {x, y, frozen, coordinate, layerHoverProp, isBase} = this.props;
+      const {x, y, frozen, coordinate, layerHoverProp, isBase, zoom} = this.props;
       const {isLeft} = this.state;
 
       const style = Number.isFinite(x) && Number.isFinite(y) ? this._getPosition(x, y, isLeft) : {};
@@ -221,7 +222,7 @@ export default function MapPopoverFactory(LayerHoverInfo, CoordinateInfo) {
                 )}
               </div>
             ) : null}
-            {Array.isArray(coordinate) && <CoordinateInfo coordinate={coordinate} />}
+            {Array.isArray(coordinate) && <CoordinateInfo coordinate={coordinate} zoom={zoom} />}
             {layerHoverProp && <LayerHoverInfo {...layerHoverProp} />}
           </StyledMapPopover>
         </ErrorBoundary>


### PR DESCRIPTION

<img width="400" alt="Screen Shot 2020-07-06 at 4 59 18 PM" src="https://user-images.githubusercontent.com/3605556/86670996-153ebc80-bfaa-11ea-8d26-5149f1b8cf85.png">

**tooltip with object hover info**



<img width="400" alt="Screen Shot 2020-07-06 at 4 59 06 PM" src="https://user-images.githubusercontent.com/3605556/86671000-15d75300-bfaa-11ea-81e2-d323c848ada7.png">

**tooltip with only coordinate**

Signed-off-by: Shan He <heshan0131@gmail.com>