### PR TITLE
Add typescript types for upload modal and components

### DIFF
--- a/src/components/common/file-uploader/file-drop.d.ts
+++ b/src/components/common/file-uploader/file-drop.d.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export type FileDropProps = {
+  dropEffect?: 'copy' | 'move' | 'link' | 'none';
+  frame?: typeof document | typeof window | HTMLElement;
+  className?: string;
+  targetClassName?: string;
+  draggingOverFrameClassName?: string;
+  draggingOverTargetClassName?: string;
+  onDragOver?: (event: any) => void;
+  onDragLeave?: (event: any) => void;
+  onDrop?: (fileList: FileList, event: any) => void;
+  onFrameDragEnter?: (event: any) => void;
+  onFrameDragLeave?: (event: any) => void;
+  onFrameDrop?: (event: any) => void;
+};
+
+const FileDrop: React.FunctionComponent<FileDropProps>;
+export default FileDrop;

--- a/src/components/common/file-uploader/file-drop.js
+++ b/src/components/common/file-uploader/file-drop.js
@@ -22,10 +22,12 @@
  * Copied from https://github.com/sarink/react-file-drop
  * For React 16.8 compatibility
  */
-import PropTypes from 'prop-types';
 import React from 'react';
 import window from 'global/window';
 
+/** @typedef {import('./file-drop').FileDropProps} FileDropProps */
+
+/** @augments React.PureComponent<FileDropProps> */
 class FileDrop extends React.PureComponent {
   static isIE = () =>
     window &&
@@ -47,33 +49,6 @@ class FileDrop extends React.PureComponent {
       }
     }
     return hasFiles;
