### PR TITLE
[Feat] Add display format setting for table/tooltip

### DIFF
--- a/src/actions/src/vis-state-actions.ts
+++ b/src/actions/src/vis-state-actions.ts
@@ -622,22 +622,23 @@ export function copyTableColumn(
 
 export type SetColumnDisplayFormatUpdaterAction = {
   dataId: string;
-  column: string;
-  displayFormat: string;
+  formats: {
+    [key: string]: string;
+  };
 };
 
 /**
  * Set column display format
  * @param dataId
- * @param column
- * @param displayFormat
+ * @param formats
  * @returns action
  * @public
  */
 export function setColumnDisplayFormat(
   dataId: string,
-  column: string,
-  displayFormat: string
+  formats: {
+    [key: string]: string;
+  }
 ): Merge<
   SetColumnDisplayFormatUpdaterAction,
   {type: typeof ActionTypes.SET_COLUMN_DISPLAY_FORMAT}
@@ -645,8 +646,7 @@ export function setColumnDisplayFormat(
   return {
     type: ActionTypes.SET_COLUMN_DISPLAY_FORMAT,
     dataId,
-    column,
-    displayFormat
+    formats
   };
 }
 

--- a/src/components/src/common/data-table/display-format.tsx
+++ b/src/components/src/common/data-table/display-format.tsx
@@ -1,0 +1,177 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React, {useCallback, useState} from 'react';
+import styled from 'styled-components';
+
+import {getFieldFormatLabels} from '@kepler.gl/utils';
+import {ALL_FIELD_TYPES} from '@kepler.gl/constants';
+import {ColMeta, ColMetaProps} from '@kepler.gl/types';
+
+import {InputLight} from '../../common/styled-components';
+import {FormatterDropdown} from './option-dropdown';
+
+const StyledConfigPanel = styled.div`
+  background-color: ${props => props.theme.headerCellBackground};
+  box-shadow: 0 10px 18px 0 rgb(0 0 0 / 36%);
+  flex-grow: 1;
+`;
+const StyledConfigPanelContent = styled.div`
+  padding: 20px;
+  min-width: 230px;
+  max-height: 400px;
+  overflow: overlay;
+`;
+
+const StyledTableConfigGroup = styled.div`
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+
+  input {
+    cursor: pointer !important;
+    width: 184px;
+    height: 22px;
+  }
+`;
+
+export type DataTableConfigProps = {
+  title: string;
+  id: string;
+  defaultFormat: any; // ! fix this
+  options: any;
+  columns: {name: string}[];
+  colMeta: ColMeta;
+  setColumnDisplayFormat: (formats: {column: string; displayFormat: string}) => void;
+  onClose: () => void;
+};
+
+export const NumberFormatConfig: React.FC<DataTableConfigProps> = ({
+  title,
+  id,
+  defaultFormat,
+  options,
+  columns,
+  setColumnDisplayFormat,
+  onClose
+}) => {
+  const [showFormatter, setShowFormatter] = useState(false);
+  const [format, setFormat] = useState(defaultFormat);
+
+  const onSetDisplayFormat = useCallback(
+    option => {
+      setFormat(option.label);
+      const formats = columns.reduce((prev, col) => {
+        prev[col.name] = option.format;
+        return prev;
+      }, {} as {column: string; displayFormat: string});
+      setColumnDisplayFormat(formats);
+      onClose();
+    },
+    [columns, setColumnDisplayFormat, onClose]
+  );
+
+  return (
+    <StyledTableConfigGroup>
+      <InputLight
+        id={id}
+        type="text"
+        value={title}
+        data-tip={format}
+        readOnly
+        onClick={() => setShowFormatter(true)}
+      />
+      <FormatterDropdown
+        left={-185}
+        top={10}
+        isOpened={showFormatter}
+        displayFormat={format}
+        setDisplayFormat={onSetDisplayFormat}
+        onClose={() => setShowFormatter(false)}
+        formatLabels={options}
+      />
+    </StyledTableConfigGroup>
+  );
+};
+
+function DataTableConfigFactory() {
+  const getColumnsByFieldType = (columns, colMeta: ColMeta, fieldType: string) => {
+    const result: ColMetaProps[] = [];
+    columns.forEach(colName => {
+      if (colMeta[colName]?.type === fieldType) {
+        result.push(colMeta[colName]);
+      }
+    });
+    return result;
+  };
+
+  const DataTableConfig = ({columns, colMeta, setColumnDisplayFormat, onClose}) => {
+    const formatConfigs = [
+      {
+        title: '# Set Integer Number Format',
+        id: 'input-iteger-format',
+        displayType: ALL_FIELD_TYPES.integer
+      },
+      {
+        title: '# Set Float Number Format',
+        id: 'input-float-format',
+        displayType: ALL_FIELD_TYPES.real
+      },
+      {
+        title: '# Set Timestamp Format',
+        id: 'input-datetime-format',
+        displayType: ALL_FIELD_TYPES.timestamp
+      },
+      {
+        title: '# Set Date Format',
+        id: 'input-date-format',
+        displayType: ALL_FIELD_TYPES.date
+      },
+      {
+        title: '# Set Boolean Format',
+        id: 'input-bool-format',
+        displayType: ALL_FIELD_TYPES.boolean
+      }
+    ];
+
+    return (
+      <StyledConfigPanel>
+        <StyledConfigPanelContent>
+          {formatConfigs.map((config, index) => (
+            <NumberFormatConfig
+              title={`${config.title}`}
+              key={index}
+              id={config.id}
+              defaultFormat={'None'}
+              colMeta={colMeta}
+              options={getFieldFormatLabels(`${config.displayType}`)}
+              columns={getColumnsByFieldType(columns, colMeta, `${config.displayType}`)}
+              setColumnDisplayFormat={setColumnDisplayFormat}
+              onClose={onClose}
+            />
+          ))}
+        </StyledConfigPanelContent>
+      </StyledConfigPanel>
+    );
+  };
+  return DataTableConfig;
+}
+
+export default DataTableConfigFactory;

--- a/src/components/src/common/data-table/display-format.tsx
+++ b/src/components/src/common/data-table/display-format.tsx
@@ -22,7 +22,7 @@ import React, {useCallback, useState} from 'react';
 import styled from 'styled-components';
 
 import {getFieldFormatLabels} from '@kepler.gl/utils';
-import {ALL_FIELD_TYPES} from '@kepler.gl/constants';
+import {ALL_FIELD_TYPES, TooltipFormat} from '@kepler.gl/constants';
 import {ColMeta, ColMetaProps} from '@kepler.gl/types';
 
 import {InputLight} from '../../common/styled-components';
@@ -55,11 +55,11 @@ const StyledTableConfigGroup = styled.div`
 export type DataTableConfigProps = {
   title: string;
   id: string;
-  defaultFormat: any; // ! fix this
-  options: any;
+  defaultFormat: string;
+  options: TooltipFormat[];
   columns: {name: string}[];
   colMeta: ColMeta;
-  setColumnDisplayFormat: (formats: {column: string; displayFormat: string}) => void;
+  setColumnDisplayFormat: (formats: {[key: string]: string}) => void;
   onClose: () => void;
 };
 
@@ -71,17 +71,17 @@ export const NumberFormatConfig: React.FC<DataTableConfigProps> = ({
   columns,
   setColumnDisplayFormat,
   onClose
-}) => {
+}: DataTableConfigProps) => {
   const [showFormatter, setShowFormatter] = useState(false);
   const [format, setFormat] = useState(defaultFormat);
 
   const onSetDisplayFormat = useCallback(
-    option => {
+    (option: TooltipFormat) => {
       setFormat(option.label);
-      const formats = columns.reduce((prev, col) => {
+      const formats: {[key: string]: string} = columns.reduce((prev, col) => {
         prev[col.name] = option.format;
         return prev;
-      }, {} as {column: string; displayFormat: string});
+      }, {});
       setColumnDisplayFormat(formats);
       onClose();
     },
@@ -112,7 +112,7 @@ export const NumberFormatConfig: React.FC<DataTableConfigProps> = ({
 };
 
 function DataTableConfigFactory() {
-  const getColumnsByFieldType = (columns, colMeta: ColMeta, fieldType: string) => {
+  const getColumnsByFieldType = (columns: string[], colMeta: ColMeta, fieldType: string) => {
     const result: ColMetaProps[] = [];
     columns.forEach(colName => {
       if (colMeta[colName]?.type === fieldType) {

--- a/src/components/src/common/data-table/header-cell.tsx
+++ b/src/components/src/common/data-table/header-cell.tsx
@@ -106,7 +106,7 @@ const HeaderCellFactory = (FieldToken: React.FC<FieldTokenProps>) => {
       sortTableColumn,
       pinTableColumn,
       copyTableColumn,
-      setDisplayFormat
+      setColumnDisplayFormat
     } = props;
     const [showFormatter, setShowFormatter] = useState(false);
     const column = columns[columnIndex];
@@ -125,9 +125,9 @@ const HeaderCellFactory = (FieldToken: React.FC<FieldTokenProps>) => {
     const onCopy = useCallback(() => copyTableColumn(column), [copyTableColumn, column]);
     const onSetDisplayFormat = useCallback(
       displayFormat => {
-        setDisplayFormat(column, displayFormat.format);
+        setColumnDisplayFormat({[column]: displayFormat.format});
       },
-      [column, setDisplayFormat]
+      [column, setColumnDisplayFormat]
     );
 
     const onToggleDisplayFormat = useCallback(() => {
@@ -172,7 +172,7 @@ const HeaderCellFactory = (FieldToken: React.FC<FieldTokenProps>) => {
                       left={0}
                       top={0}
                       isOpened={isFormatted && showFormatter}
-                      column={colMeta[column]}
+                      displayFormat={colMeta[column].displayFormat}
                       setDisplayFormat={onSetDisplayFormat}
                       onClose={() => setShowFormatter(false)}
                       formatLabels={formatLabels}

--- a/src/components/src/common/data-table/index.tsx
+++ b/src/components/src/common/data-table/index.tsx
@@ -390,7 +390,7 @@ export interface DataTableProps {
   sortColumn: SortColumn;
   sortTableColumn: (column: string, mode?: string) => void;
   pinTableColumn: (column: string) => void;
-  setDisplayFormat: (column: string, displayFormat: string) => void;
+  setColumnDisplayFormat: (formats: {[key: string]: string}) => void;
   copyTableColumn: (column: string) => void;
   sortOrder?: number[] | null;
   showStats?: boolean;

--- a/src/components/src/common/data-table/option-dropdown.tsx
+++ b/src/components/src/common/data-table/option-dropdown.tsx
@@ -81,7 +81,7 @@ export type FormatterDropdownProps = {
   top: number;
   isOpened: boolean;
   displayFormat?: string;
-  setDisplayFormat: (displayFormat: string) => void;
+  setDisplayFormat: (displayFormat: TooltipFormat) => void;
   onClose: () => void;
   formatLabels: TooltipFormat[];
 };
@@ -89,7 +89,15 @@ export type FormatterDropdownProps = {
 export const FormatterDropdown: React.FC<FormatterDropdownProps> = (
   props: FormatterDropdownProps
 ) => {
-  const {left, top, isOpened, displayFormat = '', setDisplayFormat, onClose, formatLabels} = props;
+  const {
+    left,
+    top,
+    isOpened,
+    displayFormat = 'None',
+    setDisplayFormat,
+    onClose,
+    formatLabels
+  } = props;
   const selectionIndex = formatLabels.findIndex(label => label.format === displayFormat);
 
   const onSelectDisplayFormat = useCallback(
@@ -123,7 +131,7 @@ interface OptionDropdownProps {
   sortTableColumn: (sort: string) => void;
   pinTableColumn: () => void;
   copyTableColumn: () => void;
-  setDisplayFormat: (displayFormat: string) => void;
+  setDisplayFormat: (displayFormat: any) => void;
   sortMode?: string;
   isSorted?: string;
   isPinned?: boolean;

--- a/src/components/src/common/data-table/option-dropdown.tsx
+++ b/src/components/src/common/data-table/option-dropdown.tsx
@@ -24,7 +24,7 @@ import Portaled from '../portaled';
 import DropdownList from '../item-selector/dropdown-list';
 import {SORT_ORDER, TABLE_OPTION, TABLE_OPTION_LIST, TooltipFormat} from '@kepler.gl/constants';
 import {getFieldFormatLabels} from '@kepler.gl/utils';
-import {ColMeta, ColMetaProps} from '@kepler.gl/types';
+import {ColMeta} from '@kepler.gl/types';
 import {ArrowDown, ArrowUp, Clipboard, Pin, Cancel, Hash} from '../icons';
 
 const ListItem = ({value}) => (
@@ -80,7 +80,7 @@ export type FormatterDropdownProps = {
   left: number;
   top: number;
   isOpened: boolean;
-  column: ColMetaProps;
+  displayFormat?: string;
   setDisplayFormat: (displayFormat: string) => void;
   onClose: () => void;
   formatLabels: TooltipFormat[];
@@ -89,8 +89,8 @@ export type FormatterDropdownProps = {
 export const FormatterDropdown: React.FC<FormatterDropdownProps> = (
   props: FormatterDropdownProps
 ) => {
-  const {left, top, isOpened, column, setDisplayFormat, onClose, formatLabels} = props;
-  const selectionIndex = formatLabels.findIndex(label => label.format === column.displayFormat);
+  const {left, top, isOpened, displayFormat = '', setDisplayFormat, onClose, formatLabels} = props;
+  const selectionIndex = formatLabels.findIndex(label => label.format === displayFormat);
 
   const onSelectDisplayFormat = useCallback(
     (result, e) => {
@@ -214,7 +214,7 @@ const OptionDropdown = (props: OptionDropdownProps) => {
           top={-10}
           isOpened={Boolean(isOpened && showFormatter)}
           formatLabels={formatLabels}
-          column={colMeta[column]}
+          displayFormat={colMeta[column]?.displayFormat}
           setDisplayFormat={setDisplayFormat}
           onClose={onClose}
         />

--- a/src/components/src/common/field-selector.tsx
+++ b/src/components/src/common/field-selector.tsx
@@ -107,7 +107,7 @@ interface FieldSelectorFactoryProps {
   closeOnSelect?: boolean;
   showToken?: boolean;
   suggested?: ReadonlyArray<string | number | boolean | object> | null;
-  CustomChickletComponent?: ComponentType;
+  CustomChickletComponent?: ComponentType<any>;
   size?: string;
 }
 

--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -222,6 +222,7 @@ export {default as SliderHandle} from './common/slider/slider-handle';
 export {default as SliderBarHandle} from './common/slider/slider-bar-handle';
 export {default as ActionPanel, ActionPanelItem} from './common/action-panel';
 export {default as HeaderCellFactory} from './common/data-table/header-cell';
+export {default as DataTableConfigFactory, NumberFormatConfig} from './common/data-table/display-format';
 export {default as DataTableFactory} from './common/data-table';
 export {default as CanvasHack} from './common/data-table/canvas';
 export {default as OptionDropdown, FormatterDropdown} from './common/data-table/option-dropdown';

--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -133,14 +133,15 @@ const EntryInfoRow = ({item, fields, data, primaryData, compareType}) => {
   const value = data.valueAt(fieldIdx);
   const displayValue = getTooltipDisplayValue({item, field, value});
 
-  const displayDeltaValue = getTooltipDisplayDeltaValue({
-    item,
-    field,
-    data,
-    fieldIdx,
-    primaryData,
-    compareType
-  });
+  const displayDeltaValue = primaryData
+    ? getTooltipDisplayDeltaValue({
+        field,
+        data,
+        fieldIdx,
+        primaryData,
+        compareType
+      })
+    : null;
 
   return (
     <Row

--- a/src/components/src/side-panel/interaction-manager.tsx
+++ b/src/components/src/side-panel/interaction-manager.tsx
@@ -49,7 +49,7 @@ function InteractionManagerFactory(
     visStateActions,
     panelMetadata
   }) => {
-    const {interactionConfigChange: onConfigChange} = visStateActions;
+    const {interactionConfigChange: onConfigChange, setColumnDisplayFormat} = visStateActions;
     const intl = useIntl();
     return (
       <div className="interaction-manager">
@@ -63,6 +63,7 @@ function InteractionManagerFactory(
             config={interactionConfig[key]}
             key={key}
             onConfigChange={onConfigChange}
+            setColumnDisplayFormat={setColumnDisplayFormat}
           />
         ))}
       </div>

--- a/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
+++ b/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
@@ -26,7 +26,10 @@ import BrushConfigFactory from './brush-config';
 import TooltipConfigFactory from './tooltip-config';
 import {Datasets} from '@kepler.gl/table';
 import {InteractionConfig, ValueOf} from '@kepler.gl/types';
-import {setColumnDisplayFormat} from '@kepler.gl/actions';
+import {
+  setColumnDisplayFormat as setColumnDisplayFormatAction,
+  ActionHandler
+} from '@kepler.gl/actions';
 
 import {
   StyledPanelHeader,
@@ -45,7 +48,7 @@ interface InteractionPanelProps {
   interactionConfigIcons?: {
     [key: string]: React.ElementType;
   };
-  setColumnDisplayFormat: typeof setColumnDisplayFormat;
+  setColumnDisplayFormat: ActionHandler<typeof setColumnDisplayFormatAction>;
 }
 
 const StyledInteractionPanel = styled.div`

--- a/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
+++ b/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
@@ -44,6 +44,7 @@ interface InteractionPanelProps {
   interactionConfigIcons?: {
     [key: string]: React.ElementType;
   };
+  setColumnDisplayFormat: any; // !
 }
 
 const StyledInteractionPanel = styled.div`
@@ -68,6 +69,7 @@ function InteractionPanelFactory(
     config,
     onConfigChange,
     datasets,
+    setColumnDisplayFormat,
     interactionConfigIcons = INTERACTION_CONFIG_ICONS
   }) => {
     const [isConfigActive, setIsConfigAction] = useState(false);
@@ -82,6 +84,13 @@ function InteractionPanelFactory(
       [onConfigChange, config]
     );
 
+    const _updateDisplayFormat = useCallback(
+      (dataId, column, displayFormat) => {
+        setColumnDisplayFormat(dataId, {[column]: displayFormat});
+      },
+      [setColumnDisplayFormat]
+    );
+
     const togglePanelActive = useCallback(() => {
       setIsConfigAction(!isConfigActive);
     }, [setIsConfigAction, isConfigActive]);
@@ -92,13 +101,27 @@ function InteractionPanelFactory(
     }, [_updateConfig, enabled]);
 
     const onChange = useCallback(newConfig => _updateConfig({config: newConfig}), [_updateConfig]);
+
+    // ! redundant
+    const onDisplayFormatChange = useCallback(
+      (dataId, column, displayFormat) => _updateDisplayFormat(dataId, column, displayFormat),
+      [_updateDisplayFormat]
+    );
+
     const IconComponent = interactionConfigIcons[config.id];
 
     let template: ReactElement | null = null;
 
     switch (config.id) {
       case 'tooltip':
-        template = <TooltipConfig datasets={datasets} config={config.config} onChange={onChange} />;
+        template = (
+          <TooltipConfig
+            datasets={datasets}
+            config={config.config}
+            onChange={onChange}
+            onDisplayFormatChange={onDisplayFormatChange}
+          />
+        );
         break;
       case 'brush':
         template = <BrushConfig config={config.config} onChange={onChange} />;

--- a/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
+++ b/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
@@ -26,6 +26,7 @@ import BrushConfigFactory from './brush-config';
 import TooltipConfigFactory from './tooltip-config';
 import {Datasets} from '@kepler.gl/table';
 import {InteractionConfig, ValueOf} from '@kepler.gl/types';
+import {setColumnDisplayFormat} from '@kepler.gl/actions';
 
 import {
   StyledPanelHeader,
@@ -44,7 +45,7 @@ interface InteractionPanelProps {
   interactionConfigIcons?: {
     [key: string]: React.ElementType;
   };
-  setColumnDisplayFormat: any; // !
+  setColumnDisplayFormat: typeof setColumnDisplayFormat;
 }
 
 const StyledInteractionPanel = styled.div`
@@ -84,7 +85,7 @@ function InteractionPanelFactory(
       [onConfigChange, config]
     );
 
-    const _updateDisplayFormat = useCallback(
+    const onDisplayFormatChange = useCallback(
       (dataId, column, displayFormat) => {
         setColumnDisplayFormat(dataId, {[column]: displayFormat});
       },
@@ -101,12 +102,6 @@ function InteractionPanelFactory(
     }, [_updateConfig, enabled]);
 
     const onChange = useCallback(newConfig => _updateConfig({config: newConfig}), [_updateConfig]);
-
-    // ! redundant
-    const onDisplayFormatChange = useCallback(
-      (dataId, column, displayFormat) => _updateDisplayFormat(dataId, column, displayFormat),
-      [_updateDisplayFormat]
-    );
 
     const IconComponent = interactionConfigIcons[config.id];
 

--- a/src/components/src/side-panel/interaction-panel/tooltip-config.tsx
+++ b/src/components/src/side-panel/interaction-panel/tooltip-config.tsx
@@ -85,6 +85,7 @@ type TooltipConfigProps = {
   }) => void;
   datasets: Datasets;
   intl: IntlShape;
+  onDisplayFormatChange: (dataId, column, displayFormat) => void;
 };
 
 type DatasetTooltipConfigProps = {
@@ -103,6 +104,7 @@ type DatasetTooltipConfigProps = {
     compareType: string | null;
   }) => void;
   dataset: KeplerTable;
