### PR TITLE
[Bug] Geojson layer is not updated when dataset updated

### DIFF
--- a/src/layers/base-layer.js
+++ b/src/layers/base-layer.js
@@ -846,12 +846,12 @@ class Layer {
     this.meta = {...this.meta, ...meta};
   }
 
-  getDataUpdateTriggers({filteredIndex, id}) {
+  getDataUpdateTriggers({filteredIndex, id, allData}) {
     const {columns} = this.config;
 
     return {
-      getData: {datasetId: id, columns, filteredIndex},
-      getMeta: {datasetId: id, columns},
+      getData: {datasetId: id, allData, columns, filteredIndex},
+      getMeta: {datasetId: id, allData, columns},
       ...(this.config.textLabel || []).reduce(
         (accu, tl, i) => ({
           ...accu,


### PR DESCRIPTION
In current implementation when `addDataToMap` is called second time for the same `dataset.info.id`, `geojson-layer` will not  update correctly. Because `calculateDataAttribute` in GeoJSON layer require precalculated `this.dataToFeature` property which calculated in `updateLayerMeta`. So If metadata did not change (same columns but different rows), `updateLayerMeta` will not be called and layer will not update correctly.

Given that `updateLayerMeta` takes `allData` as param, it will be logical to call it when data updates.