### PR TITLE
chore: replaced _renderMapPopover with combined popovers component to avoid useless re-renders

### DIFF
--- a/src/components/combined-popovers.js
+++ b/src/components/combined-popovers.js
@@ -1,0 +1,150 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {useMemo} from 'react';
+import MapPopoverFactory from './map/map-popover';
+import {getLayerHoverProp} from 'utils/layer-utils';
+import WebMercatorViewport from 'viewport-mercator-project';
+
+const getHoverXY = (viewport, lngLat) => {
+  const screenCoord = !viewport || !lngLat ? null : viewport.project(lngLat);
+  return screenCoord && {x: screenCoord[0], y: screenCoord[1]};
+};
+
+CombinedPopoversFactory.deps = [MapPopoverFactory];
+
+function CombinedPopoversFactory(MapPopover) {
+  const CombinedPopovers = ({
+    mapState,
+    hoverInfo,
+    clicked,
+    datasets,
+    interactionConfig,
+    layers,
+    mousePosition,
+    coordinate,
+    pinned,
+    layersToRender,
+    onClosePopover,
+    hasTooltip,
+    hasComparisonTooltip,
+    compareMode,
+    onHoverXY = getHoverXY
+  }) => {
+    // if clicked something, ignore hover behavior
+    const position = useMemo(
+      () => ({
+        x: mousePosition[0],
+        y: mousePosition[1]
+      }),
+      [mousePosition]
+    );
+
+    const {pinnedPosition, layerPinnedProp, layerHoverProp} = useMemo(() => {
+      const hoverProps = getLayerHoverProp({
+        interactionConfig,
+        hoverInfo,
+        layers,
+        layersToRender,
+        datasets
+      });
+
+      // project lnglat to screen so that tooltip follows the object on zoom
+      if (hasTooltip) {
+        const viewport = new WebMercatorViewport(mapState);
+        const lngLat = clicked ? clicked.lngLat : pinned.coordinate;
+        const pinnedPos = onHoverXY(viewport, lngLat);
+        const pinnedProp = getLayerHoverProp({
+          interactionConfig,
+          hoverInfo: clicked,
+          layers,
+          layersToRender,
+          datasets
+        });
+
+        if (hoverProps && layerPinnedProp && pinnedProp) {
+          hoverProps.primaryData = pinnedProp.data;
+          hoverProps.compareType = interactionConfig.tooltip.config.compareType;
+        }
+
+        return {
+          pinnedPosition: pinnedPos,
+          layerPinnedProp: pinnedProp,
+          layerHoverProp: hoverProps
+        };
+      }
+
+      return {
+        pinnedPosition: {},
+        layerPinnedProp: null,
+        layerHoverProp: hoverProps
+      };
+    }, [
+      hasTooltip,
+      mapState,
+      clicked,
+      pinned,
+      interactionConfig,
+      layers,
+      layersToRender,
+      datasets,
+      hoverInfo
+    ]);
+
+    const {width, height, zoom} = mapState;
+
+    const commonProp = useMemo(
+      () => ({
+        onClose: onClosePopover,
+        mapW: width,
+        mapH: height,
+        zoom
+      }),
+      [width, height, zoom, onClosePopover]
+    );
+
+    return (
+      <>
+        {hasTooltip && (
+          <MapPopover
+            {...pinnedPosition}
+            {...commonProp}
+            layerHoverProp={layerPinnedProp}
+            coordinate={interactionConfig.coordinate.enabled && (pinned || {}).coordinate}
+            frozen={hasTooltip}
+            isBase={compareMode}
+          />
+        )}
+        {hasComparisonTooltip && (
+          <MapPopover
+            {...position}
+            {...commonProp}
+            layerHoverProp={layerHoverProp}
+            coordinate={interactionConfig.coordinate.enabled && coordinate}
+          />
+        )}
+      </>
+    );
+  };
+
+  return React.memo(CombinedPopovers);
+}
+
+export default CombinedPopoversFactory;

--- a/src/components/common/item-selector/item-selector.js
+++ b/src/components/common/item-selector/item-selector.js
@@ -313,9 +313,7 @@ class ItemSelector extends Component {
                     light={this.props.inputTheme === 'light'}
                   />
                 ) : (
-                  <FormattedMessage
-                    id={this.props.placeholder || 'placeholder.selectValue'}
-                  />
+                  <FormattedMessage id={this.props.placeholder || 'placeholder.selectValue'} />
                 )}
               </DropdownSelectValue>
               {this.props.erasable && hasValue ? (

--- a/src/components/common/range-slider.js
+++ b/src/components/common/range-slider.js
@@ -126,20 +126,14 @@ export default function RangeSliderFactory(RangePlot) {
     _setRangeVal1 = val => {
       const {value0, range, onChange} = this.props;
       const val1 = Number(val);
-      onChange([
-        value0,
-        clamp([value0, range[1]], this._roundValToStep(val1))
-      ]);
+      onChange([value0, clamp([value0, range[1]], this._roundValToStep(val1))]);
       return true;
     };
 
     _setRangeVal0 = val => {
       const {value1, range, onChange} = this.props;
       const val0 = Number(val);
-      onChange([
-        clamp([range[0], value1], this._roundValToStep(val0)),
-        value1
-      ]);
+      onChange([clamp([range[0], value1], this._roundValToStep(val0)), value1]);
       return true;
     };
 

--- a/src/components/common/slider/slider.js
+++ b/src/components/common/slider/slider.js
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 import SliderHandle from './slider-handle';
 import SliderBarHandle from './slider-bar-handle';
 import {normalizeSliderValue} from 'utils/data-utils';
-import { clamp } from 'utils/data-utils';
+import {clamp} from 'utils/data-utils';
 
 function noop() {}
 


### PR DESCRIPTION
This PR replace __renderMapPopover with an actual react component. It will avoid re-renders because it's not a simple function but it takes advantage of react optimization

Signed-off-by: Giuseppe Macri <macri.giuseppe@gmail.com>