### PR TITLE
[BUG] Set colorbrewer version to 1.4.0 #1416

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@turf/boolean-within": "^6.0.1",
     "@turf/helpers": "^6.1.4",
     "classnames": "^2.2.1",
-    "colorbrewer": "^1.0.0",
+    "colorbrewer": "^1.4.0",
     "copy-to-clipboard": "^3.3.1",
     "d3-array": "^2.8.0",
     "d3-axis": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,10 +3938,10 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorbrewer@^1.0.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/colorbrewer/-/colorbrewer-1.3.0.tgz#1d7e92a6277e42dc56377911bbd867bdbcb2ff7d"
-  integrity sha512-AzVPpWa+fuO/qY8LxPQjej6F49Lb2Cl+7U9YhPn6y4/SOY6u/EZiXUc7qHzRb6i6fWPStCUdEaU2731QyQKWjg==
+colorbrewer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colorbrewer/-/colorbrewer-1.4.0.tgz#ffe893675c4de868f27216e50db7d7aa39ee50cf"
+  integrity sha512-+NM91BbBU/le4Kt/1CsCDf+Hoir1Z+o43od1ZbmSOyMUI6DwlUKmfJdsOPplNiGzq4NSn2C3yn/ZOvtKHC27zQ==
 
 colorette@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
- Fix: Color ranges definition depends on colorbrewer.schemeGroups attribute, which isn't defined in colorbrewer v1.0.0.