### PR TITLE
[Bug] Fix 12350 format in tooltip

### DIFF
--- a/src/constants/tooltip.js
+++ b/src/constants/tooltip.js
@@ -80,8 +80,8 @@ export const TOOLTIP_FORMATS = {
   },
   DECIMAL_INT: {
     id: 'DECIMAL_INT',
-    label: '12350',
-    format: '.5r',
+    label: '12345 → 12350',
+    format: '.4~r',
     type: TOOLTIP_FORMAT_TYPES.DECIMAL
   },
   DECIMAL_THREE: {

--- a/src/constants/tooltip.js
+++ b/src/constants/tooltip.js
@@ -81,7 +81,7 @@ export const TOOLTIP_FORMATS = {
   DECIMAL_INT: {
     id: 'DECIMAL_INT',
     label: '12350',
-    format: '.4r',
+    format: '.5r',
     type: TOOLTIP_FORMAT_TYPES.DECIMAL
   },
   DECIMAL_THREE: {


### PR DESCRIPTION
Somehow formatting for 12350 was faulty and misleading from the start