### PR TITLE
Load: extract extensions from loader objects

### DIFF
--- a/src/components/common/file-uploader/file-upload.d.ts
+++ b/src/components/common/file-uploader/file-upload.d.ts
@@ -3,11 +3,14 @@ import {FileLoading, FileLoadingProgress} from '../../../reducers/vis-state-upda
 
 export type FileUploadProps = {
   onFileUpload: (files: File[]) => void;
-  validFileExt: string[];
   fileLoading: FileLoading | false;
   fileLoadingProgress: FileLoadingProgress;
   intl: any;
   theme: object;
+  /** A list of names of supported formats suitable to present to user */
+  fileFormatNames: string[];
+  /** A list of typically 3 letter extensions (without '.') for file matching */
+  fileExtensions: string[];
 };
 
 export const WarningMsg: React.Component;

--- a/src/components/common/file-uploader/file-upload.d.ts
+++ b/src/components/common/file-uploader/file-upload.d.ts
@@ -8,9 +8,9 @@ export type FileUploadProps = {
   intl: any;
   theme: object;
   /** A list of names of supported formats suitable to present to user */
-  fileFormatNames: string[];
+  fileFormatNames?: string[];
   /** A list of typically 3 letter extensions (without '.') for file matching */
-  fileExtensions: string[];
+  fileExtensions?: string[];
 };
 
 export const WarningMsg: React.Component;

--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -34,12 +34,6 @@ import {FormattedMessage, injectIntl} from 'react-intl';
 
 /** @typedef {import('./file-upload').FileUploadProps} FileUploadProps */
 
