### PR TITLE
Add types for composer helpers

### DIFF
--- a/src/actions/vis-state-actions.d.ts
+++ b/src/actions/vis-state-actions.d.ts
@@ -389,36 +389,40 @@ export function loadFilesErr(
   error: any
 ): Merge<loadFilesErrUpdaterAction, {type: ActionTypes.LOAD_FILES_ERR}>;
 
-export type loadFileStepSuccessAction = {
+export type LoadFileStepSuccessAction = {
   fileName: string;
   fileCache: FileCacheItem[];
 };
 export function loadFileStepSuccess(payload: {
   fileName: string;
   fileCache: FileCacheItem[];
-}): Merge<loadFileStepSuccessAction, {type: ActionTypes.LOAD_FILE_STEP_SUCCESS}>;
+}): Merge<LoadFileStepSuccessAction, {type: ActionTypes.LOAD_FILE_STEP_SUCCESS}>;
 
 type FileContent = {
   fileName: string;
   header: string[];
   data: any;
 };
-export type nextFileBatchUpdaterAction = {
-  gen: AsyncGenerator<FileContent>;
-  fileName: string;
-  progress?: any;
-  accumulated?: any;
-  onFinish: (result: any) => any;
+export type NextFileBatchUpdaterAction = {
+  payload: {
+    gen: AsyncGenerator<FileContent>;
+    fileName: string;
+    progress?: any;
+    accumulated?: any;
+    onFinish: (result: any) => any;
+  };
 };
 export function nextFileBatch(
-  payload: nextFileBatchAction
-): {payload: nextFileBatchAction; type: ActionTypes.NEXT_FILE_BATCH};
+  payload: NextFileBatchAction['payload']
+): Merge<NextFileBatchUpdaterAction, {type: ActionTypes.NEXT_FILE_BATCH}>;
 
-export type processFileContentUpdaterAction = {
-  content: FileContent;
-  fileCache: FileCacheItem[];
+export type ProcessFileContentUpdaterAction = {
+  payload: {
+    content: FileContent;
+    fileCache: FileCacheItem[];
+  };
 };
 
 export function processFileContent(
-  payload: processFileContentUpdaterAction
-): {payload: processFileContentUpdaterAction; type: ActionTypes.PROCESS_FILE_CONTENT};
+  payload: ProcessFileContentUpdaterAction['payload']
+): Merge<ProcessFileContentUpdaterAction, {type: ActionTypes.PROCESS_FILE_CONTENT}>;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -139,11 +139,11 @@ export {default as LayerConfigGroup} from './side-panel/layer-panel/layer-config
 export {default as LayerTypeSelector} from './side-panel/layer-panel/layer-type-selector';
 
 export {
-  ChannelByValueSelector, 
+  ChannelByValueSelector,
   HowToButton,
   LayerColorRangeSelector,
   LayerColorSelector
-} from './side-panel/layer-panel/layer-configurator'
+} from './side-panel/layer-panel/layer-configurator';
 
 export * from './common/styled-components';
 import * as Icons from './common/icons';

