### PR TITLE
[fix] correct provider downloadMap type

### DIFF
--- a/src/cloud-providers/src/provider.ts
+++ b/src/cloud-providers/src/provider.ts
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 import Upload from './upload';
-import {MapData, ExportFileOptions, Millisecond} from '@kepler.gl/types';
+import {MapData, ExportFileOptions, Millisecond, SavedMap} from '@kepler.gl/types';
 import {ComponentType} from 'react';
 
 export type MapListItem = {
@@ -243,7 +243,7 @@ export default class Provider {
    *  return downloadMap;
    * }
    */
-  async downloadMap(loadParams): Promise<{map: MapData; format: string}> {
+  async downloadMap(loadParams): Promise<{map: SavedMap; format: string}> {
     // @ts-expect-error
     return;
   }


### PR DESCRIPTION
This fixes the return type of the `downloadMap()` method in `Provider`.

It was `Promise<{ map: SavedMap; format: string }>`, but `SavedMap` itself has a `map` property. When an implementation of `downloadMap()` returns an object like `{ map: { map: { ... } }, format: ... }`, loading maps works, but the "Save"/"Save As" functionality breaks. I haven't figured out why, but I tested manually and confirmed that flattening the nested `map` property fixes the re-saving, without breaking the loading.

Signed-off-by: Eric Peterson <git@ericp.co>