### PR TITLE
Make showing User Guide link optional for jupyter widget

### DIFF
--- a/bindings/kepler.gl-jupyter/keplergl/keplergl.py
+++ b/bindings/kepler.gl-jupyter/keplergl/keplergl.py
@@ -100,8 +100,12 @@ class KeplerGl(widgets.DOMWidget):
     height = Int(400).tag(sync=True)
 
     def __init__(self, **kwargs):
+        if 'show_docs' not in kwargs:
+            kwargs['show_docs'] = True
+        if kwargs['show_docs']:
+            print('User Guide: {}'.format(documentation))
+        kwargs.pop('show_docs')
         super(KeplerGl, self).__init__(**kwargs)
-        print('User Guide: {}'.format(documentation))
 
     @validate('data')
     def _validate_data(self, proposal):

--- a/docs/keplergl-jupyter/README.md
+++ b/docs/keplergl-jupyter/README.md
@@ -90,6 +90,16 @@ map_1
 
 ![empty map][empty_map]
 
+ By default, the User Guide URL (<https://docs.kepler.gl/docs/keplergl-jupyter>) will be printed when a map is created. To hide the User Guide URL, set `show_docs=False`.
+
+```python
+# Hide the User Guide URL
+from keplergl import KeplerGl
+map_1 = KeplerGl(show_docs=False)
+map_1
+```
+
+
 You can also create the map and pass in the data or data and config at the same time. Follow the instruction to [match config with data][match-config-w-data]
 
 ```python

--- a/docs/keplergl-jupyter/README.md
+++ b/docs/keplergl-jupyter/README.md
@@ -75,7 +75,12 @@ $ jupyter labextension install @jupyter-widgets/jupyterlab-manager keplergl-jupy
       Datasets as a dictionary, key is the name of the dataset. Read more on [Accepted data format][data_format]
 
   - __`config`__ `dict` _optional_
+      
       Map config as a dictionary. The `dataId` in the layer and filter settings should match the `name` of the dataset they are created under
+
+  - __`show_docs`__ `bool` _optional_
+      
+      By default, the User Guide URL (<https://docs.kepler.gl/docs/keplergl-jupyter>) will be printed when a map is created. To hide the User Guide URL, set `show_docs=False`.   
 
 The following command will load kepler.gl widget below a cell.
 **The map object created here is `map_1` it will be used throughout the code example in this doc.**
@@ -89,15 +94,6 @@ map_1
 ```
 
 ![empty map][empty_map]
-
- By default, the User Guide URL (<https://docs.kepler.gl/docs/keplergl-jupyter>) will be printed when a map is created. To hide the User Guide URL, set `show_docs=False`.
-
-```python
-# Hide the User Guide URL
-from keplergl import KeplerGl
-map_1 = KeplerGl(show_docs=False)
-map_1
-```
 
 
 You can also create the map and pass in the data or data and config at the same time. Follow the instruction to [match config with data][match-config-w-data]


### PR DESCRIPTION
This pull request resolves the issue https://github.com/keplergl/kepler.gl/issues/1553. By default, the User Guide URL will always be printed when a map is created. Users can set `KeplerGl(show_docs=False)` to hide the User Guide URL if needed. 

Before:
![](https://user-images.githubusercontent.com/5016453/126163819-026b0c86-4766-48fa-b9d2-56e967bdeb9e.png)
After:
![](https://i.imgur.com/9Cww5Ue.png)