### PR TITLE
[Bug/Enhancement] Pass PanelHeader props to the onClick handler of action items

### DIFF
--- a/src/components/side-panel/panel-header.js
+++ b/src/components/side-panel/panel-header.js
@@ -296,8 +296,9 @@ function PanelHeaderFactory(SaveExportDropdown, CloudStorageDropdown) {
                     onClick={() => {
                       if (item.dropdownComponent) {
                         showExportDropdown(item.id);
+                      } else {
+                        item.onClick && item.onClick(this.props);
                       }
-                      item.onClick && item.onClick(this.props);
                     }}
                   />
                   {item.dropdownComponent ? (

--- a/src/components/side-panel/panel-header.js
+++ b/src/components/side-panel/panel-header.js
@@ -297,7 +297,7 @@ function PanelHeaderFactory(SaveExportDropdown, CloudStorageDropdown) {
                       if (item.dropdownComponent) {
                         showExportDropdown(item.id);
                       }
-                      item.onClick();
+                      item.onClick && item.onClick(this.props);
                     }}
                   />
                   {item.dropdownComponent ? (


### PR DESCRIPTION
`PanelHeader` has a prop called `actionItems` which contains a list of actions, each with a `id`, `tooltip`, `iconComponent`, `dropDownComponent` and an `onClick` handler:
![image](https://user-images.githubusercontent.com/1332450/87102039-7f9f6900-c205-11ea-8f5b-4910b0e4b2b9.png)

In order for the `onClick` handler to be able to dispatch actions, it needs access to the `PanelHeader`'s prop, which this PR adds.

