### PR TITLE
[Enhancemen] Export Map (maplegend and locale) as HTML 

### DIFF
--- a/src/reducers/combined-updaters.js
+++ b/src/reducers/combined-updaters.js
@@ -20,7 +20,9 @@
 
 import {
   toggleModalUpdater,
-  loadFilesSuccessUpdater as uiStateLoadFilesSuccessUpdater
+  toggleMapControlUpdater,
+  loadFilesSuccessUpdater as uiStateLoadFilesSuccessUpdater,
+  setLocaleUpdater
 } from './ui-state-updaters';
 import {
   updateVisDataUpdater as visStateUpdateVisDataUpdater,
@@ -131,6 +133,11 @@ export const addDataToMapUpdater = (state, {payload}) => {
     // if passed in saved config
     parsedConfig = state.visState.schema.parseSavedConfig(config);
   }
+
+  const mapControls = parsedConfig.uiState ? parsedConfig.uiState.mapControls : undefined;
+  const mapLenged = mapControls ? mapControls.mapLegend : undefined;
+  const mapLocale = mapControls ? mapControls.locale : undefined;
+
   const oldLayers = state.visState.layers;
   const filterNewlyAddedLayers = layers => layers.filter(nl => !oldLayers.find(ol => ol === nl));
 
@@ -169,6 +176,18 @@ export const addDataToMapUpdater = (state, {payload}) => {
     pick_('uiState')(apply_(uiStateLoadFilesSuccessUpdater, payload_(null))),
 
     pick_('uiState')(apply_(toggleModalUpdater, payload_(null))),
+
+    if_(
+      mapLenged,
+      pick_('uiState')(
+        apply_(
+          toggleMapControlUpdater,
+          payload_({panelId: 'mapLegend', index: mapLenged ? mapLenged.activeMapIndex : 0})
+        )
+      )
+    ),
+
+    if_(mapLocale, pick_('uiState')(apply_(setLocaleUpdater, payload_({locale: mapLocale})))),
 
     pick_('uiState')(merge_(options.hasOwnProperty('readOnly') ? {readOnly: options.readOnly} : {}))
   ])(state);

--- a/src/reducers/combined-updaters.js
+++ b/src/reducers/combined-updaters.js
@@ -134,9 +134,10 @@ export const addDataToMapUpdater = (state, {payload}) => {
     parsedConfig = state.visState.schema.parseSavedConfig(config);
   }
 
-  const mapControls = parsedConfig.uiState ? parsedConfig.uiState.mapControls : undefined;
+  const newUiState = parsedConfig ? parsedConfig.uiState : undefined;
+  const newLocale = newUiState ? newUiState.locale : undefined;
+  const mapControls = newUiState ? newUiState.mapControls : undefined;
   const mapLenged = mapControls ? mapControls.mapLegend : undefined;
-  const mapLocale = mapControls ? mapControls.locale : undefined;
 
   const oldLayers = state.visState.layers;
   const filterNewlyAddedLayers = layers => layers.filter(nl => !oldLayers.find(ol => ol === nl));
@@ -187,7 +188,7 @@ export const addDataToMapUpdater = (state, {payload}) => {
       )
     ),
 
-    if_(mapLocale, pick_('uiState')(apply_(setLocaleUpdater, payload_({locale: mapLocale})))),
+    if_(newLocale, pick_('uiState')(apply_(setLocaleUpdater, payload_({locale: newLocale})))),
 
     pick_('uiState')(merge_(options.hasOwnProperty('readOnly') ? {readOnly: options.readOnly} : {}))
   ])(state);

--- a/src/reducers/ui-state-updaters.d.ts
+++ b/src/reducers/ui-state-updaters.d.ts
@@ -196,3 +196,10 @@ export function initUiStateUpdater(
     payload: KeplerGlInitPayload;
   }
 ): UiState;
+export function receiveMapConfigUpdater(
+  state: UiState,
+  action: {
+    type?: ActionTypes.RECEIVE_MAP_CONFIG;
+    payload: ReceiveMapConfigPayload;
+  }
+): UiState;

--- a/src/reducers/ui-state-updaters.js
+++ b/src/reducers/ui-state-updaters.js
@@ -764,3 +764,42 @@ export const setLocaleUpdater = (state, {payload: {locale}}) => ({
   ...state,
   locale
 });
