### PR TITLE
Request for Comment: Attempt at removing react-palm for 1 task

### DIFF
--- a/src/components/effectful/request-map-style.js
+++ b/src/components/effectful/request-map-style.js
@@ -5,6 +5,12 @@ import {generateHashId} from 'utils/utils';
 // Utils
 import {isValidStyleUrl, getStyleDownloadUrl} from 'utils/map-style-utils/mapbox-gl-style-editor';
 
+// This is exported to aid testing.
+export const TASKS = {
+  loadMapStyleTask,
+  requestMapStyles
+};
+
 export default function RequestMapStyle({
   defaultMapStyles,
   mapStyles,
@@ -32,7 +38,11 @@ export default function RequestMapStyle({
       );
       loadMapStyles(allStyles.toLoad);
       // TODO: Make the side effect here and then call loadMapStyles
-      requestMapStyles(allStyles.toRequest, {mapboxApiAccessToken, mapboxApiUrl, loadMapStyles});
+      TASKS.requestMapStyles(allStyles.toRequest, {
+        mapboxApiAccessToken,
+        mapboxApiUrl,
+        loadMapStyles
+      });
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -51,7 +61,7 @@ function requestMapStyles(mapStyles, {mapboxApiAccessToken, mapboxApiUrl, loadMa
           ? getStyleDownloadUrl(url, accessToken || mapboxApiAccessToken, mapboxApiUrl)
           : url
       }))
-      .map(loadMapStyleTask)
+      .map(TASKS.loadMapStyleTask)
   ).then(
     // success
     results =>

--- a/src/components/effectful/request-map-style.js
+++ b/src/components/effectful/request-map-style.js
@@ -1,3 +1,4 @@
+import {default as Console} from 'global/console';
 import {useEffect} from 'react';
 import {json as requestJson} from 'd3-request';
 import {generateHashId} from 'utils/utils';
@@ -79,7 +80,9 @@ function requestMapStyles(mapStyles, {mapboxApiAccessToken, mapboxApiUrl, loadMa
       ),
     // error
     // loadMapStyleErr
-    () => {}
+    e => {
+      Console.warn('loadMapStyleErr', e);
+    }
   );
 }
 

--- a/src/components/effectful/request-map-style.js
+++ b/src/components/effectful/request-map-style.js
@@ -1,0 +1,38 @@
+import {useEffect} from 'react';
+import {generateHashId} from 'utils/utils';
+
+export default function RequestMapStyle({
+  defaultMapStyles,
+  mapStyles,
+  loadMapStyles,
+  requestMapStyles
+}) {
+  useEffect(
+    () => {
+      const defaultStyles = Object.values(defaultMapStyles);
+      // add id to custom map styles if not given
+      const customStyles = (mapStyles || []).map(ms => ({
+        ...ms,
+        id: ms.id || generateHashId()
+      }));
+
+      const allStyles = [...customStyles, ...defaultStyles].reduce(
+        (accu, style) => {
+          const hasStyleObject = style.style && typeof style.style === 'object';
+          accu[hasStyleObject ? 'toLoad' : 'toRequest'][style.id] = style;
+
+          return accu;
+        },
+        {toLoad: {}, toRequest: {}}
+      );
+      loadMapStyles(allStyles.toLoad);
+      // TODO: Make the side effect here and then call loadMapStyles
+      requestMapStyles(allStyles.toRequest);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      // This is intentional. This effect is only called once, on mount.
+    ]
+  );
+  return null;
+}

--- a/src/components/effectful/request-map-style.js
+++ b/src/components/effectful/request-map-style.js
@@ -76,9 +76,10 @@ function requestMapStyles(mapStyles, {mapboxApiAccessToken, mapboxApiUrl, loadMa
           }),
           {}
         )
-      )
+      ),
     // error
     // loadMapStyleErr
