### PR TITLE
jupyter widget: don't take over <title>

### DIFF
--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
@@ -97,7 +97,6 @@ function App() {
       {Helmet ? (
         <Helmet>
           <meta charSet="utf-8" />
-          <title>Kepler.gl Jupyter</title>
           <link
             rel="stylesheet"
             href="http://d1a3f4spazzrp4.cloudfront.net/kepler.gl/uber-fonts/4.0.0/superfine.css"


### PR DESCRIPTION
The Helmet component injects a new <title> for the page when the jupyter component renders. I'm guessing it's not the intention to take over the page title of a notebook.

Signed-off-by: Jack Amadeo <jamadeo@gmail.com>