### PR TITLE
[fix] Move FeatureActionPanel to class component

### DIFF
--- a/src/components/src/editor/feature-action-panel.tsx
+++ b/src/components/src/editor/feature-action-panel.tsx
@@ -152,19 +152,26 @@ FeatureActionPanelFactory.deps = PureFeatureActionPanelFactory.deps;
 export default function FeatureActionPanelFactory() {
   const PureFeatureActionPanel = PureFeatureActionPanelFactory();
 
-  const ClickOutsideFeatureActionPanel: React.FC<FeatureActionPanelProps> = props => {
-    // @ts-ignore
-    ClickOutsideFeatureActionPanel.handleClickOutside = (e: Event) => {
+  /**
+   * FeatureActionPanel wrapped with a click-outside handler. Note that this needs to be a
+   * class component, as react-onclickoutside does not handle functional components.
+   * @typedef {Parameters<typeof PureFeatureActionPanel>[0] & {onClose: any}} Props
+   * @extends {React.Component<Props>}
+   */
+  class ClickOutsideFeatureActionPanel extends React.Component<FeatureActionPanelProps> {
+    handleClickOutside(e) {
       e.preventDefault();
       e.stopPropagation();
-      props.onClose?.();
-    };
-    return <PureFeatureActionPanel {...props} />;
-  };
+      this.props.onClose?.();
+    }
+
+    render() {
+      return <PureFeatureActionPanel {...this.props} />;
+    }
+  }
 
   const clickOutsideConfig = {
-    // @ts-ignore
-    handleClickOutside: () => ClickOutsideFeatureActionPanel.handleClickOutside
+    handleClickOutside: () => ClickOutsideFeatureActionPanel.prototype.handleClickOutside
   };
 
   return onClickOutside(ClickOutsideFeatureActionPanel, clickOutsideConfig);

--- a/src/components/src/editor/feature-action-panel.tsx
+++ b/src/components/src/editor/feature-action-panel.tsx
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {useCallback, useState} from 'react';
+import React, {useCallback, useState, Component, ComponentType} from 'react';
 import {useIntl} from 'react-intl';
 
 import ActionPanel, {ActionPanelItem} from '../common/action-panel';
@@ -149,14 +149,14 @@ export function PureFeatureActionPanelFactory(): React.FC<FeatureActionPanelProp
 
 FeatureActionPanelFactory.deps = PureFeatureActionPanelFactory.deps;
 
-export default function FeatureActionPanelFactory() {
+export default function FeatureActionPanelFactory(): ComponentType<FeatureActionPanelProps> {
   const PureFeatureActionPanel = PureFeatureActionPanelFactory();
 
   /**
    * FeatureActionPanel wrapped with a click-outside handler. Note that this needs to be a
    * class component, as react-onclickoutside does not handle functional components.
    */
-  class ClickOutsideFeatureActionPanel extends React.Component<FeatureActionPanelProps> {
+  class ClickOutsideFeatureActionPanel extends Component<FeatureActionPanelProps> {
     handleClickOutside(e) {
       e.preventDefault();
       e.stopPropagation();

--- a/src/components/src/editor/feature-action-panel.tsx
+++ b/src/components/src/editor/feature-action-panel.tsx
@@ -155,8 +155,6 @@ export default function FeatureActionPanelFactory() {
   /**
    * FeatureActionPanel wrapped with a click-outside handler. Note that this needs to be a
    * class component, as react-onclickoutside does not handle functional components.
-   * @typedef {Parameters<typeof PureFeatureActionPanel>[0] & {onClose: any}} Props
-   * @extends {React.Component<Props>}
    */
   class ClickOutsideFeatureActionPanel extends React.Component<FeatureActionPanelProps> {
     handleClickOutside(e) {


### PR DESCRIPTION
Moves FeatureActionPanel to the class component to work with react-onclickoutside. We were using onClickOutside incorrectly in FeatureActionPanelFactory - it's not intended to support functional components (fails in esbuild)

Signed-off-by: Ihor Dykhta <dikhta.igor@gmail.com>