+    () => {}
   );
 }
 

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -390,7 +390,8 @@ function KeplerGlFactory(
                   defaultMapStyles={this.props.mapStyle.mapStyles}
                   mapStyles={this.props.mapStyles}
                   loadMapStyles={this.props.mapStyleActions.loadMapStyles}
-                  requestMapStyles={this.props.mapStyleActions.requestMapStyles}
+                  mapboxApiAccessToken={this.props.mapboxApiAccessToken}
+                  mapboxApiUrl={this.props.mapboxApiUrl}
                 />
                 <NotificationPanel {...notificationPanelFields} />
                 {!uiState.readOnly && !readOnly && <SidePanel {...sideFields} />}

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -50,8 +50,8 @@ import ModalContainerFactory from './modal-container';
 import PlotContainerFactory from './plot-container';
 import NotificationPanelFactory from './notification-panel';
 import GeoCoderPanelFactory from './geocoder-panel';
+import RequestMapStyle from './effectful/request-map-style';
 
-import {generateHashId} from 'utils/utils';
 import {validateToken} from 'utils/mapbox-utils';
 import {mergeMessages} from 'utils/locale-utils';
 
@@ -259,7 +259,6 @@ function KeplerGlFactory(
 
     componentDidMount() {
       this._validateMapboxToken();
-      this._loadMapStyle();
       this._handleResize(this.props);
       if (typeof this.props.onKeplerGlInitialized === 'function') {
         this.props.onKeplerGlInitialized();
@@ -332,28 +331,6 @@ function KeplerGlFactory(
       });
     }
 
-    _loadMapStyle = () => {
-      const defaultStyles = Object.values(this.props.mapStyle.mapStyles);
-      // add id to custom map styles if not given
-      const customStyles = (this.props.mapStyles || []).map(ms => ({
-        ...ms,
-        id: ms.id || generateHashId()
-      }));
-
-      const allStyles = [...customStyles, ...defaultStyles].reduce(
-        (accu, style) => {
-          const hasStyleObject = style.style && typeof style.style === 'object';
-          accu[hasStyleObject ? 'toLoad' : 'toRequest'][style.id] = style;
-
-          return accu;
-        },
-        {toLoad: {}, toRequest: {}}
-      );
-
-      this.props.mapStyleActions.loadMapStyles(allStyles.toLoad);
-      this.props.mapStyleActions.requestMapStyles(allStyles.toRequest);
-    };
-
     render() {
       const {
         id,
@@ -409,6 +386,12 @@ function KeplerGlFactory(
                 }}
                 ref={this.root}
               >
+                <RequestMapStyle
+                  defaultMapStyles={this.props.mapStyle.mapStyles}
+                  mapStyles={this.props.mapStyles}
+                  loadMapStyles={this.props.mapStyleActions.loadMapStyles}
+                  requestMapStyles={this.props.mapStyleActions.requestMapStyles}
+                />
                 <NotificationPanel {...notificationPanelFields} />
                 {!uiState.readOnly && !readOnly && <SidePanel {...sideFields} />}
                 <div className="maps" style={{display: 'flex'}}>

--- a/test/browser/components/effectful/index.js
+++ b/test/browser/components/effectful/index.js
@@ -1,0 +1,1 @@
+import './request-map-style-test';

--- a/test/browser/components/index.js
+++ b/test/browser/components/index.js
@@ -35,3 +35,4 @@ import './geocoder-panel-test';
 import './tooltip-config-test';
 import './bottom-widget-test';
 import './plot-container-test';
+import './effectful';

--- a/test/browser/components/index.js
+++ b/test/browser/components/index.js
@@ -35,4 +35,3 @@ import './geocoder-panel-test';
 import './tooltip-config-test';
 import './bottom-widget-test';
 import './plot-container-test';
-import './effectful';

--- a/test/browser/components/kepler-gl-test.js
+++ b/test/browser/components/kepler-gl-test.js
@@ -24,6 +24,9 @@ import {mount} from 'enzyme';
 import {drainTasksForTesting, succeedTaskWithValues} from 'react-palm/tasks';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
+import {render} from 'react-dom';
+import {act} from 'react-dom/test-utils';
+import sinon from 'sinon';
 
 import coreReducer from 'reducers/core';
 import {keplerGlInit} from 'actions/actions';
@@ -38,6 +41,7 @@ import {
   GeocoderPanelFactory
 } from 'components';
 import NotificationPanelFactory from 'components/notification-panel';
+import {TASKS as RequestMapStyleTasks} from 'components/effectful/request-map-style';
 import {ActionTypes} from 'actions';
 import {DEFAULT_MAP_STYLES, EXPORT_IMAGE_ID} from 'constants';
 
@@ -222,32 +226,49 @@ test('Components -> KeplerGl -> Mount -> Split Maps', t => {
   t.end();
 });
 
-test('Components -> KeplerGl -> Mount -> Load default map style task', t => {
+test('Components -> KeplerGl -> Mount -> Load default map style task', async t => {
+  // setup
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const requestMapStylesStub = sinon.stub(RequestMapStyleTasks, 'requestMapStyles').callThrough();
+  const loadMapStyleTaskRetPromises = [];
+  const loadMapStylesStub = sinon.stub(RequestMapStyleTasks, 'loadMapStyleTask').callsFake(() => {
+    const p = new Promise(resolve => {
+      loadMapStyleTaskRetPromises.push(resolve);
+    });
+    return p;
+  });
+  const stateSelector = state => state.keplerGl.map;
+
   // mount with empty store
   const store = mockStore(initialState);
 
-  t.doesNotThrow(() => {
-    mount(
+  // t.doesNotThrow(async () => {
+  await act(async () =>
+    render(
       <Provider store={store}>
         <KeplerGl
           id="map"
           mapboxApiAccessToken="smoothie-the-cat"
-          selector={state => state.keplerGl.map}
+          selector={stateSelector}
           dispatch={store.dispatch}
         />
-      </Provider>
-    );
-  }, 'Should not throw error when mount KeplerGl');
+      </Provider>,
+      container
+    )
+  );
+  // }, 'Should not throw error when mount KeplerGl');
 
   const actions = store.getActions();
   const expectedActions = [
-    {type: ActionTypes.LOAD_MAP_STYLES, payload: {}},
-    {
-      type: ActionTypes.REQUEST_MAP_STYLES,
-      payload: DEFAULT_MAP_STYLES.reduce((accu, curr) => ({...accu, [curr.id]: curr}), {})
-    },
-    {type: ActionTypes.UPDATE_MAP, payload: {width: 800, height: 800}}
+    {type: ActionTypes.UPDATE_MAP, payload: {width: 800, height: 800}},
+    {type: ActionTypes.LOAD_MAP_STYLES, payload: {}}
   ];
+  t.deepEqual(
+    requestMapStylesStub.firstCall.args[0],
+    DEFAULT_MAP_STYLES.reduce((accu, curr) => ({...accu, [curr.id]: curr}), {}),
+    'Should call request map styles'
+  );
   t.deepEqual(
     actions,
     expectedActions,
@@ -255,8 +276,6 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', t => {
   );
 
   const resultState1 = coreReducer(initialCoreState, actions[1]);
-  const [task1, ...rest] = drainTasksForTesting();
-  t.equal(rest.length, 0, 'should dispatch 1 tasks');
 
   const expectedTask = {
     payload: [
@@ -288,19 +307,26 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', t => {
     ]
   };
 
-  t.deepEqual(task1.payload, expectedTask.payload, 'should create task to load map styles');
+  t.deepEqual(
+    loadMapStylesStub.getCalls().map(call => call.args[0]),
+    expectedTask.payload,
+    'should create task to load map styles'
+  );
   t.deepEqual(resultState1, initialCoreState, 'state should be the same');
 
-  const resultState2 = coreReducer(
-    resultState1,
-    succeedTaskWithValues(task1, [
-      {id: 'dark', style: {layers: [], name: 'dark'}},
-      {id: 'light', style: {layers: [], name: 'light'}},
-      {id: 'muted', style: {hello: 'world'}},
-      {id: 'muted_night', style: {world: 'hello'}},
-      {id: 'satellite', style: {satellite: 'yes'}}
-    ])
-  );
+  [
+    {id: 'dark', style: {layers: [], name: 'dark'}},
+    {id: 'light', style: {layers: [], name: 'light'}},
+    {id: 'muted', style: {hello: 'world'}},
+    {id: 'muted_night', style: {world: 'hello'}},
+    {id: 'satellite', style: {satellite: 'yes'}}
+  ].forEach((ret, i) => loadMapStyleTaskRetPromises[i](ret));
+
+  // Find the proper way to wait.
+  await new Promise(resolve => {
+    setTimeout(() => resolve(), 10);
+  });
+  const resultState2 = coreReducer(resultState1, store.getActions()[2]);
 
   const expectedStateMapStyles = {
     dark: {
@@ -331,6 +357,9 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', t => {
     expectedStateMapStyles,
     'should update state with loaded map styles'
   );
+
+  // teardown
+  document.body.removeChild(container);
 
   t.end();
 });

--- a/test/browser/components/kepler-gl-test.js
+++ b/test/browser/components/kepler-gl-test.js
@@ -21,7 +21,6 @@
 import React from 'react';
 import test from 'tape';
 import {mount} from 'enzyme';
-import {drainTasksForTesting, succeedTaskWithValues} from 'react-palm/tasks';
 import configureStore from 'redux-mock-store';
 import {Provider} from 'react-redux';
 import {render} from 'react-dom';

--- a/test/browser/components/kepler-gl-test.js
+++ b/test/browser/components/kepler-gl-test.js
@@ -232,6 +232,7 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', async t =
   document.body.appendChild(container);
   const requestMapStylesStub = sinon.stub(RequestMapStyleTasks, 'requestMapStyles').callThrough();
   const loadMapStylesStub = sinon.stub(RequestMapStyleTasks, 'loadMapStyleTask');
+  t.plan(5);
 
   [
     {id: 'dark', style: {layers: [], name: 'dark'}},
@@ -353,12 +354,11 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', async t =
   document.body.removeChild(container);
   requestMapStylesStub.restore();
   loadMapStylesStub.restore();
-
-  t.end();
 });
 
 test('Components -> KeplerGl -> Mount -> Load custom map style task', async t => {
   // setup
+  t.plan(4);
   const container = document.createElement('div');
   document.body.appendChild(container);
   const requestMapStylesStub = sinon.spy(RequestMapStyleTasks, 'requestMapStyles');

--- a/test/browser/components/kepler-gl-test.js
+++ b/test/browser/components/kepler-gl-test.js
@@ -231,13 +231,16 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', async t =
   const container = document.createElement('div');
   document.body.appendChild(container);
   const requestMapStylesStub = sinon.stub(RequestMapStyleTasks, 'requestMapStyles').callThrough();
-  const loadMapStyleTaskRetPromises = [];
-  const loadMapStylesStub = sinon.stub(RequestMapStyleTasks, 'loadMapStyleTask').callsFake(() => {
-    const p = new Promise(resolve => {
-      loadMapStyleTaskRetPromises.push(resolve);
-    });
-    return p;
-  });
+  const loadMapStylesStub = sinon.stub(RequestMapStyleTasks, 'loadMapStyleTask');
+
+  [
+    {id: 'dark', style: {layers: [], name: 'dark'}},
+    {id: 'light', style: {layers: [], name: 'light'}},
+    {id: 'muted', style: {hello: 'world'}},
+    {id: 'muted_night', style: {world: 'hello'}},
+    {id: 'satellite', style: {satellite: 'yes'}}
+  ].forEach((ret, i) => loadMapStylesStub.onCall(i).resolves(ret));
+
   const stateSelector = state => state.keplerGl.map;
 
   // mount with empty store
@@ -270,7 +273,7 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', async t =
     'Should call request map styles'
   );
   t.deepEqual(
-    actions,
+    actions.slice(0, 2),
     expectedActions,
     'Should mount kepler.gl and dispatch 2 actions to load map styles'
   );
@@ -314,18 +317,6 @@ test('Components -> KeplerGl -> Mount -> Load default map style task', async t =
   );
   t.deepEqual(resultState1, initialCoreState, 'state should be the same');
 
-  [
-    {id: 'dark', style: {layers: [], name: 'dark'}},
-    {id: 'light', style: {layers: [], name: 'light'}},
-    {id: 'muted', style: {hello: 'world'}},
-    {id: 'muted_night', style: {world: 'hello'}},
-    {id: 'satellite', style: {satellite: 'yes'}}
-  ].forEach((ret, i) => loadMapStyleTaskRetPromises[i](ret));
-
-  // Find the proper way to wait.
-  await new Promise(resolve => {
-    setTimeout(() => resolve(), 10);
-  });
   const resultState2 = coreReducer(resultState1, store.getActions()[2]);
 
   const expectedStateMapStyles = {


### PR DESCRIPTION
## Approach
* Rewrite tasks into a component with effects following the [Data Fetching example on ReactJS](https://reactjs.org/docs/testing-recipes.html#data-fetching)
* Uses standard `react-dom/test-utils`

Here's what things could be like if we don't use react-palm for side effects/tasks.

## Evaluation
Pros:
* Less non-standard practices

Cons:
* Promises stubbing in sinon still seems pretty primitive, need to pre-declare all the `resolves` before the method is called in order to have synchronous tests. It doesn't have the niceties of task draining/resolving in order
* Since there isn't a "tasks" abstraction, tests need to _know_ about the implementation details of the component in order to test its payloads. In this case, the `TASKS` exposed by the `request-map-styles` component.
* You lose the developer ergonomics of redux. (i.e. there isn't a redux action you can output)

Overall: The tests seem a little less readable after removing tasks. However, I guess one could introduce some sinon.spy helpers to help with readability.

## What this PR is missing / left todo:
- [ ] Remove the unused tasks (request map styles)
- [ ] Remove commented out `doesNotThrow` call
- [ ] Update to tape@5 which includes https://github.com/substack/tape/issues/472 to support async tests
- [ ] Does not handle tasks called from a redux action (need to change this to use a useEffect and listen to changes to `mapStyles` object but without infinite loop): https://github.com/keplergl/kepler.gl/blob/070b04b2c02a87cab1d3e48d789c146682befa1a/src/reducers/map-style-updaters.js#L359-L361