### PR TITLE
[fix] fix import in demo-app carto provider

### DIFF
--- a/examples/demo-app/src/cloud-providers/carto/carto-provider.js
+++ b/examples/demo-app/src/cloud-providers/carto/carto-provider.js
@@ -23,7 +23,7 @@ import Console from 'global/console';
 import CartoIcon from './carto-icon';
 import {Provider} from '@kepler.gl/cloud-providers';
 import {createDataContainer} from '@kepler.gl/utils';
-import {formatCsv} from 'reducers';
+import {formatCsv} from '@kepler.gl/reducers';
 
 const NAME = 'carto';
 const DISPLAY_NAME = 'CARTO';


### PR DESCRIPTION
When running the project locally via `npm start`, the below error is produced. This changes fixes that error so the demo website builds and serves locally.

```
ERROR in ./src/cloud-providers/carto/carto-provider.js
Module not found: Error: Can't resolve 'reducers' in '/Users/ericp/epeterson320/kepler.gl/examples/demo-app/src/cloud-providers/carto'
 @ ./src/cloud-providers/carto/carto-provider.js 40:0-37 477:17-26
 @ ./src/cloud-providers/index.js
 @ ./src/app.js
 @ ./src/main.js
```

Signed-off-by: Eric Peterson <git@ericp.co>
