### PR TITLE
Enable serving framed kepler.gl-jupyter over https

### DIFF
--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
@@ -100,11 +100,11 @@ function App() {
           <title>Kepler.gl Jupyter</title>
           <link
             rel="stylesheet"
-            href="http://d1a3f4spazzrp4.cloudfront.net/kepler.gl/uber-fonts/4.0.0/superfine.css"
+            href="//d1a3f4spazzrp4.cloudfront.net/kepler.gl/uber-fonts/4.0.0/superfine.css"
           />
           <link
             rel="stylesheet"
-            href="http://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.css"
+            href="//api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.css"
           />
           <style type="text/css">
             {`font-family: ff-clan-web-pro, 'Helvetica Neue', Helvetica, sans-serif;


### PR DESCRIPTION
Remove HTTP protocol specifier for stylesheets used in `bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js` to select the most appropriate protocol.

This is needed when kepler.gl is served on a website served via HTTPS. Today, this fails since chrome blocks loading of insecure resources when the page is served via HTTPS (Mixed content). However, Firefox and Safari are not as strict as chrome, so this fix is not needed for those browsers.

See image below to see what happened before this fix, included the error messages in the dev console at the bottom.

<img width="1113" alt="image" src="https://user-images.githubusercontent.com/6378834/168047043-4ba66477-9b70-4d86-b09d-fb6ad8aa6ebd.png">