--- a/src/components/side-panel/layer-panel/layer-config-group.js
+++ b/src/components/side-panel/layer-panel/layer-config-group.js
@@ -162,7 +162,7 @@ class LayerConfigGroup extends Component {
         >
           <StyledLayerConfigGroupLabel className="layer-config-group__label">
             <span>
-              <FormattedMessage id={label || 'misc.empty'} defaultMessage={label}/>
+              <FormattedMessage id={label || 'misc.empty'} defaultMessage={label} />
             </span>
             {description && <InfoHelper description={description} id={label} />}
           </StyledLayerConfigGroupLabel>

--- a/src/components/side-panel/layer-panel/layer-panel.js
+++ b/src/components/side-panel/layer-panel/layer-panel.js
@@ -124,8 +124,7 @@ function LayerPanelFactory(LayerConfigurator, LayerPanelHeader) {
             layerId={layer.id}
             isVisible={config.isVisible}
             label={config.label}
-            labelRCGColorValues={
-              config.dataId ? datasets[config.dataId].color : null}
+            labelRCGColorValues={config.dataId ? datasets[config.dataId].color : null}
             layerType={layer.type}
             onToggleEnableConfig={this._toggleEnableConfig}
             onToggleVisibility={this._toggleVisibility}

--- a/src/components/side-panel/layer-panel/layer-type-selector.js
+++ b/src/components/side-panel/layer-panel/layer-type-selector.js
@@ -65,7 +65,8 @@ const StyledListItem = styled.div`
 
     .layer-type-selector__item__icon {
       color: ${props => props.theme.activeColor};
-      background-size: ${props => props.theme.layerTypeIconSizeSM}px ${props => props.theme.layerTypeIconSizeSM}px;
+      background-size: ${props => props.theme.layerTypeIconSizeSM}px
+        ${props => props.theme.layerTypeIconSizeSM}px;
       margin-right: 12px;
     }
   }
@@ -74,7 +75,8 @@ const StyledListItem = styled.div`
     color: ${props => props.theme.labelColor};
     display: flex;
     background-image: url(${`${CLOUDFRONT}/kepler.gl-layer-icon-bg.png`});
-    background-size: ${props => props.theme.layerTypeIconSizeL}px ${props => props.theme.layerTypeIconSizeL}px;
+    background-size: ${props => props.theme.layerTypeIconSizeL}px
+      ${props => props.theme.layerTypeIconSizeL}px;
   }
 
   .layer-type-selector__item__label {

--- a/src/reducers/combined-updaters.js
+++ b/src/reducers/combined-updaters.js
@@ -134,6 +134,12 @@ export const addDataToMapUpdater = (state, {payload}) => {
   const oldLayers = state.visState.layers;
   const filterNewlyAddedLayers = layers => layers.filter(nl => !oldLayers.find(ol => ol === nl));
 
+  // Returns undefined if not found, to make typescript happy
+  const findMapBoundsIfCentered = layers => {
+    const bounds = options.centerMap && findMapBounds(layers);
+    return bounds ? bounds : undefined;
+  };
+
   return compose_([
     pick_('visState')(
       apply_(visStateUpdateVisDataUpdater, {
@@ -152,9 +158,7 @@ export const addDataToMapUpdater = (state, {payload}) => {
           payload_({
             config: parsedConfig,
             options,
-            bounds: options.centerMap
-              ? findMapBounds(filterNewlyAddedLayers(visState.layers))
-              : null
+            bounds: findMapBoundsIfCentered(filterNewlyAddedLayers(visState.layers))
           })
         )
       )
@@ -162,7 +166,7 @@ export const addDataToMapUpdater = (state, {payload}) => {
 
     pick_('mapStyle')(apply_(styleMapConfigUpdater, payload_({config: parsedConfig, options}))),
 
-    pick_('uiState')(apply_(uiStateLoadFilesSuccessUpdater)),
+    pick_('uiState')(apply_(uiStateLoadFilesSuccessUpdater, payload_(null))),
 
     pick_('uiState')(apply_(toggleModalUpdater, payload_(null))),
 

--- a/src/reducers/composer-helpers.d.ts
+++ b/src/reducers/composer-helpers.d.ts
@@ -1,0 +1,39 @@
+/** Returns a function that logs a value with a given message */
+declare export function log(text: string): (value: any) => void;
+
+/** Wraps a value in an object and stores it the `payload` field */
+declare export function payload_<P>(payload: P): {payload: P};
+
+/** Wraps a value in an object and stores it the `payload` field */
+declare export function compose_<State>(fns: Array<(s: State) => State>): (s: State) => State;
+
+/** TBA */
+declare export function apply_<State, P>(
+  updater: (s: State, p: P) => State,
+  payload: P
+): (s: State) => State;
+
+/** TBA */
+declare export function pick_<State, Prop extends keyof State>(
+  prop: Prop
+): (fn: (p: State[Prop]) => State[Prop]) => (state: State) => State;
+
+/** Returns a reducer function that merges in a partial state value */
+declare export function merge_<State>(
+  object: Partial<State>
+): (state: State) => State;
+
+declare export function pickKepler_<X>(fn: (x: X) => X): (s: {keplerGL: {map: X}}) => {keplerGL: {map: X}}
+
+/** TBA */
+declare export function swap_<X>(item: X): (arr: X[]) => X[]
+
+/** TBA */
+declare export function findById<X>(id: string): (arr: X[]) => X | undefined
+
+/** TBA */
+declare export function with_<State>(fn: (state: State) => State): (state: State) => State;
+
+/** TBA */
+declare export function if_(pred: boolean, fn: (state: State) => State): (state: State) => State;
+

--- a/src/reducers/composer-helpers.d.ts
+++ b/src/reducers/composer-helpers.d.ts
@@ -18,10 +18,10 @@ declare export function pick_<State, Prop extends keyof State>(
   prop: Prop
 ): (fn: (p: State[Prop]) => State[Prop]) => (state: State) => State;
 
-/** Returns a reducer function that merges in a partial state value */
-declare export function merge_<State>(
-  object: Partial<State>
-): (state: State) => State;
+/** Returns a reducer function that merges props with state */
+declare export function merge_<State, Props>(
+  object: Props
+): (state: State) => State & Props;
 
 declare export function pickKepler_<X>(fn: (x: X) => X): (s: {keplerGL: {map: X}}) => {keplerGL: {map: X}}
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -48,3 +48,6 @@ export * as combinedUpdaters from './combined-updaters';
 
 // reducer merges
 export * as visStateMergers from './vis-state-merger';
+
+// Helpers
+export * from './composer-helpers';

--- a/src/reducers/vis-state-updaters.d.ts
+++ b/src/reducers/vis-state-updaters.d.ts
@@ -264,7 +264,7 @@ export type MapInfo = {
   description: string;
 };
 export type FileLoading = {
-  filesToLoad: any[];
+  filesToLoad: FileList;
   onFinish: (payload: any) => any;
   fileCache: any[];
 };
@@ -300,7 +300,7 @@ export type VisState = {
   editor: Editor;
   splitMaps: SplitMap[];
   splitMapsToBeMerged?: SplitMap[];
-  fileLoading?: FileLoading;
+  fileLoading: FileLoading | false;
   fileLoadingProgress: FileLoadingProgress;
   initialState?: Partial<VisState>;
 };
@@ -461,8 +461,7 @@ export function loadFilesUpdater(
   action: VisStateActions.LoadFilesUpdaterAction
 ): VisState;
 export function loadNextFileUpdater(
-  state: VisState,
-  action: VisStateActions.LoadNextFileUpdaterAction
+  state: VisState
 ): VisState;
 export function loadFilesSuccessUpdater(
   state: VisState,
@@ -474,15 +473,15 @@ export function loadFilesErrUpdater(
 ): VisState;
 export function loadFileStepSuccessUpdater(
   state: VisState,
-  action: VisStateActions.loadFileStepSuccessAction
+  action: VisStateActions.LoadFileStepSuccessAction
 ): VisState;
 export function nextFileBatchUpdater(
   state: VisState,
-  action: VisStateActions.nextFileBatchUpdaterAction
+  action: VisStateActions.NextFileBatchUpdaterAction
 ): VisState;
 export function processFileContentUpdater(
   state: VisState,
-  action: VisStateActions.processFileContentUpdaterAction
+  action: VisStateActions.ProcessFileContentUpdaterAction
 ): VisState;
 export function setFeaturesUpdater(
   state: VisState,

--- a/src/reducers/vis-state-updaters.d.ts
+++ b/src/reducers/vis-state-updaters.d.ts
@@ -263,13 +263,11 @@ export type MapInfo = {
   title: string;
   description: string;
 };
-export type FileLoading =
-  | {
-      filesToLoad: any[];
-      onFinish: (payload: any) => any;
-      fileCache: any[];
-    }
-  | false;
+export type FileLoading = {
+  filesToLoad: any[];
+  onFinish: (payload: any) => any;
+  fileCache: any[];
+};
 export type FileLoadingProgress = {
   [key: string]: {
     percent: number;
@@ -302,9 +300,9 @@ export type VisState = {
   editor: Editor;
   splitMaps: SplitMap[];
   splitMapsToBeMerged?: SplitMap[];
-  initialState?: Partial<VisState>;
   fileLoading?: FileLoading;
-  fileLoadingProgress?: FileLoadingProgress;
+  fileLoadingProgress: FileLoadingProgress;
+  initialState?: Partial<VisState>;
 };
 
 export function addDefaultLayers(

--- a/src/reducers/vis-state-updaters.js
+++ b/src/reducers/vis-state-updaters.js
@@ -204,7 +204,7 @@ export const INITIAL_VIS_STATE = {
 
   editor: DEFAULT_EDITOR,
 
-  // fileLoading: {}
+  fileLoading: false,
   fileLoadingProgress: {}
 };
 
@@ -1251,20 +1251,28 @@ export const loadFilesUpdater = (state, action) => {
     (accu, f, i) => merge_(initialFileLoadingProgress(f, i))(accu),
     {}
   );
+
   const fileLoading = {
     fileCache: [],
     filesToLoad: files,
     onFinish
   };
-  let nextState = state;
-  nextState = merge_({fileLoadingProgress})(nextState);
-  nextState = merge_({fileLoading})(nextState);
+
+  const nextState = merge_({fileLoadingProgress, fileLoading})(state);
 
   return loadNextFileUpdater(nextState);
 };
 
-// sucessfully loaded one file, move on to the next one
+/**
+ * Sucessfully loaded one file, move on to the next one
+ * @memberof visStateUpdaters
+ * @type {typeof import('./vis-state-updaters').loadFileStepSuccessUpdater}
+ * @public
+ */
 export function loadFileStepSuccessUpdater(state, action) {
+  if (!state.fileLoading) {
+    return state;
+  }
   const {fileName, fileCache} = action;
   const {filesToLoad, onFinish} = state.fileLoading;
   const stateWithProgress = updateFileLoadingProgressUpdater(state, {
@@ -1281,7 +1289,18 @@ export function loadFileStepSuccessUpdater(state, action) {
   );
 }
 
+// withTask<T>(state: T, task: any): T
+
+/**
+ *
+ * @memberof visStateUpdaters
+ * @type {typeof import('./vis-state-updaters').loadNextFileUpdater}
+ * @public
+ */
 export function loadNextFileUpdater(state) {
+  if (!state.fileLoading) {
+    return state;
+  }
   const {filesToLoad} = state.fileLoading;
   const [file, ...remainingFilesToLoad] = filesToLoad;
 
@@ -1316,6 +1335,12 @@ export function makeLoadFileTask(file, fileCache) {
   );
 }
 
+/**
+ *
+ * @memberof visStateUpdaters
+ * @type {typeof import('./vis-state-updaters').processFileContentUpdater}
+ * @public
+ */
 export function processFileContentUpdater(state, action) {
   const {content, fileCache} = action.payload;
 
@@ -1345,7 +1370,12 @@ export function parseProgress(prevProgress = {}, progress) {
   };
 }
 
-// gets called with payload = AsyncGenerator<???>
+/**
+ * gets called with payload = AsyncGenerator<???>
+ * @memberof visStateUpdaters
+ * @type {typeof import('./vis-state-updaters').nextFileBatchUpdater}
+ * @public
+ */
 export const nextFileBatchUpdater = (
   state,
   {payload: {gen, fileName, progress, accumulated, onFinish}}

--- a/src/reducers/vis-state-updaters.js
+++ b/src/reducers/vis-state-updaters.js
@@ -202,7 +202,10 @@ export const INITIAL_VIS_STATE = {
   // time in unix timestamp (milliseconds) (the number of seconds since the Unix Epoch)
   animationConfig: DEFAULT_ANIMATION_CONFIG,
 
-  editor: DEFAULT_EDITOR
+  editor: DEFAULT_EDITOR,
+
+  // fileLoading: {}
+  fileLoadingProgress: {}
 };
 
 /**
@@ -1253,7 +1256,9 @@ export const loadFilesUpdater = (state, action) => {
     filesToLoad: files,
     onFinish
   };
-  const nextState = merge_({fileLoading})(merge_({fileLoadingProgress})(state));
+  let nextState = state;
+  nextState = merge_({fileLoadingProgress})(nextState);
+  nextState = merge_({fileLoading})(nextState);
 
   return loadNextFileUpdater(nextState);
 };

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -2468,7 +2468,9 @@ test('#visStateReducer -> REMOVE_DATASET w filter and layer', t => {
     mapInfo: {
       title: '',
       description: ''
-    }
+    },
+    fileLoading: oldState.fileLoading, 
+    fileLoadingProgress: oldState.fileLoadingProgress
   };
 
   const newReducer = reducer(oldState, VisStateActions.removeDataset(testCsvDataId));
@@ -2703,7 +2705,9 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_DATASET', t => {
     mapInfo: {
       title: '',
       description: ''
-    }
+    },
+    fileLoading: oldState.fileLoading, 
+    fileLoadingProgress: oldState.fileLoadingProgress
   };
 
   const newReducer = reducer(oldState, VisStateActions.removeDataset(testGeoJsonDataId));


### PR DESCRIPTION
Add typescript types for composer helpers and export the types.

Unfortunately the generic type for `_merge` does not work, it appears that as written it is not able to deduce the full `State` type, but just the partial state which breaks further type checks.