### PR TITLE
fix: save to map provider

### DIFF
--- a/src/components/map-container.js
+++ b/src/components/map-container.js
@@ -503,7 +503,7 @@ export default function MapContainerFactory(MapPopover, MapControl, Editor) {
         transformRequest
       };
 
-      const isEdit = mapControls.mapDraw.active;
+      const isEdit = mapControls.mapDraw ? mapControls.mapDraw.active : false;
       const hasGeocoderLayer = layers.find(l => l.id === GEOCODER_LAYER_ID);
 
       return (


### PR DESCRIPTION
Issue #1374

This should fix the error that appears when trying to Save map to a provider (Dropbox / Carto).

The error currently happens at **MapContainer**, lin 506. The presence of `mapControls.mapDraw` is assumed, but that's not the case from this Providers > Save option flow

This small change looks enough to avoid the error and present the popup, but I'm not sure if it needs any other extra check.