### PR TITLE
Enable modal types #1 of 2

### DIFF
--- a/src/components/common/data-table/button.js
+++ b/src/components/common/data-table/button.js
@@ -38,10 +38,10 @@ const StyledButton = styled.button`
   }
 `;
 const noop = () => {};
-const TableHeaderButton = ({onClick = noop, disabled, text, children, ...props}) => (
+const Button = ({onClick = noop, disabled = false, text = '', children, ...props}) => (
   <StyledButton {...props} onClick={disabled ? null : onClick}>
     {text || children}
   </StyledButton>
 );
 
-export default TableHeaderButton;
+export default Button;

--- a/src/components/common/data-table/index.js
+++ b/src/components/common/data-table/index.js
@@ -378,7 +378,7 @@ export const TableSection = ({
   columns,
   headerGridProps,
   fixedWidth,
-  fixedHeight,
+  fixedHeight = undefined,
   onScroll,
   scrollTop,
   dataGridProps,
@@ -386,7 +386,7 @@ export const TableSection = ({
   setGridRef,
   headerCellRender,
   dataCellRender,
-  scrollLeft
+  scrollLeft = undefined
 }) => (
   <AutoSizer>
     {({width, height}) => {
@@ -580,7 +580,6 @@ export class DataTable extends Component {
                       }}
                       isPinned={false}
                       columns={unpinnedColumnsGhost}
-                      ghost={ghost}
                       headerGridProps={headerGridProps}
                       fixedWidth={fixedWidth}
                       fixedHeight={fixedHeight}

--- a/src/components/common/image-preview.js
+++ b/src/components/common/image-preview.js
@@ -67,8 +67,26 @@ const StyledImagePreview = styled.div.attrs({
   }
 `;
 
-const ImagePreview = ({exportImage = {}, width = 400, showDimension}) => {
-  const {error, imageDataUri, exporting, imageSize: {imageW, imageH} = {}} = exportImage;
+/** @typedef {{
+  error: Error;
+  imageDataUri: string;
+  exporting: boolean;
+  imageSize: {
+    imageW: number;
+    imageH: number;
+  }
+}} ExportImage;
+ */
+
+/**
+ * @param {object} props
+ * @param {ExportImage} [props.exportImage]
+ * @param {number} [props.width]
+ * @param {boolean} [props.showDimension]
+ */
+const ImagePreview = ({exportImage, width = 400, showDimension = false}) => {
+  const {error, imageDataUri, exporting, imageSize: {imageW = 0, imageH = 0} = {}} =
+    exportImage || {};
 
   const imageStyle = {
     width: `${width}px`,

--- a/src/components/common/portaled.js
+++ b/src/components/common/portaled.js
@@ -149,6 +149,7 @@ class Portaled extends Component {
 
   componentWillUnmount() {
     this._unmounted = true;
+    // @ts-ignore
     this.unsubscribe();
   }
 
@@ -216,6 +217,7 @@ class Portaled extends Component {
                   // React modal issue: https://github.com/reactjs/react-modal/issues/769
                   // failed to execute removeChild on parent node when it is already unmounted
                   return (
+                    // @ts-ignore
                     (context && context.current) || {
                       removeChild: () => {},
                       appendChild: () => {}
@@ -233,6 +235,7 @@ class Portaled extends Component {
                     top: this.state.top,
                     transition: this.props.theme.transition,
                     marginTop: isVisible ? '0px' : '14px',
+                    // @ts-ignore
                     ...pos
                   }}
                 >

--- a/src/components/common/switch.js
+++ b/src/components/common/switch.js
@@ -24,6 +24,7 @@ import Checkbox from './checkbox';
 
 const propTypes = {
   checked: PropTypes.bool,
+  type: PropTypes.string,
   id: PropTypes.string.isRequired,
   label: PropTypes.node,
   error: PropTypes.string,

--- a/src/components/modal-container.d.ts
+++ b/src/components/modal-container.d.ts
@@ -1,6 +1,9 @@
 import React from 'react';
+import * as VisStateActions from '../actions/vis-state-actions';
+import * as UIStateActions from '../actions/ui-state-actions';
+import * as MapStyleActions from '../actions/map-style-actions';
 
-export type ModelContainerProps = {
+export type ModalContainerProps = {
   rootNode: object;
   containerW: number;
   containerH: number;
@@ -10,9 +13,9 @@ export type ModelContainerProps = {
   mapStyle: object;
   uiState: object;
   visState: object;
-  visStateActions: object;
-  uiStateActions: object;
-  mapStyleActions: object;
+  visStateActions: typeof VisStateActions;
+  uiStateActions: typeof UIStateActions;
+  mapStyleActions: typeof MapStyleActions;
   onSaveToStorage: () => void,
   cloudProviders: object[]
 };

--- a/src/components/modal-container.js
+++ b/src/components/modal-container.js
@@ -117,8 +117,8 @@ export default function ModalContainerFactory(
   SaveMapModal,
   ShareMapModal
 ) {
-  /** @typedef {import('./modal-container').ModalContainer} ModalContainer */
-  /** @augments React.Component<ModalContainer> */
+  // /** @typedef {import('./modal-container').ModalContainerProps} ModalContainerProps */
+  // /** @augments React.Component<ModalContainerProps> */
   class ModalContainer extends Component {
     // TODO - remove when prop types are fully exported
     static propTypes = {
@@ -179,7 +179,7 @@ export default function ModalContainerFactory(
 
     _onExportImage = () => {
       if (!this.props.uiState.exportImage.exporting) {
-        exportImage(this.props, this.props.uiState.exportImage);
+        exportImage(this.props);
         this.props.uiStateActions.cleanupExportImage();
         this._closeModal();
       }
@@ -352,6 +352,7 @@ export default function ModalContainerFactory(
             );
             modalProps = {
               title: 'modal.title.exportImage',
+              cssStyle: '',
               footer: true,
               onCancel: this._closeModal,
               onConfirm: this._onExportImage,
@@ -376,6 +377,7 @@ export default function ModalContainerFactory(
             );
             modalProps = {
               title: 'modal.title.exportData',
+              cssStyle: '',
               footer: true,
               onCancel: this._closeModal,
               onConfirm: this._onExportData,
@@ -403,6 +405,7 @@ export default function ModalContainerFactory(
             );
             modalProps = {
               title: 'modal.title.exportMap',
+              cssStyle: '',
               footer: true,
               onCancel: this._closeModal,
               onConfirm: this._onExportMap,
@@ -425,6 +428,7 @@ export default function ModalContainerFactory(
             );
             modalProps = {
               title: 'modal.title.addCustomMapboxStyle',
+              cssStyle: '',
               footer: true,
               onCancel: this._closeModal,
               onConfirm: this._onAddCustomMapStyle,
@@ -449,6 +453,7 @@ export default function ModalContainerFactory(
             );
             modalProps = {
               title: 'modal.title.saveMap',
+              cssStyle: '',
               footer: true,
               onCancel: this._closeModal,
               onConfirm: () => this._onSaveMap(false),
@@ -501,6 +506,7 @@ export default function ModalContainerFactory(
             );
             modalProps = {
               title: 'modal.title.shareURL',
+              cssStyle: '',
               onCancel: this._onCloseSaveMap
             };
             break;
@@ -515,7 +521,7 @@ export default function ModalContainerFactory(
           isOpen={Boolean(currentModal)}
           onCancel={this._closeModal}
           {...modalProps}
-          cssStyle={DefaultStyle.concat(modalProps.cssStyle || '')}
+          cssStyle={DefaultStyle.concat(modalProps.cssStyle)}
         >
           {template}
         </ModalDialog>

--- a/src/components/modals/add-map-style-modal.js
+++ b/src/components/modals/add-map-style-modal.js
@@ -149,7 +149,7 @@ function AddMapStyleModalFactory() {
         });
 
         map.on('error', () => {
-          this.loadMaoStyleError();
+          this.loadMapStyleError();
         });
       }
     }

--- a/src/components/modals/data-table-modal.js
+++ b/src/components/modals/data-table-modal.js
@@ -57,7 +57,7 @@ export const DatasetModalTab = styled.div`
   }
 `;
 
-export const DatasetTabs = React.memo(({activeDataset, datasets, showDatasetTable}) => (
+const DatasetTabsUnmemoized = ({activeDataset, datasets, showDatasetTable}) => (
   <DatasetCatalog className="dataset-modal-catalog">
     {Object.values(datasets).map(dataset => (
       <DatasetModalTab
@@ -70,7 +70,9 @@ export const DatasetTabs = React.memo(({activeDataset, datasets, showDatasetTabl
       </DatasetModalTab>
     ))}
   </DatasetCatalog>
-));
+);
+
+export const DatasetTabs = React.memo(DatasetTabsUnmemoized);
 
 DatasetTabs.displayName = 'DatasetTabs';
 

--- a/src/components/modals/delete-data-modal.js
+++ b/src/components/modals/delete-data-modal.js
@@ -27,9 +27,9 @@ const StyledMsg = styled.div`
   margin-top: 24px;
 `;
 
-export const DeleteDatasetModal = ({dataset = {}, layers = []}) => {
+export const DeleteDatasetModal = ({dataset, layers = []}) => {
   // retrieve only layers related to the current dataset
-  const currDatasetLayers = layers.filter(layer => layer.config.dataId === dataset.id);
+  const currDatasetLayers = layers.filter(layer => layer.config.dataId === (dataset && dataset.id));
 
   return (
     <div className="delete-dataset-modal">

--- a/src/components/modals/export-map-modal/export-html-map.js
+++ b/src/components/modals/export-map-modal/export-html-map.js
@@ -27,8 +27,6 @@ import {EXPORT_HTML_MAP_DOC, EXPORT_HTML_MAP_MODES_DOC} from 'constants/user-gui
 import styled from 'styled-components';
 import {FormattedMessage, injectIntl} from 'react-intl';
 
-const NO_OP = () => {};
-
 const ExportMapStyledExportSection = styled(StyledExportSection)`
   .disclaimer {
     font-size: ${props => props.theme.inputFontSize};
@@ -67,85 +65,90 @@ const exportHtmlPropTypes = {
   onEditUserMapboxAccessToken: PropTypes.func.isRequired
 };
 
-const ExportHtmlMap = React.memo(
-  ({
-    onChangeExportMapHTMLMode = NO_OP,
-    onEditUserMapboxAccessToken = NO_OP,
-    options = {},
-    intl
-  }) => (
-    <div>
-      <StyledExportMapSection>
-        <div className="description" />
-        <div className="selection">
-          <FormattedMessage id={'modal.exportMap.html.selection'} />
+const ExportHtmlMapUnmemoized = ({
+  onChangeExportMapHTMLMode = mode => {},
+  onEditUserMapboxAccessToken = token => {},
+  options = {},
+  intl
+}) => (
+  <div>
+    <StyledExportMapSection>
+      <div className="description" />
+      <div className="selection">
+        <FormattedMessage id={'modal.exportMap.html.selection'} />
+      </div>
+    </StyledExportMapSection>
+    <ExportMapStyledExportSection className="export-map-modal__html-options">
+      <div className="description">
+        <div className="title">
+          <FormattedMessage id={'modal.exportMap.html.tokenTitle'} />
         </div>
-      </StyledExportMapSection>
-      <ExportMapStyledExportSection className="export-map-modal__html-options">
-        <div className="description">
-          <div className="title">
-            <FormattedMessage id={'modal.exportMap.html.tokenTitle'} />
-          </div>
-          <div className="subtitle">
-            <FormattedMessage id={'modal.exportMap.html.tokenSubtitle'} />
-          </div>
+        <div className="subtitle">
+          <FormattedMessage id={'modal.exportMap.html.tokenSubtitle'} />
         </div>
-        <div className="selection">
-          <StyledInput
-            onChange={e => onEditUserMapboxAccessToken(e.target.value)}
-            type="text"
-            placeholder={intl.formatMessage({id: 'modal.exportMap.html.tokenPlaceholder'})}
-            value={options ? options.userMapboxToken : ''}
-          />
-          <div className="disclaimer">
-            <StyledWarning>
-              <FormattedMessage id={'modal.exportMap.html.tokenMisuseWarning'} />
-            </StyledWarning>
-            <FormattedMessage id={'modal.exportMap.html.tokenDisclaimer'} />
-            <ExportMapLink href={EXPORT_HTML_MAP_DOC}>
-              <FormattedMessage id={'modal.exportMap.html.tokenUpdate'} />
-            </ExportMapLink>
-          </div>
+      </div>
+      <div className="selection">
+        <StyledInput
+          onChange={e => onEditUserMapboxAccessToken(e.target.value)}
+          type="text"
+          placeholder={intl.formatMessage({id: 'modal.exportMap.html.tokenPlaceholder'})}
+          value={
+            // @ts-ignore
+            options ? options.userMapboxToken : ''
+          }
+        />
+        <div className="disclaimer">
+          <StyledWarning>
+            <FormattedMessage id={'modal.exportMap.html.tokenMisuseWarning'} />
+          </StyledWarning>
+          <FormattedMessage id={'modal.exportMap.html.tokenDisclaimer'} />
+          <ExportMapLink href={EXPORT_HTML_MAP_DOC}>
+            <FormattedMessage id={'modal.exportMap.html.tokenUpdate'} />
+          </ExportMapLink>
         </div>
-      </ExportMapStyledExportSection>
-      <ExportMapStyledExportSection>
-        <div className="description">
-          <div className="title">
-            <FormattedMessage id={'modal.exportMap.html.modeTitle'} />
-          </div>
-          <div className="subtitle">
-            <FormattedMessage id={'modal.exportMap.html.modeSubtitle1'} />
-            <a href={EXPORT_HTML_MAP_MODES_DOC}>
-              <FormattedMessage id={'modal.exportMap.html.modeSubtitle2'} />
-            </a>
-          </div>
+      </div>
+    </ExportMapStyledExportSection>
+    <ExportMapStyledExportSection>
+      <div className="description">
+        <div className="title">
+          <FormattedMessage id={'modal.exportMap.html.modeTitle'} />
         </div>
-        <div className="selection">
-          {EXPORT_HTML_MAP_MODE_OPTIONS.map(mode => (
-            <BigStyledTile
-              key={mode.id}
-              selected={options.mode === mode.id}
-              available={mode.available}
-              onClick={() => mode.available && onChangeExportMapHTMLMode(mode.id)}
-            >
-              <img src={mode.url} alt="" />
-              <p>
-                <FormattedMessage
-                  id={'modal.exportMap.html.modeDescription'}
-                  values={{mode: intl.formatMessage({id: mode.label})}}
-                />
-              </p>
-            </BigStyledTile>
-          ))}
+        <div className="subtitle">
+          <FormattedMessage id={'modal.exportMap.html.modeSubtitle1'} />
+          <a href={EXPORT_HTML_MAP_MODES_DOC}>
+            <FormattedMessage id={'modal.exportMap.html.modeSubtitle2'} />
+          </a>
         </div>
-      </ExportMapStyledExportSection>
-    </div>
-  )
+      </div>
+      <div className="selection">
+        {EXPORT_HTML_MAP_MODE_OPTIONS.map(mode => (
+          <BigStyledTile
+            key={mode.id}
+            selected={
+              // @ts-ignore
+              options.mode === mode.id
+            }
+            available={mode.available}
+            onClick={() => mode.available && onChangeExportMapHTMLMode(mode.id)}
+          >
+            <img src={mode.url} alt="" />
+            <p>
+              <FormattedMessage
+                id={'modal.exportMap.html.modeDescription'}
+                values={{mode: intl.formatMessage({id: mode.label})}}
+              />
+            </p>
+          </BigStyledTile>
+        ))}
+      </div>
+    </ExportMapStyledExportSection>
+  </div>
 );
 
-ExportHtmlMap.propTypes = exportHtmlPropTypes;
+ExportHtmlMapUnmemoized.propTypes = exportHtmlPropTypes;
+ExportHtmlMapUnmemoized.displayName = 'ExportHtmlMap';
 
-ExportHtmlMap.displayName = 'ExportHtmlMap';
+const ExportHtmlMap = React.memo(ExportHtmlMapUnmemoized);
 
 const ExportHtmlMapFactory = () => injectIntl(ExportHtmlMap);
 

--- a/src/components/modals/export-map-modal/export-json-map.js
+++ b/src/components/modals/export-map-modal/export-json-map.js
@@ -57,7 +57,7 @@ const exportJsonPropTypes = {
   options: PropTypes.object
 };
 
-const ExportJsonMap = React.memo(({config = {}}) => (
+const ExportJsonMapUnmemoized = ({config = {}}) => (
   <div>
     <StyledExportMapSection>
       <div className="description" />
@@ -87,11 +87,13 @@ const ExportJsonMap = React.memo(({config = {}}) => (
       </div>
     </StyledJsonExportSection>
   </div>
-));
+);
 
-ExportJsonMap.propTypes = exportJsonPropTypes;
+ExportJsonMapUnmemoized.propTypes = exportJsonPropTypes;
 
-ExportJsonMap.displayName = 'ExportJsonMap';
+ExportJsonMapUnmemoized.displayName = 'ExportJsonMap';
+
+const ExportJsonMap = React.memo(ExportJsonMapUnmemoized);
 
 const ExportJsonMapFactory = () => ExportJsonMap;
 

--- a/src/components/modals/export-map-modal/export-map-modal.js
+++ b/src/components/modals/export-map-modal/export-map-modal.js
@@ -44,65 +44,76 @@ const NO_OP = () => {};
 ExportMapModalFactory.deps = [ExportHtmlMapFactory, ExportJsonMapFactory];
 
 function ExportMapModalFactory(ExportHtmlMap, ExportJsonMap) {
-  const ExportMapModal = React.memo(
-    ({
-      config = {},
-      onChangeExportData = NO_OP,
-      onChangeExportMapFormat = NO_OP,
-      onChangeExportMapHTMLMode = NO_OP,
-      onEditUserMapboxAccessToken = NO_OP,
-      options = {}
-    }) => (
-      <StyledModalContent className="export-map-modal">
-        <div style={style}>
-          <StyledExportMapSection>
-            <div className="description">
-              <div className="title">
-                <FormattedMessage id={'modal.exportMap.formatTitle'} />
-              </div>
-              <div className="subtitle">
-                <FormattedMessage id={'modal.exportMap.formatSubtitle'} />
-              </div>
+  const ExportMapModalUnmemoized = ({
+    config = {},
+    onChangeExportData = NO_OP,
+    onChangeExportMapFormat = format => {},
+    onChangeExportMapHTMLMode = NO_OP,
+    onEditUserMapboxAccessToken = NO_OP,
+    options = {}
+  }) => (
+    <StyledModalContent className="export-map-modal">
+      <div style={style}>
+        <StyledExportMapSection>
+          <div className="description">
+            <div className="title">
+              <FormattedMessage id={'modal.exportMap.formatTitle'} />
             </div>
-            <div className="selection">
-              {EXPORT_MAP_FORMAT_OPTIONS.map(op => (
-                <StyledType
-                  key={op.id}
-                  selected={options.format === op.id}
-                  available={op.available}
-                  onClick={() => op.available && onChangeExportMapFormat(op.id)}
-                >
-                  <FileType ext={op.label} height="80px" fontSize="11px" />
-                </StyledType>
-              ))}
+            <div className="subtitle">
+              <FormattedMessage id={'modal.exportMap.formatSubtitle'} />
             </div>
-          </StyledExportMapSection>
+          </div>
+          <div className="selection">
+            {EXPORT_MAP_FORMAT_OPTIONS.map(op => (
+              <StyledType
+                key={op.id}
+                selected={
+                  // @ts-ignore
+                  options.format === op.id
+                }
+                available={op.available}
+                onClick={() => op.available && onChangeExportMapFormat(op.id)}
+              >
+                <FileType ext={op.label} height="80px" fontSize="11px" />
+              </StyledType>
+            ))}
+          </div>
+        </StyledExportMapSection>
+        {
           {
-            {
-              [EXPORT_MAP_FORMATS.HTML]: (
-                <ExportHtmlMap
-                  onChangeExportMapHTMLMode={onChangeExportMapHTMLMode}
-                  onEditUserMapboxAccessToken={onEditUserMapboxAccessToken}
-                  options={options[options.format]}
-                />
-              ),
-              [EXPORT_MAP_FORMATS.JSON]: (
-                <ExportJsonMap
-                  config={config}
-                  onChangeExportData={onChangeExportData}
-                  options={options[options.format]}
-                />
-              )
-            }[options.format]
-          }
-        </div>
-      </StyledModalContent>
-    )
+            [EXPORT_MAP_FORMATS.HTML]: (
+              <ExportHtmlMap
+                onChangeExportMapHTMLMode={onChangeExportMapHTMLMode}
+                onEditUserMapboxAccessToken={onEditUserMapboxAccessToken}
+                options={
+                  // @ts-ignore
+                  options[options.format]
+                }
+              />
+            ),
+            [EXPORT_MAP_FORMATS.JSON]: (
+              <ExportJsonMap
+                config={config}
+                onChangeExportData={onChangeExportData}
+                options={
+                  // @ts-ignore
+                  options[options.format]
+                }
+              />
+            )
+          }[
+            // @ts-ignore
+            options.format
+          ]
+        }
+      </div>
+    </StyledModalContent>
   );
 
-  ExportMapModal.propTypes = propTypes;
+  ExportMapModalUnmemoized.propTypes = propTypes;
+  ExportMapModalUnmemoized.displayName = 'ExportMapModal';
 
-  ExportMapModal.displayName = 'ExportMapModal';
+  const ExportMapModal = React.memo(ExportMapModalUnmemoized);
 
   return ExportMapModal;
 }

--- a/src/components/modals/share-map-modal.js
+++ b/src/components/modals/share-map-modal.js
@@ -59,7 +59,7 @@ export const StyleSharingUrl = styled.div.attrs({
   }
 `;
 
-export const SharingUrl = ({url, message}) => {
+export const SharingUrl = ({url, message = ''}) => {
   const [copied, setCopy] = useState(false);
   return (
     <StyleSharingUrl>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,10 @@
     "isolatedModules": true,
     "baseUrl": "./src"
   },
+  "paths": {
+    "actions": "src/actions",
+    "actions/*": "src/actions/*"
+  },
   "include": [
     "src/actions",
     "src/cloud-providers",
@@ -33,6 +37,7 @@
     "src/components/common/file-uploader",
     "src/components/common/progress-bar.js",
     "src/components/modals/load-data-modal.js",
+    "src/components/modal-container.js",
     "src/components/kepler.gl"
 
     // TODO: add types


### PR DESCRIPTION
This gets type checking flowing through the big modal-container component all the way to `upload-file.js`.

A few files look like they have big changes but I am just splitting out unmemoized components from memoized ones to ensure typescript can infer the types automatically.
