### PR TITLE
[Feat] Drag and drop interaction for split map

### DIFF
--- a/src/components/package.json
+++ b/src/components/package.json
@@ -32,6 +32,10 @@
   "dependencies": {
     "@deck.gl/core": "^8.6.0",
     "@deck.gl/react": "^8.6.0",
+    "@dnd-kit/core": "^6.0.5",
+    "@dnd-kit/modifiers": "^6.0.0",
+    "@dnd-kit/sortable": "^7.0.1",
+    "@dnd-kit/utilities": "^3.2.0",
     "@kepler.gl/actions": "3.0.0-alpha.0",
     "@kepler.gl/cloud-providers": "3.0.0-alpha.0",
     "@kepler.gl/constants": "3.0.0-alpha.0",

--- a/src/components/src/dnd-layer-items.ts
+++ b/src/components/src/dnd-layer-items.ts
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import {
+  restrictToVerticalAxis,
+  restrictToWindowEdges,
+  restrictToParentElement
+} from '@dnd-kit/modifiers';
+import {arrayMove} from '@dnd-kit/sortable';
+
+export const DragItem = styled.div`
+  color: ${props => props.theme.textColorHl};
+  border-radius: ${props => props.theme.radioButtonRadius}px;
+  padding: 5px 10px;
+  display: inline;
+`;
+
+export const DND_MODIFIERS = [restrictToVerticalAxis, restrictToParentElement];
+export const DND_EMPTY_MODIFIERS = [];
+export const DRAGOVERLAY_MODIFIERS = [restrictToWindowEdges];
+export const findDndContainerId = (id, items) =>
+  id in items ? id : Object.keys(items).find(key => items[key].includes(id));
+export const getLayerOrderOnSort = (layerOrder, dndItems, activeLayerId, overLayerId) => {
+  const activeIndex = dndItems.indexOf(activeLayerId);
+  const overIndex = dndItems.indexOf(overLayerId);
+
+  return activeIndex === overIndex ? layerOrder : arrayMove(layerOrder, activeIndex, overIndex);
+};

--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -344,10 +344,10 @@ type KeplerGLBasicProps = {
 
 type KeplerGLProps = KeplerGlState & KeplerGlActions & KeplerGLBasicProps;
 type KeplerGLCompState = {
-  dimensions: any;
-  activeLayer: undefined | Layer;
+  dimensions: {width: number; height: number} | null;
+  activeLayer?: Layer;
   isDragging: boolean | null;
-  dndItems: any;
+  dndItems: {sortablelist: string[]; 0: []; 1: []};
 };
 
 KeplerGlFactory.deps = [

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -26,6 +26,7 @@ import {PickInfo} from '@deck.gl/core/lib/deck';
 import DeckGL from '@deck.gl/react';
 import {createSelector, Selector} from 'reselect';
 import mapboxgl from 'mapbox-gl';
+import {useDroppable} from '@dnd-kit/core';
 
 import {VisStateActions, MapStateActions, UIStateActions} from '@kepler.gl/actions';
 
@@ -137,6 +138,28 @@ const MapboxLogo = () => (
     />
   </div>
 );
+
+interface StyledDroppableProps {
+  isOver: boolean;
+}
+
+const StyledDroppable = styled.div<StyledDroppableProps>`
+  background-color: ${({isOver}) => (isOver ? 'rgba(128,128,128,0.2)' : 'none')};
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  pointer-events: none;
+  z-index: 1;
+`;
+
+export const isSplitSelector = props =>
+  props.visState.splitMaps && props.visState.splitMaps.length > 1;
+
+export const Droppable = ({containerId}) => {
+  const {isOver, setNodeRef} = useDroppable({id: containerId});
+
+  return <StyledDroppable ref={setNodeRef} isOver={isOver} />;
+};
 
 interface StyledDatasetAttributionsContainerProps {
   isPalm: boolean;
@@ -262,6 +285,8 @@ interface MapContainerProps {
   onMapRender?: Function;
   getMapboxRef?: (mapbox?: MapRef | null, index?: number) => void;
   index?: number;
+  deleteMapLabels?: any;
+  containerId?: number;
 
   locale?: any;
   theme?: any;
@@ -832,7 +857,8 @@ export default function MapContainerFactory(
         bottomMapContainerProps,
         topMapContainerProps,
         theme,
-        datasetAttributions = []
+        datasetAttributions = [],
+        containerId = 0
       } = this.props;
 
       const {layers, datasets, editor, interactionConfig} = visState;
@@ -888,6 +914,7 @@ export default function MapContainerFactory(
             onToggleEditorVisibility={visStateActions.toggleEditorVisibility}
             mapHeight={mapState.height}
           />
+          {isSplitSelector(this.props) && <Droppable containerId={containerId} />}
           {/* 
           // @ts-ignore */}
           <MapComponent

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -285,7 +285,7 @@ interface MapContainerProps {
   onMapRender?: Function;
   getMapboxRef?: (mapbox?: MapRef | null, index?: number) => void;
   index?: number;
-  deleteMapLabels?: any;
+  deleteMapLabels?: (containerId: string, layerId: string) => void;
   containerId?: number;
 
   locale?: any;

--- a/src/components/src/side-panel/layer-panel/dataset-section.tsx
+++ b/src/components/src/side-panel/layer-panel/dataset-section.tsx
@@ -56,8 +56,6 @@ const StyledDatasetTitle = styled.div<{showDatasetList?: boolean}>`
 `;
 
 const StyledDatasetSection = styled.div`
-  margin: 0 -32px 0 -16px;
-  padding: 0 32px 0 16px;
   border-bottom: 1px solid ${props => props.theme.sidePanelBorderColor};
 `;
 

--- a/src/components/src/side-panel/layer-panel/layer-list.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-list.tsx
@@ -95,7 +95,6 @@ function LayerListFactory(LayerPanel: ReturnType<typeof LayerPanelFactory>) {
         <LayerPanel
           {...panelProps}
           {...layerActions}
-          sortData={layerIndex}
           key={layerId}
           idx={layerIndex}
           layer={layers[layerIndex]}

--- a/src/components/src/side-panel/layer-panel/layer-list.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-list.tsx
@@ -18,15 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import React, {useCallback, useMemo, useState} from 'react';
+import React, {useMemo} from 'react';
 import styled from 'styled-components';
 import classnames from 'classnames';
-import {SortableContainer, SortableElement} from 'react-sortable-hoc';
 import LayerPanelFactory from './layer-panel';
 import {Layer, LayerClassesType} from '@kepler.gl/layers';
 import {Datasets} from '@kepler.gl/table';
-import {arrayMove} from '@kepler.gl/utils';
 import {UIStateActions, VisStateActions} from '@kepler.gl/actions';
+
+import {useDroppable} from '@dnd-kit/core';
+import {useSortable, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable';
+import {CSS} from '@dnd-kit/utilities';
 
 type LayerListProps = {
   datasets: Datasets;
@@ -40,9 +42,18 @@ type LayerListProps = {
 
 // make sure the element is always visible while is being dragged
 // item being dragged is appended in body, here to reset its global style
-const SortableStyledItem = styled.div`
+
+interface SortableStyledItemProps {
+  transition?: string;
+  transform?: string;
+}
+
+const SortableStyledItem = styled.div<SortableStyledItemProps>`
   z-index: ${props => props.theme.dropdownWrapperZ + 1};
+  transition: ${props => props.transition};
+  transform: ${props => props.transform};
   &.sorting {
+    opacity: 0.3;
     pointer-events: none;
   }
   &.sorting-layers .layer-panel__header {
@@ -68,17 +79,44 @@ LayerListFactory.deps = [LayerPanelFactory];
 function LayerListFactory(LayerPanel: ReturnType<typeof LayerPanelFactory>) {
   // By wrapping layer panel using a sortable element we don't have to implement the drag and drop logic into the panel itself;
   // Developers can provide any layer panel implementation and it will still be sortable
-  const SortableItem = SortableElement(({children, isSorting}) => {
+  const SortableItem = ({layerId, layers, layerIndex, panelProps, layerActions}) => {
+    const {attributes, listeners, setNodeRef, isDragging, transform, transition} = useSortable({
+      id: layerId
+    });
+
     return (
-      <SortableStyledItem className={classnames('sortable-layer-items', {sorting: isSorting})}>
-        {children}
+      <SortableStyledItem
+        ref={setNodeRef}
+        className={classnames('sortable-layer-items', {sorting: isDragging})}
+        transform={CSS.Transform.toString(transform)}
+        transition={transition}
+        {...attributes}
+      >
+        <LayerPanel
+          {...panelProps}
+          {...layerActions}
+          sortData={layerIndex}
+          key={layerId}
+          idx={layerIndex}
+          layer={layers[layerIndex]}
+          listeners={listeners}
+        />
       </SortableStyledItem>
     );
-  });
+  };
 
-  const WrappedSortableContainer = SortableContainer(({children}) => {
-    return <div>{children}</div>;
-  });
+  const SortableList = ({containerId, sidePanelDndItems, children}) => {
+    const {setNodeRef} = useDroppable({id: containerId});
+    return (
+      <SortableContext
+        id={containerId}
+        items={sidePanelDndItems}
+        strategy={verticalListSortingStrategy}
+      >
+        <div ref={setNodeRef}>{children}</div>
+      </SortableContext>
+    );
+  };
 
   const LayerList: React.FC<LayerListProps> = props => {
     const {
@@ -91,7 +129,11 @@ function LayerListFactory(LayerPanel: ReturnType<typeof LayerPanelFactory>) {
       isSortable = true
     } = props;
     const {toggleModal: openModal} = uiStateActions;
-    const [isSorting, setIsSorting] = useState(false);
+    const sidePanelDndItems = useMemo(() => layerOrder.map(layerIdx => layers[layerIdx].id), [
+      layers,
+      layerOrder
+    ]);
+
     const layerTypeOptions = useMemo(
       () =>
         Object.keys(layerClasses).map(key => {
@@ -124,49 +166,28 @@ function LayerListFactory(LayerPanel: ReturnType<typeof LayerPanelFactory>) {
       layerTypeOptions
     };
 
-    const _handleSort = useCallback(
-      ({oldIndex, newIndex}) => {
-        visStateActions.reorderLayer(arrayMove(props.layerOrder, oldIndex, newIndex));
-        setIsSorting(false);
-      },
-      [props.layerOrder, visStateActions]
-    );
-    const _onSortStart = useCallback(() => {
-      setIsSorting(true);
-    }, []);
-    const _updateBeforeSortStart = useCallback(() => {
-      ({index}) => {
-        const layerIdx = layerOrder[index];
-        if (layers[layerIdx].config.isConfigActive) {
-          visStateActions.layerConfigChange(layers[layerIdx], {isConfigActive: false});
-        }
-      };
-    }, [layers, layerOrder, visStateActions]);
     return isSortable ? (
-      <WrappedSortableContainer
-        onSortEnd={_handleSort}
-        onSortStart={_onSortStart}
-        updateBeforeSortStart={_updateBeforeSortStart}
-        lockAxis="y"
-        helperClass="sorting-layers"
-        useDragHandle
-      >
-        {layerOrder.map(
-          (layerIdx, index) =>
-            layers[layerIdx] &&
-            !layers[layerIdx].config.hidden && (
-              <SortableItem key={`layer-${layerIdx}`} index={index} isSorting={isSorting}>
-                <LayerPanel
-                  {...panelProps}
-                  {...layerActions}
-                  key={layers[layerIdx].id}
-                  idx={layerIdx}
-                  layer={layers[layerIdx]}
+      <>
+        <SortableList containerId="sortablelist" sidePanelDndItems={sidePanelDndItems}>
+          {/* warning: containerId should be similar to the first key in dndItems defined in kepler-gl.js*/}
+
+          {sidePanelDndItems.map(
+            (id, index) =>
+              layers[layerOrder[index]] &&
+              !layers[layerOrder[index]].config.hidden &&
+              id && (
+                <SortableItem
+                  key={id}
+                  layerId={id}
+                  panelProps={panelProps}
+                  layerActions={layerActions}
+                  layers={layers}
+                  layerIndex={layerOrder[index]}
                 />
-              </SortableItem>
-            )
-        )}
-      </WrappedSortableContainer>
+              )
+          )}
+        </SortableList>
+      </>
     ) : (
       <>
         {layerOrder.map(

--- a/src/components/src/side-panel/layer-panel/layer-panel-header.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-panel-header.tsx
@@ -27,7 +27,6 @@ import React, {
 } from 'react';
 import classnames from 'classnames';
 import styled, {css} from 'styled-components';
-import {SortableHandle} from 'react-sortable-hoc';
 import PanelHeaderActionFactory from '../panel-header-action';
 import {Tooltip} from '../../common/styled-components';
 import {
@@ -89,6 +88,7 @@ type LayerPanelHeaderProps = {
     resetIsValid: ComponentType<Partial<BaseProps>>;
     duplicate: ComponentType<Partial<BaseProps>>;
   };
+  listeners?: React.ElementType;
 };
 
 export const defaultProps = {
@@ -194,9 +194,11 @@ const StyledDragHandle = styled.div`
   }
 `;
 
-export const DragHandle = SortableHandle(({className, children}) => (
-  <StyledDragHandle className={className}>{children}</StyledDragHandle>
-));
+export const DragHandle = ({className, listeners, children}) => (
+  <StyledDragHandle className={className} {...(listeners ? listeners : {})}>
+    {children}
+  </StyledDragHandle>
+);
 
 export const LayerLabelEditor: React.FC<LayerLabelEditorProps> = ({
   layerId,
@@ -211,6 +213,7 @@ export const LayerLabelEditor: React.FC<LayerLabelEditorProps> = ({
     value={label}
     onClick={(e: MouseEvent) => {
       e.stopPropagation();
+      e.preventDefault();
     }}
     onChange={onEdit}
     onFocus={onFocus}
@@ -311,10 +314,10 @@ function LayerPanelHeaderFactory(
     onRemoveLayer,
     onResetIsValid,
     showRemoveLayer,
+    listeners,
     actionIcons = defaultActionIcons
   }) => {
     const [isEditingLabel, setIsEditingLabel] = useState(false);
-
     return (
       <StyledLayerPanelHeader
         className={classnames('layer-panel__header', {
@@ -329,7 +332,7 @@ function LayerPanelHeaderFactory(
         {warning ? <HeaderWarning warning={warning} id={layerId} /> : null}
         <HeaderLabelSection className="layer-panel__header__content">
           {isDragNDropEnabled ? (
-            <DragHandle className="layer__drag-handle">
+            <DragHandle className="layer__drag-handle" listeners={listeners}>
               <VertDots height="20px" />
             </DragHandle>
           ) : (

--- a/src/components/src/side-panel/layer-panel/layer-panel.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-panel.tsx
@@ -61,6 +61,7 @@ type LayerPanelProps = {
   layerTextLabelChange: ActionHandler<typeof VisStateActions.layerTextLabelChange>;
   removeLayer: ActionHandler<typeof VisStateActions.removeLayer>;
   duplicateLayer: ActionHandler<typeof VisStateActions.duplicateLayer>;
+  listeners?: React.ElementType;
 };
 
 const PanelWrapper = styled.div<{active: boolean}>`
@@ -141,7 +142,7 @@ function LayerPanelFactory(
     };
 
     render() {
-      const {layer, datasets, isDraggable, layerTypeOptions} = this.props;
+      const {layer, datasets, isDraggable, layerTypeOptions, listeners} = this.props;
       const {config, isValid} = layer;
       const {isConfigActive} = config;
       const allowDuplicate = typeof layer.isValidToSave === 'function' && layer.isValidToSave();
@@ -170,6 +171,7 @@ function LayerPanelFactory(
             onRemoveLayer={this._removeLayer}
             onDuplicateLayer={this._duplicateLayer}
             isDragNDropEnabled={isDraggable}
+            listeners={listeners}
           />
           {isConfigActive && (
             <LayerConfigurator

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -1551,7 +1551,7 @@ export const toggleSplitMapUpdater = (
         ...state,
         // maybe we should use an array to store state for a single map as well
         // if current maps length is equal to 0 it means that we are about to split the view
-        splitMaps: computeSplitMapLayers(state.layers)
+        splitMaps: computeSplitMapLayers(state.layers, {duplicate: false})
       }
     : closeSpecificMapAtIndex(state, action);
 

--- a/src/utils/src/split-map-utils.ts
+++ b/src/utils/src/split-map-utils.ts
@@ -95,10 +95,12 @@ export function getInitialMapLayersForSplitMap(layers) {
 /**
  * This method will get default splitMap settings based on existing layers
  * @param {Array<Object>} layers
+ * @param {Object} options
  * @returns {Array<Object>} split map settings
  */
-export function computeSplitMapLayers(layers) {
+export function computeSplitMapLayers(layers, options?: {duplicate: boolean}) {
   const mapLayers = getInitialMapLayersForSplitMap(layers);
-
-  return [{layers: mapLayers}, {layers: cloneDeep(mapLayers)}];
+  const {duplicate} = options || {};
+  // show all visible layers in left map, leave right map empty
+  return [{layers: mapLayers}, {layers: duplicate ? cloneDeep(mapLayers) : {}}];
 }

--- a/test/helpers/mock-state.js
+++ b/test/helpers/mock-state.js
@@ -466,13 +466,18 @@ function mockStateWithSplitMaps(state) {
   const initialState = state || mockStateWithFileUpload();
 
   const firstLayer = initialState.visState.layers[0];
-
+  const secondLayer = initialState.visState.layers[1];
   const prepareState = applyActions(keplerGlReducer, initialState, [
     // toggle splitMaps
     {action: MapStateActions.toggleSplitMap, payload: []},
 
     // toggleLayerForMap
-    {action: VisStateActions.toggleLayerForMap, payload: [0, firstLayer.id]}
+    {action: VisStateActions.toggleLayerForMap, payload: [0, firstLayer.id]},
+
+    // open geojson layer
+    {action: VisStateActions.toggleLayerForMap, payload: [1, secondLayer.id]},
+
+    {action: VisStateActions.toggleLayerForMap, payload: [1, firstLayer.id]}
   ]);
 
   return prepareState;

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -2943,11 +2943,7 @@ test('#visStateReducer -> SPLIT_MAP: TOGGLE', t => {
           a: true
         }
       },
-      {
-        layers: {
-          a: true
-        }
-      }
+      {layers: {}}
     ],
     'should split map'
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,6 +1427,45 @@
   resolved "https://registry.yarnpkg.com/@deck.gl/test-utils/-/test-utils-8.8.9.tgz#b044c2edfd7cf090282b17c137bbeedf96a4074c"
   integrity sha512-iasv76T1NGHiwh+4b7kW7CMPZzyXASxT3xK8IViiUUegLeZbnkB7qmp66+gcsLrAEVS+a0kP9RX2a3H5ljjl3Q==
 
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
+  integrity sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.0.5":
+  version "6.0.8"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.0.8.tgz#040ae13fea9787ee078e5f0361f3b49b07f3f005"
+  integrity sha512-lYaoP8yHTQSLlZe6Rr9qogouGUz9oRUj4AHhDQGQzq/hqaJRpFo65X+JKsdHf8oUFBzx5A+SJPUvxAwTF2OabA==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^3.2.1"
+    tslib "^2.0.0"
+
+"@dnd-kit/modifiers@^6.0.0":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/modifiers/-/modifiers-6.0.1.tgz#9e39b25fd6e323659604cc74488fe044d33188c8"
+  integrity sha512-rbxcsg3HhzlcMHVHWDuh9LCjpOVAgqbV78wLGI8tziXY3+qcMQ61qVXIvNKQFuhj75dSfD+o+PYZQ/NUk2A23A==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.1"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^7.0.1":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-7.0.2.tgz#791d550872457f3f3c843e00d159b640f982011c"
+  integrity sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.0", "@dnd-kit/utilities@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.1.tgz#53f9e2016fd2506ec49e404c289392cfff30332a"
+  integrity sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/is-prop-valid@^0.8.1":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
@@ -15801,6 +15840,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tslib@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
1. replace [react-sortable-hoc](https://github.com/clauderic/react-sortable-hoc) with [dnd-kit](https://github.com/clauderic/dnd-kit). React-sortable-hoc is no longer actively maintained and its developers strongly encourage new consumers to adopt dnd-kit instead of adopting react-sortable-hoc.
2. Add support for the split map mode, allowing dragging and dropping layers from the side panel to each of the two map panels.