### PR TITLE
[fix] include CenterFlexbox in common components

### DIFF
--- a/src/components/src/common/index.ts
+++ b/src/components/src/common/index.ts
@@ -9,6 +9,7 @@ export {
     SelectText,
     SelectTextBold,
     IconRoundSmall,
+    CenterFlexbox,
     CenterVerticalFlexbox,
     SpaceBetweenFlexbox,
     SBFlexboxItem,

--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -256,6 +256,7 @@ export {
   SelectText,
   SelectTextBold,
   IconRoundSmall,
+  CenterFlexbox,
   CenterVerticalFlexbox,
   SpaceBetweenFlexbox,
   SBFlexboxItem,


### PR DESCRIPTION
Not sure if this should be considered [fix] or not, but upgrading from 2.5.5 seems to have broke importing `<CenterFlexbox>`.

Signed-off-by: Eric Peterson <git@ericp.co>