### PR TITLE
Fix screenshot with images

### DIFF
--- a/src/utils/dom-to-image.js
+++ b/src/utils/dom-to-image.js
@@ -473,7 +473,7 @@ function newImages() {
 
   function newImage(element) {
     function inline(get) {
-      if (element.src) {
+      if (isDataUrl(element.src)) {
         return Promise.resolve();
       }
       return Promise.resolve(element.src)


### PR DESCRIPTION
If map component contains images, they should be inlined as in the original dom-to-image. Only data URLs can be skipped. https://github.com/tsayen/dom-to-image/blob/master/src/dom-to-image.js#L718

The bug was introduced in https://github.com/keplergl/kepler.gl/commit/2bb3867a767f6a22a9ccc837cd5795c38013fec3#diff-32702aff9a757e2662e92aab458e2f00268c2397a3046ec69701aa6a99ad3db3L827 (expand the diff of src/utils/dom-to-image.js to see it)