### PR TITLE
[jupyter] Fix 404 issue when publishing keplergl npm package

### DIFF
--- a/.github/workflows/build-publish-pypi.yml
+++ b/.github/workflows/build-publish-pypi.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 12.x
+          registry-url: https://registry.npmjs.org/
 
       - name: Set up Python 3.8
         uses: actions/setup-python@v2


### PR DESCRIPTION
* The current action `build-publish-pypi` throws an error at step `Publish kepler-jupyter to NPM`. See https://github.com/keplergl/kepler.gl/runs/3617500852?check_suite_focus=true
```
npm ERR! code E404
npm ERR! 404 Not Found - PUT https://registry.npmjs.org/keplergl-jupyter - Not found
npm ERR! 404 
npm ERR! 404  'keplergl-jupyter@0.3.2' is not in the npm registry.
```

* According to https://github.com/npm/cli/issues/1637, adding an explicit registry URL should avoid 404 issue when publishing keplergl npm package.

* Since this error didn't impact publishing (see https://www.npmjs.com/package/keplergl-jupyter), we can test it out in the next kepler-jupyter release.