### PR TITLE
[Fix] Datasets attribution width styling

### DIFF
--- a/src/components/src/common/styled-components.tsx
+++ b/src/components/src/common/styled-components.tsx
@@ -67,6 +67,12 @@ export const CenterVerticalFlexbox = styled.div`
   align-items: center;
 `;
 
+export const EndHorizontalFlexbox = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: end;
+`;
+
 export const SpaceBetweenFlexbox = styled.div`
   display: flex;
   justify-content: space-between;
@@ -541,7 +547,7 @@ export const StyledAttrbution = styled.div.attrs({
   position: absolute;
   display: block;
   margin: 0 10px 6px;
-  z-index: 0;
+  z-index: 1;
   .attrition-link {
     display: flex;
     align-items: center;

--- a/src/components/src/common/styled-components.tsx
+++ b/src/components/src/common/styled-components.tsx
@@ -551,6 +551,7 @@ export const StyledAttrbution = styled.div.attrs({
   .attrition-link {
     display: flex;
     align-items: center;
+    margin-left: 10px;
 
     a {
       margin-right: 2px;

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -75,6 +75,7 @@ import {
 } from '@kepler.gl/constants';
 
 import ErrorBoundary from './common/error-boundary';
+import type {DatasetAttribution} from './types';
 import {LOCALE_CODES} from '@kepler.gl/localization';
 import {MapView} from '@deck.gl/core';
 import {
@@ -87,8 +88,6 @@ import {
   LayersToRender
 } from '@kepler.gl/reducers';
 import {VisState} from '@kepler.gl/schemas';
-
-import type {DatasetAttribution} from './types';
 
 /** @type {{[key: string]: React.CSSProperties}} */
 const MAP_STYLE: {[key: string]: React.CSSProperties} = {
@@ -155,7 +154,7 @@ const StyledDatasetAttributionsContainer = styled.div<StyledDatasetAttributionsC
   }
 `;
 
-const DatasetAttributions = ({datasetAttributions, isPalm}) => (
+const DatasetAttributions = ({datasetAttributions, isPalm}: {datasetAttributions: DatasetAttribution[]; isPalm: boolean}) => (
   <>
     {datasetAttributions?.length ? (
       <StyledDatasetAttributionsContainer isPalm={isPalm}>

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -142,7 +142,7 @@ interface StyledDatasetAttributionsContainerProps {
 }
 
 const StyledDatasetAttributionsContainer = styled.div<StyledDatasetAttributionsContainerProps>`
-  width: ${props => (props.isPalm ? '130px' : '180px')};
+  max-width: ${props => (props.isPalm ? '130px' : '180px')};
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -75,7 +75,7 @@ import {
 } from '@kepler.gl/constants';
 
 import ErrorBoundary from './common/error-boundary';
-import type {DatasetAttribution} from './types';
+import {DatasetAttribution} from './types';
 import {LOCALE_CODES} from '@kepler.gl/localization';
 import {MapView} from '@deck.gl/core';
 import {
@@ -154,7 +154,13 @@ const StyledDatasetAttributionsContainer = styled.div<StyledDatasetAttributionsC
   }
 `;
 
-const DatasetAttributions = ({datasetAttributions, isPalm}: {datasetAttributions: DatasetAttribution[]; isPalm: boolean}) => (
+const DatasetAttributions = ({
+  datasetAttributions,
+  isPalm
+}: {
+  datasetAttributions: DatasetAttribution[];
+  isPalm: boolean;
+}) => (
   <>
     {datasetAttributions?.length ? (
       <StyledDatasetAttributionsContainer isPalm={isPalm}>
@@ -266,7 +272,7 @@ interface MapContainerProps {
   bottomMapContainerProps: any;
   transformRequest?: any;
 
-  datasetAttributions?: DatasetAttribution[]
+  datasetAttributions?: DatasetAttribution[];
 }
 
 export default function MapContainerFactory(

--- a/src/components/src/types.ts
+++ b/src/components/src/types.ts
@@ -43,3 +43,8 @@ export type SidePanelProps = {
   panels: SidePanelItem[];
   version: string;
 };
+
+export type DatasetAttribution = {
+  title: string;
+  url: string;
+};


### PR DESCRIPTION
- replaced datasets attributes css `width` with `max-width`
- added space between basemap attribution & dataset attributions