### PR TITLE
[Feat] Using tippy for map popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@mapbox/geo-viewport": "^0.4.1",
     "@mapbox/geojson-normalize": "0.0.1",
     "@mapbox/vector-tile": "^1.3.1",
+    "@tippyjs/react": "^4.2.0",
     "@turf/bbox": "^6.0.1",
     "@turf/boolean-within": "^6.0.1",
     "@turf/helpers": "^6.1.4",
@@ -281,6 +282,6 @@
     "Giuseppe Macri <gmacri@uber.com>"
   ],
   "volta": {
-    "node": "10.23.0"
+    "node": "12.19.0"
   }
 }

--- a/src/components/map/layer-hover-info.js
+++ b/src/components/map/layer-hover-info.js
@@ -31,8 +31,6 @@ export const StyledLayerName = styled(CenterFlexbox)`
   font-size: 12px;
   letter-spacing: 0.43px;
   text-transform: capitalize;
-  padding: 0 14px;
-  margin-top: 12px;
 
   svg {
     margin-right: 4px;

--- a/src/components/map/map-popover.d.ts
+++ b/src/components/map/map-popover.d.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import {FunctionComponent} from 'react';
 import {IntlShape} from 'react-intl';
 import {LayerHoverProp} from '../../utils/layer-utils';
@@ -12,6 +13,7 @@ export type MapPopoverProps = {
   layerHoverProp: LayerHoverProp | null;
   isBase?: boolean;
   zoom: number;
+  container?: HTMLElement | null;
   onClose: () => void;
 };
 

--- a/test/browser/components/map/map-popover-test.js
+++ b/test/browser/components/map/map-popover-test.js
@@ -21,11 +21,10 @@
 import React from 'react';
 import sinon from 'sinon';
 import test from 'tape';
-import {renderHook} from '@testing-library/react-hooks';
 
 import {Pin} from 'components/common/icons';
 import {IntlWrapper, mountWithTheme} from 'test/helpers/component-utils';
-import MapPopoverFactory, {usePosition} from 'components/map/map-popover';
+import MapPopoverFactory from 'components/map/map-popover';
 import {appInjector} from 'components';
 
 const MapPopover = appInjector.get(MapPopoverFactory);
@@ -54,45 +53,6 @@ test('Map Popover - render', t => {
   t.equal(wrapper.find('.map-popover__layer-info').length, 0, 'Should display 0 layer info');
   t.equal(wrapper.find(Pin).length, 1, 'Should display 1 pin');
   t.equal(wrapper.find('.primary-label').length, 1, 'Should display 1 primary label');
-
-  t.end();
-});
-
-test('Map Popover -> renderHooks', t => {
-  const wrapper = ({children}) => <IntlWrapper>{children}</IntlWrapper>;
-  const ref = {
-    current: {
-      offsetWidth: 50,
-      offsetHeight: 50
-    }
-  };
-  const layerHoverProp = {data: [1]};
-
-  const {result} = renderHook(
-    () =>
-      usePosition(
-        {
-          x: 100,
-          y: 200,
-          mapW: 600,
-          mapH: 800,
-          layerHoverProp
-        },
-        ref
-      ),
-    {
-      wrapper
-    }
-  );
-
-  t.deepEqual(
-    result.current.pos,
-    {
-      left: 120,
-      top: 220
-    },
-    'should calculate correct pos'
-  );
 
   t.end();
 });

--- a/test/setup-browser-env.js
+++ b/test/setup-browser-env.js
@@ -113,6 +113,7 @@ function mockCanvas(globalWindow) {
 global.window = window;
 global.document = window.document;
 global.HTMLElement = window.HTMLElement;
+global.Element = window.Element;
 global.fetch = window.fetch;
 
 Object.keys(global.window).forEach(property => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,6 +2702,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.4.4":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.6.0.tgz#f022195afdfc942e088ee2101285a1d31c7d727f"
+  integrity sha512-cPqjjzuFWNK3BSKLm0abspP0sp/IGOli4p5I5fKFAzdS8fvjdOwDCfZqAaIiXd9lPkOWi3SUUfZof3hEb7J/uw==
+
 "@probe.gl/stats@3.3.0", "@probe.gl/stats@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@probe.gl/stats/-/stats-3.3.0.tgz#66f684ead7cee1f2aad5ee5e9d297e84e08c5536"
@@ -2755,6 +2760,13 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/testing-library__react-hooks" "^3.4.0"
+
+"@tippyjs/react@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@tippyjs/react/-/react-4.2.0.tgz#a1cb369d0051099e8a7e4ceb59f809abd9955283"
+  integrity sha512-T6UcHtwtGkvgsBQ4bNp8BtXGxa2ujfOkWUogYkRtN4UVJ2QRgDdFoJeaPxdndnVYFEa2uTVxSFxs8QkSkZ2Gdw==
+  dependencies:
+    tippy.js "^6.2.0"
 
 "@turf/bbox@6.x", "@turf/bbox@^6.0.1":
   version "6.0.1"
@@ -14625,6 +14637,13 @@ tinyqueue@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/tinyqueue/-/tinyqueue-2.0.3.tgz#64d8492ebf39e7801d7bd34062e29b45b2035f08"
   integrity sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==
+
+tippy.js@^6.2.0:
+  version "6.2.7"
+  resolved "https://registry.yarnpkg.com/tippy.js/-/tippy.js-6.2.7.tgz#62fb34eda23f7d78151ddca922b62818c1ab9869"
+  integrity sha512-k+kWF9AJz5xLQHBi3K/XlmJiyu+p9gsCyc5qZhxxGaJWIW8SMjw1R+C7saUnP33IM8gUhDA2xX//ejRSwqR0tA==
+  dependencies:
+    "@popperjs/core" "^2.4.4"
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
- Using Tippy to avoid complex positioning calculations. Hopefully, this will also prevent React RangeError: Maximum call stack size exceeded from happening. (BTW, I was wrong, Tippy does expose Popper's virtual element functionality, but under a different name: [getReferenceClientRect](https://atomiks.github.io/tippyjs/v6/all-props/#getreferenceclientrect), so I could use it here). Tried to keep the current tooltip behavior mostly unchanged
- A bit of a clean up of the display logic in `MapContainer`
- Tooltip positioning and overflow prevention now takes the boundaries of the container into account (`DeckGL` element)
- Improve CSS styling:
     - using Flexbox instead of absolute positioning for the header row
     - setting margins _between_ the children of the containers instead of before the individual child elements (using `& > *+* { margin-top: ...}`)
     - using CSS grid for the tables - we can specify `row-gap` and `column-gap` and avoid outer padding for the content of the cells. This way the content can be correctly aligned with the text outside of the table