+
+/**
+ * Load ui state object when pass in saved map config
+ *
+ * @memberof uiStateUpdaters
+ * @type {typeof import('./ui-state-updaters').receiveMapConfigUpdater}
+ * @public
+ */
+export const receiveMapConfigUpdater = (state, {payload: {config = {}, options = {}}}) => {
+  if (!config.uiState) {
+    return state;
+  }
+
+  // merge received uistate (mapLegend and mapLocale) with previous state
+  let mergedState = state;
+
+  if (config.uiState.locale) {
+    mergedState = setLocaleUpdater(mergedState, {
+      payload: {
+        locale: config.uiState.locale
+      }
+    });
+  }
+
+  if (config.uiState.mapControls) {
+    const mapLegend = config.uiState.mapControls.mapLegend;
+    if (mapLegend) {
+      mergedState = {
+        ...mergedState,
+        mapControls: {
+          ...mergedState.mapControls,
+          mapLegend
+        }
+      };
+    }
+  }
+
+  return mergedState;
+};

--- a/src/reducers/ui-state-updaters.js
+++ b/src/reducers/ui-state-updaters.js
@@ -795,7 +795,10 @@ export const receiveMapConfigUpdater = (state, {payload: {config = {}, options =
         ...mergedState,
         mapControls: {
           ...mergedState.mapControls,
-          mapLegend
+          mapLegend: {
+            ...mergedState.mapControls.mapLegend,
+            ...mapLegend
+          }
         }
       };
     }

--- a/src/schemas/index.d.ts
+++ b/src/schemas/index.d.ts
@@ -20,5 +20,6 @@ export const visStateSchema: {[key: string]: Schema};
 export const datasetSchema: {[key: string]: Schema};
 export const mapStyleSchema: {[key: string]: Schema};
 export const mapStateSchema: {[key: string]: Schema};
+export const uiStateSchema: {[key: string]: Schema};
 
 export {default as Schema} from './schema';

--- a/src/schemas/schema-manager.d.ts
+++ b/src/schemas/schema-manager.d.ts
@@ -12,7 +12,7 @@ import {
 import {Schema} from './schema';
 
 import {LayerTextLabel} from 'layers/layer-factory';
-import {datasetSchema, visStateSchema, mapStyleSchema, mapStateSchema} from 'schemas';
+import {datasetSchema, visStateSchema, mapStyleSchema, mapStateSchema, uiStateSchema} from 'schemas';
 
 export type SavedFilter = {
   dataId: Filter['dataId'];
@@ -203,7 +203,7 @@ export type SavedMap = {
 
 export type LoadedMap = {datasets?: ParsedDataset[] | null; config?: ParsedConfig | null};
 export const reducerSchema: {
-  [key: string]: typeof mapStateSchema | typeof visStateSchema | typeof mapStyleSchema;
+  [key: string]: typeof mapStateSchema | typeof visStateSchema | typeof mapStyleSchema | typeof uiStateSchema;
 };
 
 export class KeplerGLSchema {

--- a/src/schemas/schema-manager.js
+++ b/src/schemas/schema-manager.js
@@ -24,6 +24,7 @@ import visStateSchema from './vis-state-schema';
 import datasetSchema from './dataset-schema';
 import mapStyleSchema from './map-style-schema';
 import mapStateSchema from './map-state-schema';
+import uiStateSchema from './ui-state-schema';
 
 import {CURRENT_VERSION, VERSIONS} from './versions';
 import {isPlainObject} from 'utils/utils';
@@ -31,7 +32,8 @@ import {isPlainObject} from 'utils/utils';
 export const reducerSchema = {
   visState: visStateSchema,
   mapState: mapStateSchema,
-  mapStyle: mapStyleSchema
+  mapStyle: mapStyleSchema,
+  uiState: uiStateSchema
 };
 
 /** @type {typeof import('./schema-manager').KeplerGLSchema} */

--- a/src/schemas/ui-state-schema.js
+++ b/src/schemas/ui-state-schema.js
@@ -18,26 +18,43 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Schemas
-export {
-  default,
-  default as KeplerGlSchema,
-  reducerSchema,
-  KeplerGLSchema as KeplerGLSchemaClass
-} from './schema-manager';
-export {CURRENT_VERSION, VERSIONS} from './versions';
-export {
-  visStateSchemaV1,
-  FilterSchemaV0,
-  LayerSchemaV0,
-  InteractionSchemaV1,
-  DimensionFieldSchema,
-  SplitMapsSchema,
-  filterPropsV1,
-  default as visStateSchema
-} from './vis-state-schema';
-export {default as datasetSchema} from './dataset-schema';
-export {default as mapStyleSchema} from './map-style-schema';
-export {default as mapStateSchema} from './map-state-schema';
-export {default as uiStateSchema} from './ui-state-schema';
-export {default as Schema} from './schema';
+import {VERSIONS} from './versions';
+import Schema from './schema';
+
+export class MapControlsSchemaV1 extends Schema {
+  key = 'mapControls';
+  save(mapControls) {
+    // save mapLegend
+    return {[this.key]: mapControls};
+  }
+  load(mapControls) {
+    return typeof mapControls === 'object' && Object.keys(mapControls).length
+      ? {[this.key]: mapControls}
+      : {};
+  }
+}
+
+// version v0
+export const propertiesV0 = {
+  mapControls: new MapControlsSchemaV1(),
+  locale: null
+};
+
+export const propertiesV1 = {
+  ...propertiesV0
+};
+
+const uiStateSchema = {
+  [VERSIONS.v0]: new Schema({
+    version: VERSIONS.v0,
+    properties: propertiesV0,
+    key: 'uiState'
+  }),
+  [VERSIONS.v1]: new Schema({
+    version: VERSIONS.v1,
+    properties: propertiesV1,
+    key: 'uiState'
+  })
+};
+
+export default uiStateSchema;

--- a/test/node/reducers/composer-state-test.js
+++ b/test/node/reducers/composer-state-test.js
@@ -190,12 +190,14 @@ test('#composerStateReducer - addDataToMapUpdater: mapLegend', t => {
 
   const expectedUIState = {
     ...INITIAL_UI_STATE,
+    initialState: {},
+    currentModal: null,
     mapControls: {
       ...INITIAL_UI_STATE.mapControls,
       mapLegend: {
         show: true,
         active: true,
-        diableClose: false,
+        disableClose: false,
         activeMapIndex: 0
       }
     }
@@ -232,10 +234,9 @@ test('#composerStateReducer - addDataToMapUpdater: locale', t => {
 
   const expectedUIState = {
     ...INITIAL_UI_STATE,
-    mapControls: {
-      ...INITIAL_UI_STATE.mapControls,
-      locale: LOCALE_CODES.cn
-    }
+    initialState: {},
+    currentModal: null,
+    locale: LOCALE_CODES.es
   };
 
   t.deepEqual(

--- a/test/node/reducers/composer-state-test.js
+++ b/test/node/reducers/composer-state-test.js
@@ -35,6 +35,7 @@ import testHexIdData, {
 } from 'test/fixtures/test-hex-id-data';
 import {cmpLayers, cmpFilters, cmpDataset, cmpInteraction} from 'test/helpers/comparison-utils';
 import {INITIAL_UI_STATE} from 'reducers/ui-state-updaters';
+import {LOCALE_CODES} from 'localization/locales';
 
 const mockRawData = {
   fields: [
@@ -157,6 +158,90 @@ test('#composerStateReducer - addDataToMapUpdater: uiState', t => {
     newState.uiState,
     expectedUIState,
     'ui state should be set readOnly:false,currentModal: null'
+  );
+
+  t.end();
+});
+
+test('#composerStateReducer - addDataToMapUpdater: mapLegend', t => {
+  // init kepler.gl root and instance
+  const state = keplerGlReducer(undefined, registerEntry({id: 'test'})).test;
+
+  const newState = addDataToMapUpdater(state, {
+    payload: {
+      datasets: {
+        data: mockRawData,
+        info: {
+          id: 'foo'
+        }
+      },
+      config: {
+        uiState: {
+          mapControls: {
+            mapLegend: {
+              show: true,
+              active: true
+            }
+          }
+        }
+      }
+    }
+  });
+
+  const expectedUIState = {
+    ...INITIAL_UI_STATE,
+    mapControls: {
+      ...INITIAL_UI_STATE.mapControls,
+      mapLegend: {
+        show: true,
+        active: true,
+        diableClose: false,
+        activeMapIndex: 0
+      }
+    }
+  };
+
+  t.deepEqual(
+    newState.uiState,
+    expectedUIState,
+    'ui state should be set with mapLegend being displayed by default'
+  );
+
+  t.end();
+});
+
+test('#composerStateReducer - addDataToMapUpdater: locale', t => {
+  // init kepler.gl root and instance
+  const state = keplerGlReducer(undefined, registerEntry({id: 'test'})).test;
+
+  const newState = addDataToMapUpdater(state, {
+    payload: {
+      datasets: {
+        data: mockRawData,
+        info: {
+          id: 'foo'
+        }
+      },
+      config: {
+        uiState: {
+          locale: LOCALE_CODES.es
+        }
+      }
+    }
+  });
+
+  const expectedUIState = {
+    ...INITIAL_UI_STATE,
+    mapControls: {
+      ...INITIAL_UI_STATE.mapControls,
+      locale: LOCALE_CODES.cn
+    }
+  };
+
+  t.deepEqual(
+    newState.uiState,
+    expectedUIState,
+    'ui state should be set with locale=Spanish by default'
   );
 
   t.end();

--- a/test/node/schemas/index.js
+++ b/test/node/schemas/index.js
@@ -24,3 +24,4 @@ import './map-state-schema-test';
 import './map-style-schema-test';
 import './dataset-schema-test';
 import './schema-conversion-test';
+import './ui-state-schema-test';

--- a/test/node/schemas/ui-state-schema-test.js
+++ b/test/node/schemas/ui-state-schema-test.js
@@ -32,17 +32,13 @@ test('#uiStateSchema -> v1 -> save load uiState', t => {
   const uiToSave = savedState.config.uiState;
   const uiLoaded = SchemaManager.parseSavedConfig(savedState).uiState;
 
-  t.deepEqual(
-    Object.keys(uiToSave),
-    ['mapControls', 'locale'],
-    'uiState should have 2 entries'
-  );
+  t.deepEqual(Object.keys(uiToSave), ['mapControls', 'locale'], 'uiState should have 2 entries');
 
   t.deepEqual(
     Object.keys(uiToSave.mapControls),
     ['visibleLayers', 'mapLegend', 'toggle3d', 'splitMap', 'mapDraw', 'mapLocale'],
     'uiState.mapControls should have 6 entries'
-  )
+  );
 
   const expected = {
     mapControls: {

--- a/test/node/schemas/ui-state-schema-test.js
+++ b/test/node/schemas/ui-state-schema-test.js
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import test from 'tape';
+import cloneDeep from 'lodash.clonedeep';
+import SchemaManager from 'schemas';
+import {InitialState} from 'test/helpers/mock-state';
+
+test('#uiStateSchema -> v1 -> save load uiState', t => {
+  // mapLegend and locale in uiState should be saved and loaded
+  const initialState = cloneDeep(InitialState);
+  const savedState = SchemaManager.getConfigToSave(initialState);
+
+  // save state
+  const uiToSave = savedState.config.uiState;
+  const uiLoaded = SchemaManager.parseSavedConfig(savedState).uiState;
+
+  t.deepEqual(
+    Object.keys(uiToSave),
+    ['mapControls', 'locale'],
+    'uiState should have 2 entries'
+  );
+
+  t.deepEqual(
+    Object.keys(uiToSave.mapControls),
+    ['visibleLayers', 'mapLegend', 'toggle3d', 'splitMap', 'mapDraw', 'mapLocale'],
+    'uiState.mapControls should have 6 entries'
+  )
+
+  const expected = {
+    mapControls: {
+      visibleLayers: {
+        show: true,
+        active: false,
+        disableClose: false,
+        activeMapIndex: 0
+      },
+      mapLegend: {
+        show: true,
+        active: false,
+        disableClose: false,
+        activeMapIndex: 0
+      },
+      toggle3d: {
+        show: true,
+        active: false,
+        disableClose: false,
+        activeMapIndex: 0
+      },
+      splitMap: {
+        show: true,
+        active: false,
+        disableClose: false,
+        activeMapIndex: 0
+      },
+      mapDraw: {
+        show: true,
+        active: false,
+        disableClose: false,
+        activeMapIndex: 0
+      },
+      mapLocale: {
+        show: true,
+        active: false,
+        disableClose: false,
+        activeMapIndex: 0
+      }
+    },
+    locale: 'en'
+  };
+
+  t.deepEqual(uiToSave, expected, 'save uiState should be current');
+  t.deepEqual(uiLoaded, expected, 'load uiState should be current');
+
+  t.end();
+});


### PR DESCRIPTION
This PR is for the issue https://github.com/keplergl/kepler.gl/issues/1585 (display map legend on an exported map). There is a workaround for this issue that requires user to update the exported HTML file. However,  this seems like a reasonable feature enhancement request for the “Export Map as HTML” feature:
1. when exporting a map to a HTML file, uiState of mapLegend and map locale should be saved in config.
2. when loading config via `addDataToMapUpdater()`, the uiState of mapLegend and map locale should be loaded and used as default.


What's added and changed in this PR:

1. Add a new `uiStateSchema` class in _src/schemas/ui-state-schema.js_
2. Add above `uiStateSchema` in `reducerSchema` in _src/schemas/schema-manager.js_, so the meta data of `locale` and `mapControls:mapLegend` in `uiState` can be saved and loaded via Schema Manager
3. Since the mapLegend and locale in uiState can be added in JSON configuration, the `addDataToMap` action should be updated (_src/reducers/combined-updaters.js_) so customized `mapLegend` (on/off) and `locale` can be loaded as default.

4. Test case `#uiStateSchema -> v1 -> save load uiState` in _test/node/schemas/ui-state-schema-test.js_
5. Test case `#composerStateReducer - addDataToMapUpdater: mapLegend` in _test/node/reducers/composer-state-test.js_
6. Test case `#composerStateReducer - addDataToMapUpdater: locale` in _test/node/reducers/composer-state-test.js_

Example: an exported map with `Legend` switched ON and `locale` with Spanish(ES)
<img width="691" alt="Screen Shot 2021-08-31 at 4 08 40 PM" src="https://user-images.githubusercontent.com/2423887/131609398-f0dc4a91-2f40-4972-8bed-a4342599497e.png">



