### PR TITLE
[Enhancement] Render data table with smarter cell size, prevent scroll back

### DIFF
--- a/src/components/src/common/data-table/grid.tsx
+++ b/src/components/src/common/data-table/grid.tsx
@@ -27,7 +27,7 @@ export default class GridHack extends PureComponent<GridProps> {
 
   _preventScrollBack = e => {
     const {scrollLeft} = this.props;
-    if (scrollLeft <= 0 && e.deltaX < 0) {
+    if (scrollLeft !== undefined && scrollLeft <= 0 && e.deltaX < 0) {
       // Prevent Scroll On Scrollable Elements, avoid browser backward navigation
       // https://alvarotrigo.com/blog/prevent-scroll-on-scrollable-element-js/
       e.preventDefault();
@@ -43,12 +43,14 @@ export default class GridHack extends PureComponent<GridProps> {
        * This hack exists because we need to add wheel event listener to the div rendered by Grid
        *
        */
+      //@ts-expect-error _scrollingContainer not typed in Grid
       this.grid?._scrollingContainer?.addEventListener('wheel', this._preventScrollBack, {
         passive: false
       });
     }
   };
   componentWillUnmount() {
+    //@ts-expect-error _scrollingContainer not typed in Grid
     this.grid?._scrollingContainer?.removeEventListener('wheel', this._preventScrollBack, {
       passive: false
     });

--- a/src/components/src/common/field-token.tsx
+++ b/src/components/src/common/field-token.tsx
@@ -40,8 +40,8 @@ function FieldTokenFactory(
     font-weight: 400;
     padding: 0 5px;
     text-align: center;
-    width: 40px;
-    line-height: 20px;
+    width: ${props => props.theme.fieldTokenWidth}px;
+    line-height: ${props => props.theme.fieldTokenHeight}px;
   `;
 
   const FieldToken = ({type}: FieldTokenProps) => (

--- a/src/components/src/modals/data-table-modal.tsx
+++ b/src/components/src/modals/data-table-modal.tsx
@@ -27,7 +27,7 @@ import {renderedSize} from '../common/data-table/cell-size';
 import CanvasHack from '../common/data-table/canvas';
 import KeplerTable, {Datasets} from '@kepler.gl/table';
 
-const MIN_STATS_CELL_SIZE = 142;
+const MIN_STATS_CELL_SIZE = 122;
 
 const dgSettings = {
   sidePadding: '38px',

--- a/src/styles/src/base.ts
+++ b/src/styles/src/base.ts
@@ -431,6 +431,8 @@ export const actionPanelHeight = 32;
 
 // Styled Token
 export const fieldTokenRightMargin = 4;
+export const fieldTokenHeight = 20;
+export const fieldTokenWidth = 40;
 
 export const textTruncate = {
   maxWidth: '100%',
@@ -1524,7 +1526,9 @@ export const theme = {
   layerConfiguratorPadding,
 
   // Styled token
-  fieldTokenRightMargin
+  fieldTokenRightMargin,
+  fieldTokenHeight,
+  fieldTokenWidth
 };
 
 export const themeLT = {

--- a/test/browser/components/modals/data-table-modal-test.js
+++ b/test/browser/components/modals/data-table-modal-test.js
@@ -65,19 +65,19 @@ const expectedCellSizeCache = {
 
 const expectedExpandedCellSize = {
   cellSizeCache: {
-    'gps_data.utc_timestamp': 155,
-    'gps_data.lat': 96,
-    'gps_data.lng': 96,
+    'gps_data.utc_timestamp': 160,
+    'gps_data.lat': 108,
+    'gps_data.lng': 110,
     'gps_data.types': 125,
     epoch: 121,
-    has_result: 75,
-    uid: 75,
+    has_result: 99,
+    uid: 90,
     time: 180,
     begintrip_ts_utc: 182,
     begintrip_ts_local: 182,
-    date: 95
+    date: 143
   },
-  ghost: undefined
+  ghost: null
 };
 
 // This is to Mock Canvas.measureText response which we will not be testing
@@ -275,7 +275,7 @@ test('Components -> DataTableModal -> render DataTable: csv 1', t => {
   const enriched = {
     ...props,
     cellSizeCache: expectedCellSizeCache,
-    fixedWidth: 1300,
+    fixedWidth: 1500,
     fixedHeight: 800,
     theme: {}
   };
@@ -545,9 +545,9 @@ test('Components -> cellSize -> renderedSize', t => {
     .props();
 
   const expected = {
-    _geojson: {row: 500, header: 206},
-    'income level of people over 65': {row: 182, header: 223},
-    engagement: {row: 182, header: 206}
+    _geojson: {row: 500, header: 186},
+    'income level of people over 65': {row: 162, header: 223},
+    engagement: {row: 162, header: 186}
   };
 
   t.deepEqual(


### PR DESCRIPTION
* Smarter cell size calculator so header cell can be shown in full, a cell doesn't expand too wide
* Hide double scroll bar
* Prevent scroll left from triggering navigation change

Signed-off-by: Shan He <heshan0131@gmail.com>