+  onDisplayFormatChange: (dataId, column, displayFormat) => void;
 };
 
 TooltipConfigFactory.deps = [DatasetTagFactory, FieldSelectorFactory];
@@ -110,7 +112,12 @@ function TooltipConfigFactory(
   DatasetTag: ReturnType<typeof DatasetTagFactory>,
   FieldSelector: ReturnType<typeof FieldSelectorFactory>
 ) {
-  const DatasetTooltipConfig = ({config, onChange, dataset}: DatasetTooltipConfigProps) => {
+  const DatasetTooltipConfig = ({
+    config,
+    onChange,
+    dataset,
+    onDisplayFormatChange
+  }: DatasetTooltipConfigProps) => {
     const dataId = dataset.id;
     return (
       <SidePanelSection key={dataId}>
@@ -164,14 +171,25 @@ function TooltipConfigFactory(
           closeOnSelect={false}
           multiSelect
           inputTheme="secondary"
-          // @ts-expect-error
-          CustomChickletComponent={TooltipChickletFactory(dataId, config, onChange, dataset.fields)}
+          CustomChickletComponent={TooltipChickletFactory(
+            dataId,
+            config,
+            onChange,
+            dataset.fields,
+            onDisplayFormatChange
+          )}
         />
       </SidePanelSection>
     );
   };
 
-  const TooltipConfig = ({config, datasets, onChange, intl}: TooltipConfigProps) => {
+  const TooltipConfig = ({
+    config,
+    datasets,
+    onChange,
+    onDisplayFormatChange,
+    intl
+  }: TooltipConfigProps) => {
     return (
       <TooltipConfigWrapper>
         {Object.keys(config.fieldsToShow).map(dataId =>
@@ -181,6 +199,7 @@ function TooltipConfigFactory(
               config={config}
               onChange={onChange}
               dataset={datasets[dataId]}
+              onDisplayFormatChange={onDisplayFormatChange}
             />
           )
         )}

--- a/src/components/src/side-panel/interaction-panel/tooltip-config/tooltip-chicklet.tsx
+++ b/src/components/src/side-panel/interaction-panel/tooltip-config/tooltip-chicklet.tsx
@@ -41,7 +41,7 @@ type TooltipConfig = {
     [key: string]: {name: string; format: string | null}[];
   };
   compareMode: boolean;
-  compareType: string[];
+  compareType: string | null; // ! check
 };
 
 type IconDivProps = {
@@ -95,7 +95,8 @@ function TooltipChickletFactory(
   dataId: string,
   config: TooltipConfig,
   onChange: (cfg: TooltipConfig) => void,
-  fields: TooltipFields[]
+  fields: TooltipFields[],
+  onDisplayFormatChange
 ): ComponentType<TooltipChickletProps> {
   class TooltipChicklet extends Component<TooltipChickletProps> {
     state = {
@@ -126,10 +127,14 @@ function TooltipChickletFactory(
       if (!tooltipField) {
         return null;
       }
+      const field = fields.find(f => f.name === tooltipField.name);
+      if (!field) {
+        return null;
+      }
       const formatLabels = getFormatLabels(fields, tooltipField.name);
-      const hasFormat = Boolean(tooltipField.format);
+      const hasFormat = Boolean(field.displayFormat);
       const selectionIndex = formatLabels.findIndex(
-        fl => getFormatValue(fl) === tooltipField.format
+        fl => getFormatValue(fl) === field.displayFormat
       );
       const hashStyle = show ? hashStyles.SHOW : hasFormat ? hashStyles.ACTIVE : null;
 
@@ -143,7 +148,7 @@ function TooltipChickletFactory(
                 render={() => (
                   <span>
                     {hasFormat ? (
-                      getFormatTooltip(formatLabels, tooltipField.format)
+                      getFormatTooltip(formatLabels, field.displayName)
                     ) : (
                       <FormattedMessage id={'fieldSelector.formatting'} />
                     )}
@@ -174,12 +179,13 @@ function TooltipChickletFactory(
                         show: false
                       });
 
+                      const displayFormat = getFormatValue(result);
                       const oldFieldsToShow = config.fieldsToShow[dataId];
                       const fieldsToShow = oldFieldsToShow.map(fieldToShow => {
                         return fieldToShow.name === tooltipField.name
                           ? {
                               name: tooltipField.name,
-                              format: getFormatValue(result)
+                              format: displayFormat
                             }
                           : fieldToShow;
                       });
@@ -191,6 +197,7 @@ function TooltipChickletFactory(
                         }
                       };
                       onChange(newConfig);
+                      onDisplayFormatChange(dataId, field.name, displayFormat);
                     }}
                   />
                 </StyledPopover>

--- a/src/components/src/side-panel/interaction-panel/tooltip-config/tooltip-chicklet.tsx
+++ b/src/components/src/side-panel/interaction-panel/tooltip-config/tooltip-chicklet.tsx
@@ -41,7 +41,7 @@ type TooltipConfig = {
     [key: string]: {name: string; format: string | null}[];
   };
   compareMode: boolean;
-  compareType: string | null; // ! check
+  compareType: string | null;
 };
 
 type IconDivProps = {

--- a/src/reducers/src/interaction-utils.ts
+++ b/src/reducers/src/interaction-utils.ts
@@ -103,18 +103,13 @@ function _mergeFieldPairs(pairs) {
   return pairs.reduce((prev, pair) => [...prev, ...pair], []);
 }
 
-/**
- * @type {typeof import('./interaction-utils').getTooltipDisplayDeltaValue}
- */
 export function getTooltipDisplayDeltaValue({
   primaryData,
   field,
   compareType,
   data,
-  fieldIdx,
-  item
+  fieldIdx
 }: {
-  item: TooltipField;
   field: Field;
   data: DataRow;
   fieldIdx: number;
@@ -135,7 +130,7 @@ export function getTooltipDisplayDeltaValue({
       const deltaFormat =
         compareType === COMPARE_TYPES.RELATIVE
           ? TOOLTIP_FORMATS.DECIMAL_PERCENT_FULL_2[TOOLTIP_KEY]
-          : item.format || TOOLTIP_FORMATS.DECIMAL_DECIMAL_FIXED_3[TOOLTIP_KEY];
+          : field.displayFormat || TOOLTIP_FORMATS.DECIMAL_DECIMAL_FIXED_3[TOOLTIP_KEY];
 
       displayDeltaValue = getFormatter(deltaFormat, field)(deltaValue);
 
@@ -168,6 +163,8 @@ export function getTooltipDisplayValue({
   }
 
   return item?.format
-    ? getFormatter(item.format, field)(value)
+    ? getFormatter(item?.format, field)(value)
+    : field.displayFormat
+    ? getFormatter(field.displayFormat, field)(value)
     : parseFieldValue(value, field.type);
 }

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -2503,27 +2503,30 @@ export function copyTableColumnUpdater(
 }
 
 /**
- * Set column display format from user selection
+ * Set display format from columns from user selection
  * @memberof visStateUpdaters
  * @public
  */
 export function setColumnDisplayFormatUpdater(
   state: VisState,
-  {dataId, column, displayFormat}: VisStateActions.SetColumnDisplayFormatUpdaterAction
+  {dataId, formats}: VisStateActions.SetColumnDisplayFormatUpdaterAction
 ): VisState {
   const dataset = state.datasets[dataId];
   if (!dataset) {
     return state;
   }
-  const fieldIdx = dataset.fields.findIndex(f => f.name === column);
-  if (fieldIdx < 0) {
-    return state;
-  }
-  const field = dataset.fields[fieldIdx];
+  let newFields = dataset.fields;
+  Object.keys(formats).forEach(column => {
+    const fieldIdx = dataset.fields.findIndex(f => f.name === column);
+    if (fieldIdx >= 0) {
+      const displayFormat = formats[column];
+      const field = newFields[fieldIdx];
+      newFields = swap_(merge_({displayFormat})(field) as {id: string})(
+        newFields as {id: string}[]
+      ) as Field[];
+    }
+  });
 
-  const newFields = swap_(merge_({displayFormat})(field) as {id: string})(
-    dataset.fields as {id: string}[]
-  );
   const newDataset = copyTableAndUpdate(dataset, {fields: newFields as Field[]});
   return pick_('datasets')(merge_({[dataId]: newDataset}))(state);
 }

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -11,6 +11,8 @@ type TooltipFields = {
   name?: string;
   fieldIdx?: number;
   type?: string;
+  displayFormat?: string;
+  displayName: string;
 };
 
 export type ColMetaProps = {

--- a/test/browser/components/tooltip-config-test.js
+++ b/test/browser/components/tooltip-config-test.js
@@ -200,12 +200,19 @@ test('TooltipConfig - render -> tooltip format', t => {
   const tooltipConfig = StateWFiles.visState.interactionConfig.tooltip.config;
 
   const onChange = sinon.spy();
+  const onDisplayFormatChange = sinon.spy();
+
   let wrapper;
 
   t.doesNotThrow(() => {
     wrapper = mountWithTheme(
       <IntlWrapper>
-        <TooltipConfig onChange={onChange} config={tooltipConfig} datasets={datasets} />
+        <TooltipConfig
+          onChange={onChange}
+          onDisplayFormatChange={onDisplayFormatChange}
+          config={tooltipConfig}
+          datasets={datasets}
+        />
       </IntlWrapper>
     );
   }, 'Should render');

--- a/test/node/utils/interaction-utils-test.js
+++ b/test/node/utils/interaction-utils-test.js
@@ -140,7 +140,8 @@ test('interactionUtil -> getTooltipDisplayDeltaValue', t => {
     {
       input: {
         primaryData: dataset.dataContainer.row(0),
-        field: dataset.fields[testFieldIdx],
+        // field.displayFormat has been used to replace tooltipConfig.format
+        field: {...dataset.fields[testFieldIdx], displayFormat: item.format},
         compareType: COMPARE_TYPES.ABSOLUTE,
         data: dataset.dataContainer.row(1),
         fieldIdx: testFieldIdx,
@@ -152,7 +153,7 @@ test('interactionUtil -> getTooltipDisplayDeltaValue', t => {
     {
       input: {
         primaryData: dataset.dataContainer.row(0),
-        field: dataset.fields[testFieldIdx],
+        field: {...dataset.fields[testFieldIdx], displayFormat: item.format},
         compareType: COMPARE_TYPES.RELATIVE,
         data: dataset.dataContainer.row(1),
         fieldIdx: testFieldIdx,
@@ -164,7 +165,7 @@ test('interactionUtil -> getTooltipDisplayDeltaValue', t => {
     {
       input: {
         primaryData: dataset.dataContainer.row(3),
-        field: dataset.fields[testFieldIdx],
+        field: {...dataset.fields[testFieldIdx], displayFormat: item.format},
         compareType: COMPARE_TYPES.ABSOLUTE,
         data: dataset.dataContainer.row(1),
         fieldIdx: testFieldIdx,
@@ -176,7 +177,7 @@ test('interactionUtil -> getTooltipDisplayDeltaValue', t => {
     {
       input: {
         primaryData: dataset.dataContainer.row(0),
-        field: dataset.fields[testFieldIdx],
+        field: {...dataset.fields[testFieldIdx], displayFormat: item.format},
         compareType: COMPARE_TYPES.ABSOLUTE,
         data: dataset.dataContainer.row(3),
         fieldIdx: testFieldIdx,
@@ -188,7 +189,7 @@ test('interactionUtil -> getTooltipDisplayDeltaValue', t => {
     {
       input: {
         primaryData: dataset.dataContainer.row(4),
-        field: dataset.fields[testFieldIdx],
+        field: {...dataset.fields[testFieldIdx], displayFormat: item.format},
         compareType: COMPARE_TYPES.ABSOLUTE,
         data: dataset.dataContainer.row(3),
         fieldIdx: testFieldIdx,
@@ -230,7 +231,11 @@ test('interactionUtil -> getTooltipDisplayValue', t => {
   ];
 
   TEST_CASES.forEach(tc => {
-    const field = dataset.fields.find(f => f.name === tc.input.name);
+    // field.displayFormat has been used to replace tooltipConfig.format
+    const field = {
+      ...dataset.fields.find(f => f.name === tc.input.name),
+      displayFormat: tc.input.format
+    };
     const fieldIdx = dataset.fields.findIndex(f => f.name === tc.input.name);
 
     t.deepEqual(


### PR DESCRIPTION
Add a global “display formatter” that will be used to format the numeric and date-time values.

This global fomatter will be used as a “default formatter”, so users can set up and enable/disable the display format quickly. Besides, users will be able to customize the display format for each component on top of the global formatter (e.g. customize the display format for each column in the data table)

* Table View
  * User can set display format for all integer/float/date columns at once
  * User can overwrite display format for each column

* Tooltip
  * Use field.displayFormat instead of visState.interactionConfig.tooltips
  * User can overwrite display format for each field