-  };
-
-  static propTypes = {
-    className: PropTypes.string,
-    targetClassName: PropTypes.string,
-    draggingOverFrameClassName: PropTypes.string,
-    draggingOverTargetClassName: PropTypes.string,
-    onDragOver: PropTypes.func,
-    onDragLeave: PropTypes.func,
-    onDrop: PropTypes.func,
-    dropEffect: PropTypes.oneOf(['copy', 'move', 'link', 'none']),
-    frame: (props, propName, componentName) => {
-      const prop = props[propName];
-      if (prop === null) {
-        return new Error(
-          `Warning: Required prop \`${propName}\` was not specified in \`${componentName}\``
-        );
-      }
-      if (prop !== document && prop !== window && !(prop instanceof HTMLElement)) {
-        return new Error(
-          `Warning: Prop \`${propName}\` must be one of the following: document, HTMLElement!`
-        );
-      }
-    },
-    onFrameDragEnter: PropTypes.func,
-    onFrameDragLeave: PropTypes.func,
-    onFrameDrop: PropTypes.func
   };
 
   static defaultProps = {

--- a/src/components/common/file-uploader/file-upload-progress.d.ts
+++ b/src/components/common/file-uploader/file-upload-progress.d.ts
@@ -1,0 +1,11 @@
+import React from 'react';
+ // TODO - this seems too coupled, better define a type here and adapt FileLoadingProgress to it in the app?
+import {FileLoadingProgress} from 'reducers/vis-state-updaters';
+
+export type FileUploadProgressProps = {
+  fileLoadingProgress: FileLoadingProgress;
+  theme: object;
+};
+
+const FileUploadProgress: React.FunctionComponent<FileUploadProgressProps>;
+export default FileUploadProgress;

--- a/src/components/common/file-uploader/file-upload-progress.js
+++ b/src/components/common/file-uploader/file-upload-progress.js
@@ -21,8 +21,10 @@
 import React from 'react';
 import styled, {withTheme} from 'styled-components';
 import ProgressBar from '../progress-bar';
-import {TrancatedTitleText} from 'components/common/styled-components';
+import {TruncatedTitleText} from 'components/common/styled-components';
 import {getError} from 'utils/utils';
+
+/** @typedef {import('./file-upload-progress').FileUploadProgressProps} FileUploadProgressProps*/
 
 const StyledFileProgress = styled.div.attrs({
   className: 'file-upload__progress'
@@ -61,7 +63,17 @@ const StyledContainer = styled.div`
   display: flex;
   justify-content: center;
 `;
+
 const formatPercent = percent => `${Math.floor(percent * 100)}%`;
+
+/**
+ * @param {object} params
+ * @param {string} params.message
+ * @param {string} params.fileName
+ * @param {number} params.percent
+ * @param {any} params.error
+ * @param {object} params.theme
+ */
 const UploadProgress = ({message, fileName, percent, error, theme}) => {
   const percentStr = formatPercent(percent);
   const barColor = error ? theme.errorColor : theme.activeColorLT;
@@ -69,13 +81,13 @@ const UploadProgress = ({message, fileName, percent, error, theme}) => {
   return (
     <StyledFileProgress className="file-upload-progress__message">
       <div className="top-row">
-        <TrancatedTitleText className="file-name" title={fileName}>
+        <TruncatedTitleText className="file-name" title={fileName}>
           {fileName}
-        </TrancatedTitleText>
+        </TruncatedTitleText>
         <div className="percent">{percentStr}</div>
       </div>
       <div className="middle-row">
-        <ProgressBar percent={percentStr} barColor={barColor} isLoading />
+        <ProgressBar percent={percentStr} barColor={barColor} isLoading theme={theme} />
       </div>
       <div className="bottom-row" style={{color: error ? theme.errorColor : theme.textColorLT}}>
         {error ? getError(error) : message}
@@ -84,6 +96,7 @@ const UploadProgress = ({message, fileName, percent, error, theme}) => {
   );
 };
 
+/** @type {React.FunctionComponent<FileUploadProgressProps>} */
 const FileUploadProgress = ({fileLoadingProgress, theme}) => (
   <StyledContainer>
     <StyledProgressWrapper>

--- a/src/components/common/file-uploader/file-upload.d.ts
+++ b/src/components/common/file-uploader/file-upload.d.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+import {FileLoading, FileLoadingProgress} from '../../../reducers/vis-state-updaters';
+
+export type FileUploadProps = {
+  onFileUpload: (files: File[]) => void;
+  validFileExt: string[];
+  fileLoading: FileLoading | false;
+  fileLoadingProgress: FileLoadingProgress;
+  intl: any;
+  theme: object;
+};
+
+export const WarningMsg: React.Component;
+
+export const FileUpload: React.Component<FileUploadProps>;
+
+export default function FileUploadFactory(): React.Component<FileUploadProps>;

--- a/src/components/common/file-uploader/upload-button.d.ts.wip
+++ b/src/components/common/file-uploader/upload-button.d.ts.wip
@@ -1,0 +1,11 @@
+// For some reason these types don't work
+// JSX element type 'UploadButton' does not have any construct or call signatures.
+
+import React from 'react';
+
+export type UploadButtonProps = {
+  onUpload: (files: FileList, event: any) => void;
+};
+
+export const UploadButton: React.Component<UploadButtonProps>;
+export default UploadButton;

--- a/src/components/common/file-uploader/upload-button.js
+++ b/src/components/common/file-uploader/upload-button.js
@@ -19,8 +19,13 @@
 // THE SOFTWARE.
 
 import React, {Component, createRef} from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
+/**
+@typedef {{
+  onUpload: (files: FileList, event: any) => void;
+}} UploadButtonProps
+*/
 
 const Wrapper = styled.div`
   display: inline-block;
@@ -36,11 +41,8 @@ const Wrapper = styled.div`
 /*
 Inspired by https://github.com/okonet/react-dropzone/blob/master/src/index.js
 */
-export default class UploadButton extends Component {
-  static propTypes = {
-    onUpload: PropTypes.func.isRequired
-  };
-
+/** @augments React.Component<UploadButtonProps> */
+export class UploadButton extends Component {
   _fileInput = createRef();
 
   _onClick = () => {
@@ -48,12 +50,16 @@ export default class UploadButton extends Component {
     this._fileInput.current.click();
   };
 
-  _onChange = ({target: {files}}) => {
+  _onChange = event => {
+    const {
+      target: {files}
+    } = event;
+
     if (!files) {
       return;
     }
 
-    this.props.onUpload(files);
+    this.props.onUpload(files, event);
   };
 
   render() {
@@ -73,3 +79,5 @@ export default class UploadButton extends Component {
     );
   }
 }
+
+export default UploadButton;

--- a/src/components/common/loading-spinner.js
+++ b/src/components/common/loading-spinner.js
@@ -49,7 +49,7 @@ const LoadingWrapper = styled.div`
   padding: 2px;
 `;
 
-const LoadingSpinner = ({size = 32, color, borderColor, strokeWidth = 3, gap = 2}) => (
+const LoadingSpinner = ({size = 32, color = '', borderColor = '', strokeWidth = 3, gap = 2}) => (
   <LoadingWrapper style={{width: `${size}px`, height: `${size}px`, padding: `${gap}px`}}>
     <Loader
       color={color}

--- a/src/components/common/progress-bar.d.ts
+++ b/src/components/common/progress-bar.d.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export type ProgressBarProps = {
+  percent: string,
+  height?: number,
+  isLoading: boolean,
+  barColor: any;
+  trackColor?: any;
+  theme: object;
+};
+
+const ProgressBar: React.FunctionCompoment<ProgressBarProps>;
+export default ProgressBar;

--- a/src/components/common/progress-bar.js
+++ b/src/components/common/progress-bar.js
@@ -36,7 +36,7 @@ const StyledTrack = styled.div.attrs({
   background-color: ${props => props.trackColor || props.theme.progressBarTrackColor};
 `;
 
-/** @type {React.SFC<ProgressBarProps>} */
+/** @type {React.FunctionComponent<ProgressBarProps>} */
 const ProgressBar = ({percent, height = 4, isLoading, barColor, trackColor, theme}) => (
   <StyledTrack trackColor={trackColor} theme={theme}>
     <StyledBar

--- a/src/components/common/progress-bar.js
+++ b/src/components/common/progress-bar.js
@@ -21,6 +21,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
+/** @typedef {import('./progress-bar').ProgressBarProps} ProgressBarProps */
+
 const StyledBar = styled.span.attrs({
   className: 'progress-bar__bar'
 })`
@@ -34,8 +36,9 @@ const StyledTrack = styled.div.attrs({
   background-color: ${props => props.trackColor || props.theme.progressBarTrackColor};
 `;
 
-const ProgressBar = ({percent, height = 4, isLoading, barColor, trackColor}) => (
-  <StyledTrack trackColor={trackColor}>
+/** @type {React.SFC<ProgressBarProps>} */
+const ProgressBar = ({percent, height = 4, isLoading, barColor, trackColor, theme}) => (
+  <StyledTrack trackColor={trackColor} theme={theme}>
     <StyledBar
       barColor={barColor}
       style={{width: percent, height: `${height}px`, opacity: isLoading ? 1 : 0}}

--- a/src/components/common/styled-components.js
+++ b/src/components/common/styled-components.js
@@ -624,7 +624,7 @@ export const StyledFilterContent = styled.div`
   padding: 12px;
 `;
 
-export const TrancatedTitleText = styled.div`
+export const TruncatedTitleText = styled.div`
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;

--- a/src/components/modals/cloud-tile.js
+++ b/src/components/modals/cloud-tile.js
@@ -100,20 +100,20 @@ const StyledUserName = styled.div`
 `;
 
 const LoginButton = ({onClick}) => (
-  <Button link small onClick={onClick}>
+  <Button className="login-button" link small onClick={onClick}>
     <Login />
     Login
   </Button>
 );
 
 const LogoutButton = ({onClick}) => (
-  <Button link small onClick={onClick}>
+  <Button className="logout-button" link small onClick={onClick}>
     <Logout />
     Logout
   </Button>
 );
 
-const ActionButton = ({isConnected, actionName, isReady}) =>
+const ActionButton = ({isConnected, actionName = null, isReady}) =>
   isConnected && actionName ? (
     <Button className="cloud-tile__action" small secondary disabled={!isReady}>
       {isReady ? actionName : <LoadingSpinner size={12} />}
@@ -124,11 +124,11 @@ const CloudTile = ({
   // action when click on the tile
   onSelect,
   // default to login
-  onConnect,
+  onConnect = null,
   // default to logout
-  onLogout,
+  onLogout = null,
   // action name
-  actionName,
+  actionName = null,
   // cloud provider class
   cloudProvider,
   // function to take after login or logout
@@ -163,9 +163,9 @@ const CloudTile = ({
         {isSelected && <CheckMark />}
       </StyledTileWrapper>
       {isConnected ? (
-        <LogoutButton className="logout-button" onClick={onClickLogout} />
+        <LogoutButton onClick={onClickLogout} />
       ) : (
-        <LoginButton className="login-button" onClick={onClickConnect} />
+        <LoginButton onClick={onClickConnect} />
       )}
     </StyledBox>
   );

--- a/src/components/modals/load-data-modal.d.ts
+++ b/src/components/modals/load-data-modal.d.ts
@@ -1,0 +1,23 @@
+import React from 'react';
+import {FileLoading} from '../../reducers/vis-state-updaters';
+
+export type LoadDataModalProps = {
+  // call backs
+  onFileUpload: (files: File[]) => void;
+  onLoadCloudMap: (provider: any, vis: any) => void;
+  fileLoading?: FileLoading,
+  loadingMethods: {
+    id: string;
+    label: string;
+    elementType: React.Component;
+    tabElementType?: React.Component;
+  }[];
+};
+
+export function LoadDataModalFactory(
+  ModalTabs: React.Component,
+  FileUpload: React.Component,
+  LoadStorageMap: React.Component
+): React.Component<LoadDataModalProps>;
+
+export default LoadDataModalFactory;

--- a/src/components/modals/load-data-modal.d.ts
+++ b/src/components/modals/load-data-modal.d.ts
@@ -5,7 +5,7 @@ export type LoadDataModalProps = {
   // call backs
   onFileUpload: (files: File[]) => void;
   onLoadCloudMap: (provider: any, vis: any) => void;
-  fileLoading?: FileLoading,
+  fileLoading: FileLoading | false,
   loadingMethods: {
     id: string;
     label: string;

--- a/src/components/modals/load-data-modal.js
+++ b/src/components/modals/load-data-modal.js
@@ -72,7 +72,7 @@ export function LoadDataModalFactory(ModalTabs, FileUpload, LoadStorageMap) {
 
   LoadDataModal.defaultProps = {
     onFileUpload: noop,
-    // fileLoading: undefined,
+    fileLoading: false,
     loadingMethods: [
       {
         id: LOADING_METHODS.upload,

--- a/src/components/modals/load-data-modal.js
+++ b/src/components/modals/load-data-modal.js
@@ -19,7 +19,6 @@
 // THE SOFTWARE.
 
 import React, {useState} from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import get from 'lodash.get';
 
@@ -30,6 +29,8 @@ import ModalTabsFactory from './modal-tabs';
 import LoadingDialog from './loading-dialog';
 
 import {LOADING_METHODS} from 'constants/default-settings';
+
+/** @typedef {import('./load-data-modal').LoadDataModalProps} LoadDataModalProps */
 
 const StyledLoadDataModal = styled.div.attrs({
   className: 'load-data-modal'
@@ -45,9 +46,12 @@ const getDefaultMethod = methods => (Array.isArray(methods) ? get(methods, [0]) 
 
 LoadDataModalFactory.deps = [ModalTabsFactory, FileUploadFactory, LoadStorageMapFactory];
 
-function LoadDataModalFactory(ModalTabs, FileUpload, LoadStorageMap) {
+export function LoadDataModalFactory(ModalTabs, FileUpload, LoadStorageMap) {
+  /** @type {React.FunctionComponent<LoadDataModalProps>} */
   const LoadDataModal = props => {
-    const {loadingMethods, isCloudMapLoading} = props;
+    // @ts-ignore TODO check why this is not defined
+    const {isCloudMapLoading} = props;
+    const {loadingMethods} = props;
     const [currentMethod, toggleMethod] = useState(getDefaultMethod(loadingMethods));
 
     return (
@@ -66,24 +70,9 @@ function LoadDataModalFactory(ModalTabs, FileUpload, LoadStorageMap) {
     );
   };
 
-  LoadDataModal.propTypes = {
-    // call backs
-    onFileUpload: PropTypes.func.isRequired,
-    onLoadCloudMap: PropTypes.func.isRequired,
-    fileLoading: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
-    loadingMethods: PropTypes.arrayOf(
-      PropTypes.shape({
-        id: PropTypes.string,
-        label: PropTypes.string,
-        elementType: PropTypes.elementType,
-        tabElementType: PropTypes.elementType
-      })
-    )
-  };
-
   LoadDataModal.defaultProps = {
     onFileUpload: noop,
-    fileLoading: false,
+    // fileLoading: undefined,
     loadingMethods: [
       {
         id: LOADING_METHODS.upload,

--- a/test/browser/components/modals/save-map-modal-test.js
+++ b/test/browser/components/modals/save-map-modal-test.js
@@ -169,7 +169,10 @@ test('Components -> SaveMapModal on click provider', t => {
   t.ok(onSetCloudProvider.calledWithExactly('blue'), 'should call onSetCloudProvider with blue');
 
   // click taro to logout
-  wrapper.find('.logout-button').simulate('click');
+  wrapper
+    .find('.logout-button')
+    .at(0)
+    .simulate('click');
   t.ok(logout.calledOnce, 'should call logout');
 
   // call onSuccess after login to set current provider

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -2469,7 +2469,7 @@ test('#visStateReducer -> REMOVE_DATASET w filter and layer', t => {
       title: '',
       description: ''
     },
-    fileLoading: oldState.fileLoading, 
+    fileLoading: oldState.fileLoading,
     fileLoadingProgress: oldState.fileLoadingProgress
   };
 
@@ -2706,7 +2706,7 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_DATASET', t => {
       title: '',
       description: ''
     },
-    fileLoading: oldState.fileLoading, 
+    fileLoading: oldState.fileLoading,
     fileLoadingProgress: oldState.fileLoadingProgress
   };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "build/dist",
     "sourceMap": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
+    "suppressImplicitAnyIndexErrors": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
@@ -30,9 +30,11 @@
     "src/reducers",
     "src/schemas",
     "src/utils",
+    "src/components/common/file-uploader",
+    "src/components/common/progress-bar.js",
+    "src/components/modals/load-data-modal.js"
 
     // TODO: add types
-    // "src/components",
     // "src/constants",
     // "src/deckgl-layers",
     // "src/layers"


### PR DESCRIPTION
- Start transitioning from prop-types to typescript types for components.
- Add typescript types to file upload components, to create a better safety net in preparation for a refactor for `upload-file.js` (planning to move logic out of component)

Signed-off-by: Ib Green <ib@unfolded.ai>