### PR TITLE
Request for comment: Remove react palm task middleware requirement

### DIFF
--- a/examples/demo-app/src/store.js
+++ b/examples/demo-app/src/store.js
@@ -21,7 +21,6 @@
 import {combineReducers, createStore, applyMiddleware, compose} from 'redux';
 import {routerReducer, routerMiddleware} from 'react-router-redux';
 import {browserHistory} from 'react-router';
-import {enhanceReduxMiddleware} from 'kepler.gl/middleware';
 import thunk from 'redux-thunk';
 // eslint-disable-next-line no-unused-vars
 import window from 'global/window';
@@ -33,7 +32,7 @@ const reducers = combineReducers({
   routing: routerReducer
 });
 
-export const middlewares = enhanceReduxMiddleware([thunk, routerMiddleware(browserHistory)]);
+export const middlewares = [thunk, routerMiddleware(browserHistory)];
 
 export const enhancers = [applyMiddleware(...middlewares)];
 

--- a/src/components/kepler-gl.js
+++ b/src/components/kepler-gl.js
@@ -50,6 +50,7 @@ import ModalContainerFactory from './modal-container';
 import PlotContainerFactory from './plot-container';
 import NotificationPanelFactory from './notification-panel';
 import GeoCoderPanelFactory from './geocoder-panel';
+import TaskRunner from './task-runner';
 
 import {generateHashId} from 'utils/utils';
 import {validateToken} from 'utils/mapbox-utils';
@@ -418,6 +419,7 @@ function KeplerGlFactory(
                 {interactionConfig.geocoder.enabled && <GeoCoderPanel {...geoCoderPanelFields} />}
                 <BottomWidget {...bottomWidgetFields} />
                 <ModalContainer {...modalContainerFields} />
+                <TaskRunner />
               </GlobalStyle>
             </ThemeProvider>
           </IntlProvider>

--- a/src/components/task-runner.js
+++ b/src/components/task-runner.js
@@ -1,0 +1,31 @@
+import {useEffect} from 'react';
+import {taskMiddleware} from 'react-palm/tasks';
+import {useStore} from 'react-redux';
+
+const IDENTITY = i => i;
+
+function runTasks(store) {
+  // Run the taskMiddleware without a dummy action
+  return taskMiddleware(store)(IDENTITY)(null);
+}
+
+export default function TaskRunner() {
+  const store = useStore();
+
+  useEffect(() => {
+    if (!store) {
+      return;
+    }
+    // Initial batch of tasks on initialization of store
+    runTasks(store);
+
+    // Subscribe to subsequent updates
+    const unsubscribe = store.subscribe(() => {
+      runTasks(store);
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [store]);
+  return null;
+}

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -18,17 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Extra helpers for redux
-// We are exposing this secause react-palm has no UMD module and
-// users need taskMiddleware to initiate their redux middle ware
-import {taskMiddleware} from 'react-palm/tasks';
-
 /**
- * This method is used to enhance redux middleware and provide
- * functionality to support react-palm
+ * @deprecated This method is provided just for backward compatibility. You may stop
+ * using this now.
  * @param middlewares current redux middlewares
  * @returns {*[]} the original list of middlewares plus the react-palm middleware
  */
 export function enhanceReduxMiddleware(middlewares = []) {
-  return [...middlewares, taskMiddleware];
+  return middlewares;
 }


### PR DESCRIPTION
Here's another attempt at simplifying the react-palm tasks dependency, after discussion in #1577 . 
First off, to pull out the middleware requirement of react-palm.

This should simplify installation of kepler.gl . This approach combined with #1577 are approaches to allow for future splitting out side effects/tasks into its own components in the future.

It is safe to run the taskMiddleware twice (if the middleware is added, along with this change), so this is a non-breaking change. That's also why I left `enhanceReduxMiddleware` in the exports, but now that's a noop.

What users should expect to do:
* Upgrade with no breaking changes (unless they depend on the promises returned)
* Remove their taskMiddleware call, or `enhanceReduxMiddleware` (which is now a noop)
* In a future breaking change version, the `enhanceReduxMiddleware` can be removed.