-// File.type is not reliable if the OS does not have a
-// registered mapping for the extension.
-// NOTE: Shapefiles must be in a compressed format since
-// it requires multiple files to be present.
-const defaultValidFileExt = ['csv', 'json', 'geojson'];
-
 const fileIconColor = '#D3D8E0';
 
 const LinkRenderer = props => {
@@ -154,10 +148,6 @@ const StyledDisclaimer = styled(StyledMessage)`
 function FileUploadFactory() {
   /** @augments {Component<FileUploadProps>} */
   class FileUpload extends Component {
-    static defaultProps = {
-      validFileExt: defaultValidFileExt
-    };
-
     state = {
       dragOver: false,
       fileLoading: false,
@@ -180,8 +170,8 @@ function FileUploadFactory() {
     frame = createRef();
 
     _isValidFileType = filename => {
-      const {validFileExt} = this.props;
-      const fileExt = validFileExt.find(ext => filename.endsWith(ext));
+      const {fileExtensions} = this.props;
+      const fileExt = fileExtensions.find(ext => filename.endsWith(ext));
 
       return Boolean(fileExt);
     };
@@ -218,7 +208,8 @@ function FileUploadFactory() {
 
     render() {
       const {dragOver, files, errorFiles} = this.state;
-      const {validFileExt, intl, fileLoading, fileLoadingProgress, theme} = this.props;
+      const {fileLoading, fileLoadingProgress, theme, intl} = this.props;
+      const {fileExtensions, fileFormatNames} = this.props;
       return (
         <StyledFileUpload className="file-uploader" ref={this.frame}>
           {FileDrop ? (
@@ -231,15 +222,20 @@ function FileUploadFactory() {
             >
               <StyledUploadMessage className="file-upload__message">
                 <ReactMarkdown
-                  source={`${intl.formatMessage({
-                    id: 'fileUploader.configUploadMessage'
-                  })}(${GUIDES_FILE_FORMAT_DOC}).`}
+                  source={`${intl.formatMessage(
+                    {
+                      id: 'fileUploader.configUploadMessage'
+                    },
+                    {
+                      fileFormatNames: fileFormatNames.map(format => `**${format}**`).join(', ')
+                    }
+                  )}(${GUIDES_FILE_FORMAT_DOC}).`}
                   renderers={{link: LinkRenderer}}
                 />
               </StyledUploadMessage>
               <StyledFileDrop dragOver={dragOver}>
                 <StyledFileTypeFow className="file-type-row">
-                  {validFileExt.map(ext => (
+                  {fileExtensions.map(ext => (
                     <FileType key={ext} ext={ext} height="50px" fontSize="9px" />
                   ))}
                 </StyledFileTypeFow>

--- a/src/components/common/file-uploader/file-upload.js
+++ b/src/components/common/file-uploader/file-upload.js
@@ -170,7 +170,7 @@ function FileUploadFactory() {
     frame = createRef();
 
     _isValidFileType = filename => {
-      const {fileExtensions} = this.props;
+      const {fileExtensions = []} = this.props;
       const fileExt = fileExtensions.find(ext => filename.endsWith(ext));
 
       return Boolean(fileExt);
@@ -209,7 +209,7 @@ function FileUploadFactory() {
     render() {
       const {dragOver, files, errorFiles} = this.state;
       const {fileLoading, fileLoadingProgress, theme, intl} = this.props;
-      const {fileExtensions, fileFormatNames} = this.props;
+      const {fileExtensions = [], fileFormatNames = []} = this.props;
       return (
         <StyledFileUpload className="file-uploader" ref={this.frame}>
           {FileDrop ? (

--- a/src/components/kepler-gl.d.ts
+++ b/src/components/kepler-gl.d.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import {LoaderObject} from '@loaders.gl/loader-utils';
 
 export type KeplerGlProps = {
   mapStyles: object[];

--- a/src/components/modal-container.js
+++ b/src/components/modal-container.js
@@ -62,6 +62,23 @@ import {
 import {EXPORT_MAP_FORMATS} from 'constants/default-settings';
 import KeyEvent from 'constants/keyevent';
 
+// File.type is not reliable if the OS does not have a
+// registered mapping for the extension.
+// NOTE: Shapefiles must be in a compressed format since
+// it requires multiple files to be present.
+const DEFAULT_FILE_EXTENSIONS = ['csv', 'json', 'geojson'];
+const DEFAULT_FILE_FORMATS = ['CSV', 'Json', 'GeoJSON'];
+
+const getFileFormatNames = createSelector(
+  state => state.loaders,
+  loaders => [...DEFAULT_FILE_FORMATS, ...loaders.map(loader => loader.name)]
+);
+
+const getFileExtensions = createSelector(
+  state => state.loaders,
+  loaders => [...DEFAULT_FILE_EXTENSIONS, ...loaders.flatMap(loader => loader.extensions)]
+);
+
 const DataTableModalStyle = css`
   top: 80px;
   padding: 32px 0 0 0;
@@ -338,6 +355,8 @@ export default function ModalContainerFactory(
                 loadFiles={uiState.loadFiles}
                 fileLoading={visState.fileLoading}
                 fileLoadingProgress={visState.fileLoadingProgress}
+                fileFormatNames={getFileFormatNames(this.props.visState)}
+                fileExtensions={getFileExtensions(this.props.visState)}
               />
             );
             modalProps = {

--- a/src/components/modals/load-data-modal.d.ts
+++ b/src/components/modals/load-data-modal.d.ts
@@ -12,6 +12,10 @@ export type LoadDataModalProps = {
     elementType: React.Component;
     tabElementType?: React.Component;
   }[];
+  /** A list of names of supported formats suitable to present to user */
+  fileFormatNames: string[];
+  /** A list of typically 3 letter extensions (without '.') for file matching */
+  fileExtensions: string[];
 };
 
 export function LoadDataModalFactory(

--- a/src/localization/ca.js
+++ b/src/localization/ca.js
@@ -425,7 +425,7 @@ export default {
       '*kepler.gl és una aplicació a la banda client que no es recolza en cap servidor. Les dades només existeixen a la teva màquina/navegador. ' +
       "No s'envien dades ni mapes a cap servidor.",
     configUploadMessage:
-      'Carrega **CSV**, **GeoJson** o un mapa desat en **Json**. Més informació sobre [**supported file formats**]',
+      'Carrega {fileFormatNames} o un mapa desat en **Json**. Més informació sobre [**supported file formats**]',
     browseFiles: 'navega pels teus arxius',
     uploading: 'Carregant',
     fileNotSupported: "L'arxiu {errorFiles} no és compatible.",

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -428,7 +428,7 @@ export default {
       '*kepler.gl is a client-side application with no server backend. Data lives only on your machine/browser. ' +
       'No information or map data is sent to any server.',
     configUploadMessage:
-      'Upload **CSV**, **GeoJson** or saved map **Json**. Read more about [**supported file formats**]',
+      'Upload {fileFormatNames} or saved map **Json**. Read more about [**supported file formats**]',
     browseFiles: 'browse your files',
     uploading: 'Uploading',
     fileNotSupported: 'File {errorFiles} is not supported.',

--- a/src/localization/es.js
+++ b/src/localization/es.js
@@ -426,7 +426,7 @@ export default {
       '*kepler.gl es una aplicación al lado cliente que no utiliza ningún servidor. Los datos sólo existen en tu máquina/navegador. ' +
       'No se envian datos ni mapas a ningún servidor.',
     configUploadMessage:
-      'Cargar **CSV**, **GeoJson** o un mapa guardado en **Json**. Más información sobre [**supported file formats**]',
+      'Cargar {fileFormatNames} o un mapa guardado en **Json**. Más información sobre [**supported file formats**]',
     browseFiles: 'navega por tus archivos',
     uploading: 'Cargando',
     fileNotSupported: 'El archivo {errorFiles} no es compatible.',

--- a/src/localization/fi.js
+++ b/src/localization/fi.js
@@ -425,7 +425,7 @@ export default {
       '*kepler.gl on client-side sovellus, data pysyy vain selaimessasi...' +
       'Tietoja ei lähetetä palvelimelle.',
     configUploadMessage:
-      'Lisää **CSV**, **GeoJson** tai tallennettu kartta **Json**. Lue lisää [**tuetuista formaateista**]',
+      'Lisää {fileFormatNames} tai tallennettu kartta **Json**. Lue lisää [**tuetuista formaateista**]',
     browseFiles: 'selaa tiedostojasi',
     uploading: 'ladataan',
     fileNotSupported: 'Tiedosto {errorFiles} ei ole tuettu.',

--- a/src/localization/pt.js
+++ b/src/localization/pt.js
@@ -426,7 +426,7 @@ export default {
       '*kepler.gl é uma aplicação client-side, sem um servidor backend. Os dados ficam apenas na sua máquina/browser. ' +
       'Nenhuma informação ou dados de mapa é enviado para qualquer server.',
     configUploadMessage:
-      'Envie **CSV**, **GeoJson** ou mapas salvos **Json**. Leia mais sobre [**tipos de arquivos suportados**]',
+      'Envie {fileFormatNames} ou mapas salvos **Json**. Leia mais sobre [**tipos de arquivos suportados**]',
     browseFiles: 'procure seus arquivos',
     uploading: 'Enviando',
     fileNotSupported: 'Arquivo {errorFiles} não é suportado.',

--- a/src/reducers/vis-state-updaters.d.ts
+++ b/src/reducers/vis-state-updaters.d.ts
@@ -303,8 +303,8 @@ export type VisState = {
   splitMapsToBeMerged?: SplitMap[];
   fileLoading: FileLoading | false;
   fileLoadingProgress: FileLoadingProgress;
-  loaders?: LoaderObject[];
-  loadOptions?: object;
+  loaders: LoaderObject[];
+  loadOptions: object;
   initialState?: Partial<VisState>;
 };
 

--- a/src/reducers/vis-state-updaters.js
+++ b/src/reducers/vis-state-updaters.js
@@ -205,7 +205,10 @@ export const INITIAL_VIS_STATE = {
   editor: DEFAULT_EDITOR,
 
   fileLoading: false,
-  fileLoadingProgress: {}
+  fileLoadingProgress: {},
+
+  loaders: [],
+  loadOptions: {}
 };
 
 /**

--- a/test/browser/components/common/file-uploader-test.js
+++ b/test/browser/components/common/file-uploader-test.js
@@ -52,7 +52,7 @@ test('Components -> FileUpload.onDrop', t => {
   const stopPropagation = sinon.spy();
   const wrapper = mountWithTheme(
     <IntlWrapper>
-      <FileUpload onFileUpload={onFileUpload} />
+      <FileUpload onFileUpload={onFileUpload} fileExtensions={['csv']} />
     </IntlWrapper>
   );
 
@@ -99,7 +99,7 @@ test('Components -> FileUpload.onDrop -> render loading msg', t => {
   const wrapper = mountWithTheme(
     <IntlWrapper>
       <FileUpload
-        validFileExts={['csv', 'json', 'geojson']}
+        fileExtensions={['csv', 'json', 'geojson']}
         onFileUpload={onFileUpload}
         fileLoading={{fileCache: [], filesToLoad: [], onFinish: () => {}}}
         fileLoadingProgress={mockFileProgress}
@@ -239,7 +239,7 @@ test('Components -> UploadButton fileInput', t => {
   });
   const wrapper = mountWithTheme(
     <IntlWrapper>
-      <FileUpload onFileUpload={onFileUpload} />
+      <FileUpload onFileUpload={onFileUpload} fileExtensions={['csv']} />
     </IntlWrapper>
   );
   const uploadButton = wrapper.find(UploadButton);

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -2470,7 +2470,9 @@ test('#visStateReducer -> REMOVE_DATASET w filter and layer', t => {
       description: ''
     },
     fileLoading: oldState.fileLoading,
-    fileLoadingProgress: oldState.fileLoadingProgress
+    fileLoadingProgress: oldState.fileLoadingProgress,
+    loaders: oldState.loaders,
+    loadOptions: oldState.loadOptions
   };
 
   const newReducer = reducer(oldState, VisStateActions.removeDataset(testCsvDataId));
@@ -2707,7 +2709,9 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_DATASET', t => {
       description: ''
     },
     fileLoading: oldState.fileLoading,
-    fileLoadingProgress: oldState.fileLoadingProgress
+    fileLoadingProgress: oldState.fileLoadingProgress,
+    loaders: oldState.loaders,
+    loadOptions: oldState.loadOptions
   };
 
   const newReducer = reducer(oldState, VisStateActions.removeDataset(testGeoJsonDataId));


### PR DESCRIPTION
Signed-off-by: Ib Green <ib@unfolded.ai>

UI and functionality now dynamically adapts if additional loaders are supplied.

`upload-file.js` should not "know about" loaders.gl objects, so placed extensions and filename extraction in modal-container - it is still part of the UI but better since seems to contain a lot of glue code and knows about a lot of things and fires of actions.

But as discussed, I should probably move the new selectors into the vis-state-reducer so that we can keep the knowledge of how to extract those things from loaders.gl loaders out of the UI.