### PR TITLE
[Enhancement] automatically re-project GeoDataFrame to EPSG:4326

### DIFF
--- a/bindings/kepler.gl-jupyter/keplergl/keplergl.py
+++ b/bindings/kepler.gl-jupyter/keplergl/keplergl.py
@@ -29,6 +29,9 @@ def _gdf_to_dict(gdf):
     Returns:
     - dictionary: a dictionary variable that can be used in Kepler.gl
     '''
+    # reproject to 4326 if needed
+    if gdf.crs and not gdf.crs == 4326:
+        gdf = gdf.to_crs(4326)
 
     # get name of the geometry column
     # will cause error if data frame has no geometry column

--- a/docs/keplergl-jupyter/README.md
+++ b/docs/keplergl-jupyter/README.md
@@ -212,7 +212,7 @@ w1.add_data(data=df, name='cities')
 ```
 
 ### `GeoDataFrame`
-kepler.gl accepts [geopandas.GeoDataFrame][geo_data_frame], it automatically converts the current `geometry` column from shapely to wkt string.
+kepler.gl accepts [geopandas.GeoDataFrame][geo_data_frame], it automatically converts the current `geometry` column from shapely to wkt string and re-projects geometries to latitude and longitude (EPSG:4326) if the active `geometry` column is in a different projection.
 ```python
 url = 'http://eric.clst.org/assets/wiki/uploads/Stuff/gz_2010_us_040_00_500k.json'
 country_gdf = geopandas.read_file(url)


### PR DESCRIPTION
If you pass a GeoDataFrame to Jupyter widget it gets automatically re-projected to EPSG:4326 if `crs` is set and is different. That way user does not have to worry about projections when adding data to a map.

I haven't found a test suite for Jupyter plugin, can you point me to the right place so I can write tests?

Closes #1209 