### PR TITLE
[Chore]: Technical: Setup for different Visual channels per layer

### DIFF
--- a/src/layers/base-layer.ts
+++ b/src/layers/base-layer.ts
@@ -72,6 +72,7 @@ export type LayerColumns = {
 };
 export type VisualChannelDomain = number[] | string[];
 export type VisualChannelField = Field | null;
+export type VisualChannelScale = keyof typeof SCALE_TYPES;
 
 export type LayerBaseConfig = {
   dataId: string | null;
@@ -94,6 +95,27 @@ export type LayerBaseConfig = {
   animation: {
     enabled: boolean;
   };
+};
+
+export type LayerColorConfig = {
+  colorField: VisualChannelField;
+  colorDomain: VisualChannelDomain;
+  colorScale: VisualChannelScale;
+};
+export type LayerSizeConfig = {
+  // color by size, domain is set by filters, field, scale type
+  sizeDomain: VisualChannelDomain;
+  sizeScale: VisualChannelScale;
+  sizeField: VisualChannelField;
+};
+export type LayerHeightConfig = {
+  heightField: VisualChannelField;
+  heightDomain: VisualChannelDomain;
+  heightScale: VisualChannelScale;
+};
+
+export type LayerWeightConfig = {
+  weightField: VisualChannelField;
 };
 
 export type VisualChannel = {
@@ -156,13 +178,13 @@ function* generateColor(): Generator<RGBColor> {
 
 export const colorMaker = generateColor();
 
-class Layer {
+class Layer<LayerConfig extends LayerBaseConfig = LayerBaseConfig> {
   id: string;
   // TODO: define meta
   meta: {};
   // TODO: define visConfigSettings
   visConfigSettings: {};
-  config: LayerBaseConfig;
+  config: LayerConfig;
   // TODO: define _oldDataUpdateTriggers
   _oldDataUpdateTriggers: any;
 
@@ -179,6 +201,7 @@ class Layer {
     // visConfigSettings
     this.visConfigSettings = {};
 
+    // @ts-expect-error
     this.config = this.getDefaultLayerConfig({
       columns: this.getLayerColumns(),
       ...props


### PR DESCRIPTION
I decided to use a generic class for typing settings in all classes that inherit. 
For example, this is how the "AggregationLayer" declaration will look like:

`export default class AggregationLayer extends Layer(LayerBaseConfig & LayerColorConfig & LayerSizeConfig)`
() - Must be angle brackets 