### PR TITLE
[jupyter] WIP python save_to_json function

### DIFF
--- a/bindings/kepler.gl-jupyter/js/lib/keplergl-plugin.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl-plugin.js
@@ -47,7 +47,8 @@ export const KeplerGlModal = widgets.DOMWidgetModel.extend({
     _view_module: 'keplergl-jupyter',
 
     data: {},
-    config: {}
+    config: {},
+    _exported_map: {}
   }
 });
 
@@ -61,6 +62,7 @@ export const KeplerGlView = widgets.DOMWidgetView.extend({
     // event listener
     this.model.on('change:data', this.data_changed, this);
     this.model.on('change:config', this.config_changed, this);
+    this.model.on('custom', this.export_map, this)
 
     window.dom = this.el;
   },
@@ -75,5 +77,13 @@ export const KeplerGlView = widgets.DOMWidgetView.extend({
     log('KeplerGlModal start config_change');
 
     this.keplergl.onConfigChange(this);
+  },
+
+  export_map(content) {
+    console.log("HI", content)
+    if (content === 'export_map') {
+      this.model.set('_exported_map', this.keplergl.exportMap())
+      this.model.save_changes()
+    }
   }
 });

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/config-panel.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/config-panel.js
@@ -62,7 +62,7 @@ function configStringify(config) {
   });
 }
 
-export const CopyConfig = ({config}) => {
+export const CopyConfig = ({config, visState}) => {
   const [copied, setCopy] = useState(false);
   const value = configStringify(config);
   return (
@@ -73,6 +73,14 @@ export const CopyConfig = ({config}) => {
           {copied ? 'Copied!' : 'Copy'}
         </Button>
       </CopyToClipboard>
+      {/* <Button width="100px" onClick={() => {
+        console.log(utils)
+
+        exportJson({visState})
+        }}>
+        <Icons.Clipboard height="16px" />
+        Save
+      </Button> */}
       <TextArea value={value} readOnly selected />
     </StyleCopyConfig>
   );
@@ -82,7 +90,7 @@ function CustomSidePanelsFactory() {
   const CustomPanels = ({activeSidePanel, visState, mapState, mapStyle}) => {
     const config = KeplerGlSchema.getConfigToSave({visState, mapState, mapStyle});
     if (activeSidePanel === 'config') {
-      return <CopyConfig config={config} />;
+      return <CopyConfig config={config} visState={visState}/>;
     }
 
     return null;

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/kepler.gl.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/kepler.gl.js
@@ -57,6 +57,13 @@ function getDatasetsInStore(store) {
   }
 }
 
+function getMapExportInStore(store) {
+  if (store) {
+    const currentState = store.getState().keplerGl.map;
+    return currentState.visState.schema.save(currentState)
+  }
+}
+
 class KeplerGlJupyter {
   constructor() {
     this.id = `${DOM_EL_ID}-${counter}`;
@@ -127,6 +134,10 @@ class KeplerGlJupyter {
       log('config already in model');
       this.onConfigChange(that);
     }
+  }
+
+  exportMap() {
+    return getMapExportInStore(this.store);
   }
 
   onDataChange(that) {


### PR DESCRIPTION
- The goal is to export the entire map as a json by calling the following javascript code, and access it from a python function call:
`const exportedData = state.keplerGl.map.visState.schema.save(state.keplerGl.map)`

- Adds a `save_to_json` python function to compliment the `save_to_html` function.

This PR is *not* yet functional. I'm unsure how to implement a low level async data exchange between python->js->python. 

Research links:
https://ipywidgets.readthedocs.io/en/latest/examples/Widget%20Asynchronous.html#Waiting-for-user-interaction
https://ipywidgets.readthedocs.io/en/latest/embedding.html#python-interface
https://stackoverflow.com/questions/33845775/send-json-data-to-jupyter-notebook-frontend-via-comm/33846113
https://github.com/jupyter-widgets/ipywidgets/blob/master/docs/source/examples/Widget%20Low%20Level.ipynb
https://github.com/jupyter-widgets/ipywidgets/blob/24628f006c8a468994eba7a6e964fe619c992267/ipywidgets/widgets/widget.py#L260
https://github.com/jupyter-widgets/ipywidgets/blob/master/packages/base/src/widget.ts