### PR TITLE
Export typeahead

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -135,6 +135,7 @@ export {default as CloudTile} from './modals/cloud-tile';
 export {default as FileUploadFactory, FileUpload} from './common/file-uploader/file-upload';
 export {default as DatasetLabel} from './common/dataset-label';
 export {default as ItemSelector} from './common/item-selector/item-selector';
+export {default as Typeahead} from './common/item-selector/typeahead';
 export {default as FieldSelectorFactory} from './common/field-selector';
 export {default as Modal, ModalFooter, ModalTitle} from './common/modal';
 export {default as AppLogo} from './common/logo';


### PR DESCRIPTION
This PR is about exporting the Typeahead component from the item-selector