### PR TITLE
[Fix] round the float number to up to 4 decimal places in table

### DIFF
--- a/src/utils/src/data-utils.ts
+++ b/src/utils/src/data-utils.ts
@@ -166,8 +166,6 @@ export function preciseRound(num: number, decimals: number): string {
 /**
  * round a giving number at most 4 decimal places
  * e.g. 10 -> 10, 1.12345 -> 1.2345, 2.0 -> 2
- * @param {number} num
- * @returns number
  */
 export function roundToFour(num: number): number {
   // @ts-expect-error

--- a/src/utils/src/data-utils.ts
+++ b/src/utils/src/data-utils.ts
@@ -164,6 +164,16 @@ export function preciseRound(num: number, decimals: number): string {
 }
 
 /**
+ * round a giving number at most 4 decimal places
+ * e.g. 10 -> 10, 1.12345 -> 1.2345, 2.0 -> 2
+ * @param {number} num
+ * @returns number
+ */
+export function roundToFour(num: number): number {
+  // @ts-expect-error
+  return Number(`${Math.round(`${num}e+4`)}e-4`);
+}
+/**
  * get number of decimals to round to for slider from step
  * @param step
  * @returns- number of decimal
@@ -257,6 +267,8 @@ export function roundValToStep(minValue: number, step: number, val: number): num
  * Used in render tooltip value
  */
 export const defaultFormatter: FieldFormatter = v => (notNullorUndefined(v) ? String(v) : '');
+
+export const floatFormatter = v => (isNumber(v) ? String(roundToFour(v)) : '');
 
 export const FIELD_DISPLAY_FORMAT: {
   [key: string]: FieldFormatter;

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -61,6 +61,7 @@ export {
   arrayMove,
   getFormatter,
   applyDefaultFormat,
+  roundToFour,
   getBooleanFormatter,
   applyCustomFormat,
   datetimeFormatter,

--- a/test/node/utils/data-utils-test.js
+++ b/test/node/utils/data-utils-test.js
@@ -30,7 +30,8 @@ import {
   arrayMove,
   getFormatter,
   defaultFormatter,
-  formatNumber
+  formatNumber,
+  roundToFour
 } from '@kepler.gl/utils';
 import {ALL_FIELD_TYPES} from '@kepler.gl/constants';
 
@@ -49,6 +50,19 @@ test('dataUtils -> preciseRound', t => {
   t.equal(preciseRound(13, 2), '13.00', 'should round 13 correctly');
   t.equal(preciseRound(1.437, 2), '1.44', 'should round 1.437 correctly');
   t.equal(preciseRound(0.09999999999999987, 8), '0.10000000', 'should round 0.10000000 correctly');
+  t.end();
+});
+
+test('dataUtils -> roundToFour', t => {
+  t.equal(roundToFour(1.2344), 1.2344, 'should round 1.2344 to 4 decimals correctly');
+  t.equal(roundToFour(13.23445), 13.2345, 'should round 13.23445 to 4 decimals correctly');
+  t.equal(roundToFour(13), 13, 'should round 13 to 4 decimals correctly');
+  t.equal(roundToFour(1.437), 1.437, 'should round 1.437 to 4 decimals correctly');
+  t.equal(
+    roundToFour(0.09999999999999987),
+    0.1,
+    'should round 0.09999999999999987 to 4 decimals correctly'
+  );
   t.end();
 });
 


### PR DESCRIPTION
round a giving number at most 4 decimal places, e.g.

10 -> 10
1.12345 -> 1.2345
1.123455 -> 1.2346
2.0 -> 2
1.00005 -> 1.0001