### PR TITLE
[feat] Convert layer order from idx to layer IDs

### DIFF
--- a/src/actions/src/vis-state-actions.ts
+++ b/src/actions/src/vis-state-actions.ts
@@ -408,7 +408,7 @@ export function addLayer(
 }
 
 export type ReorderLayerUpdaterAction = {
-  order: number[];
+  order: string[];
 };
 /**
  * Reorder layer, order is an array of layer indexes, index 0 will be the one at the bottom
@@ -418,12 +418,12 @@ export type ReorderLayerUpdaterAction = {
  * @public
  * @example
  *
- * // bring `layers[1]` below `layers[0]`, the sequence layers will be rendered is `1`, `0`, `2`, `3`.
- * // `1` will be at the bottom, `3` will be at the top.
- * this.props.dispatch(reorderLayer([1, 0, 2, 3]));
+ * bring `layers[1]` below `layers[0]`, the sequence layers will be rendered is `layers[1].id`, `layers[0].id`, `layers[2].id`, `layers[3].id`.
+ * `layers[1]` will be at the bottom, `layers[13]` will be at the top.
+ * this.props.dispatch(reorderLayer([`layers[1].id`, `layers[0].id`, `layers[2].id`, `layers[3].id`]));
  */
 export function reorderLayer(
-  order: number[]
+  order: string[]
 ): Merge<ReorderLayerUpdaterAction, {type: typeof ActionTypes.REORDER_LAYER}> {
   return {
     type: ActionTypes.REORDER_LAYER,
@@ -451,7 +451,7 @@ export function removeFilter(
 }
 
 export type RemoveLayerUpdaterAction = {
-  id: string | number;
+  id: string;
 };
 /**
  * Remove a layer
@@ -461,7 +461,7 @@ export type RemoveLayerUpdaterAction = {
  * @public
  */
 export function removeLayer(
-  id: string | number
+  id: string
 ): Merge<RemoveLayerUpdaterAction, {type: typeof ActionTypes.REMOVE_LAYER}> {
   return {
     type: ActionTypes.REMOVE_LAYER,
@@ -470,21 +470,21 @@ export function removeLayer(
 }
 
 export type DuplicateLayerUpdaterAction = {
-  idx: number;
+  id: string;
 };
 /**
  * Duplicate a layer
  * @memberof visStateActions
- * @param idx idx of layer to be duplicated
+ * @param id id of layer to be duplicated
  * @returns action
  * @public
  */
 export function duplicateLayer(
-  idx: number
+  id: string
 ): Merge<DuplicateLayerUpdaterAction, {type: typeof ActionTypes.DUPLICATE_LAYER}> {
   return {
     type: ActionTypes.DUPLICATE_LAYER,
-    idx
+    id
   };
 }
 

--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -491,13 +491,13 @@ function KeplerGlFactory(
       // update dndItems when layerOrder or layers change
       this.setState((state, props) => {
         const {
-          visState: {layers, layerOrder}
+          visState: {layerOrder}
         } = props;
 
         return {
           dndItems: {
             ...state.dndItems,
-            sortablelist: layerOrder.map(layerIdx => layers[layerIdx].id)
+            sortablelist: layerOrder
           }
         };
       });

--- a/src/components/src/side-panel/layer-manager.tsx
+++ b/src/components/src/side-panel/layer-manager.tsx
@@ -56,7 +56,7 @@ type OverlayBlendingSelectorProps = {
 type LayerManagerProps = {
   datasets: Datasets;
   layers: Layer[];
-  layerOrder: number[];
+  layerOrder: string[];
   layerClasses: LayerClassesType;
   layerBlending: string;
   overlayBlending: string;

--- a/src/components/src/side-panel/layer-panel/dataset-layer-group.tsx
+++ b/src/components/src/side-panel/layer-panel/dataset-layer-group.tsx
@@ -28,7 +28,7 @@ import {KeplerTable, Datasets} from '@kepler.gl/table';
 type DatasetLayerGroupProps = {
   datasets: Datasets;
   layers: Layer[];
-  layerOrder: number[];
+  layerOrder: string[];
   layerClasses: LayerClassesType;
   showDeleteDataset: boolean;
   removeDataset: ActionHandler<typeof UIStateActions.openDeleteModal>;

--- a/src/components/src/side-panel/layer-panel/dataset-layer-section.tsx
+++ b/src/components/src/side-panel/layer-panel/dataset-layer-section.tsx
@@ -31,7 +31,7 @@ type DatasetLayerSectionProps = {
   datasets: Datasets;
   dataset: KeplerTable;
   layers: Layer[];
-  layerOrder: number[];
+  layerOrder: string[];
   layerClasses: LayerClassesType;
   showDeleteDataset: boolean;
   showDatasetTable: ActionHandler<typeof VisStateActions.showDatasetTable>;

--- a/src/components/src/side-panel/layer-panel/layer-panel.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-panel.tsx
@@ -41,7 +41,6 @@ type LayerPanelProps = {
   onTouchStart?: TouchEventHandler;
   layer: Layer;
   datasets: Datasets;
-  idx: number;
   layerTypeOptions: {
     id: string;
     label: string;
@@ -133,12 +132,12 @@ function LayerPanelFactory(
 
     _removeLayer: MouseEventHandler = e => {
       e.stopPropagation();
-      this.props.removeLayer(this.props.idx);
+      this.props.removeLayer(this.props.layer.id);
     };
 
     _duplicateLayer: MouseEventHandler = e => {
       e.stopPropagation();
-      this.props.duplicateLayer(this.props.idx);
+      this.props.duplicateLayer(this.props.layer.id);
     };
 
     render() {

--- a/src/components/src/types.ts
+++ b/src/components/src/types.ts
@@ -27,7 +27,7 @@ export type SidePanelProps = {
   overlayBlending: string;
   layers: Layer[];
   layerClasses: LayerClassesType;
-  layerOrder: number[];
+  layerOrder: string[];
   mapStyle: MapStyle;
   onSaveMap?: () => void;
   width: number;

--- a/src/reducers/src/composer-helpers.ts
+++ b/src/reducers/src/composer-helpers.ts
@@ -66,10 +66,14 @@ export function swap_<X extends {id: string}>(item: X): (arr: X[]) => X[] {
   return arr => arr.map(a => (a.id === item.id ? item : a));
 }
 
-export function findById<X extends {id: string}>(id: string): (arr: X[]) => X | undefined {
-  return arr => arr.find(a => a.id === id);
+export function map_<X, T>(fn: (state: X) => T): (arr: X[]) => T[] {
+  return arr => arr.map(e => fn(e));
 }
 
-export function map_<X>(fn: (state: X) => X): (arr: X[]) => X[] {
-  return arr => arr.map(e => fn(e));
+export function filterOutById<X extends {id: string}>(id: string): (arr: X[]) => X[] {
+  return arr => arr.filter(e => e.id !== id);
+}
+
+export function removeElementAtIndex<X>(index: number): (arr: X[]) => X[] {
+  return arr => [...arr.slice(0, index), ...arr.slice(index + 1, arr.length)];
 }

--- a/src/reducers/src/vis-state-merger.ts
+++ b/src/reducers/src/vis-state-merger.ts
@@ -25,8 +25,10 @@ import {
   arrayInsert,
   getInitialMapLayersForSplitMap,
   applyFiltersToDatasets,
-  validateFiltersUpdateDatasets
+  validateFiltersUpdateDatasets,
+  findById
 } from '@kepler.gl/utils';
+import {getLayerOrderFromLayers} from '@kepler.gl/reducers';
 
 import {LayerColumns, LayerColumn, Layer} from '@kepler.gl/layers';
 import {LAYER_BLENDINGS, OVERLAY_BLENDINGS} from '@kepler.gl/constants';
@@ -122,7 +124,7 @@ export function parseLayerConfig(
   const savedConfig = {
     version: CURRENT_VERSION,
     config: {
-      visState: {layers: [layerConfig], layerOrder: [0]}
+      visState: {layers: [layerConfig], layerOrder: [layerConfig.id]}
     }
   };
 
@@ -191,7 +193,10 @@ export function serializeLayer(
   newLayer: Layer,
   schema: KeplerGLSchemaClass
 ): ParsedLayer | undefined {
-  const serializedVisState = serializeVisState({layers: [newLayer], layerOrder: [0]}, schema);
+  const serializedVisState = serializeVisState(
+    {layers: [newLayer], layerOrder: [newLayer.id]},
+    schema
+  );
   return serializedVisState?.layers?.[0];
 }
 
@@ -217,7 +222,9 @@ export function mergeLayers<S extends VisState>(
   layersToMerge: NonNullable<ParsedConfig['visState']>['layers'] = [],
   fromConfig?: boolean
 ): S {
-  const preserveLayerOrder = fromConfig ? layersToMerge.map(l => l.id) : state.preserveLayerOrder;
+  const preserveLayerOrder = fromConfig
+    ? getLayerOrderFromLayers(layersToMerge)
+    : state.preserveLayerOrder;
   if (!Array.isArray(layersToMerge) || !layersToMerge.length) {
     return state;
   }
@@ -265,9 +272,10 @@ export function insertLayerAtRightOrder(
     return {newLayers: currentLayers, newLayerOrder: currentOrder};
   }
   // perservedOrder ['a', 'b', 'c'];
-  // layerOrder [1, 0, 3]
-  // layerOrderMap ['a', 'c']
-  const currentLayerQueue = currentOrder.map(i => currentLayers[i]);
+  // layerOrder ['a', 'b', 'c']
+  const currentLayerQueue = currentOrder
+    .map(id => findById(id)(currentLayers))
+    .filter(layer => Boolean(layer));
   const newLayers = currentLayers.concat(layersToInsert);
   const newLayerOrderQueue = insertItemBasedOnPreservedOrder(
     currentLayerQueue,
@@ -277,7 +285,7 @@ export function insertLayerAtRightOrder(
   );
 
   // reconstruct layerOrder after insert
-  const newLayerOrder = newLayerOrderQueue.map(lyr => newLayers.findIndex(l => l.id === lyr.id));
+  const newLayerOrder = getLayerOrderFromLayers(newLayerOrderQueue);
 
   return {
     newLayerOrder,

--- a/src/schemas/src/vis-state-schema.ts
+++ b/src/schemas/src/vis-state-schema.ts
@@ -21,11 +21,11 @@
 import pick from 'lodash.pick';
 import {VERSIONS} from './versions';
 import {LAYER_VIS_CONFIGS, FILTER_VIEW_TYPES} from '@kepler.gl/constants';
-import {AddDataToMapOptions} from '@kepler.gl/types';
-import {isFilterValidToSave, notNullorUndefined} from '@kepler.gl/utils';
+import {isFilterValidToSave, notNullorUndefined, findById} from '@kepler.gl/utils';
 import Schema from './schema';
 import cloneDeep from 'lodash.clonedeep';
 import {
+  AddDataToMapOptions,
   AnimationConfig,
   Editor,
   FileLoading,
@@ -67,7 +67,7 @@ export interface VisState {
   layers: Layer[];
   layerData: any[];
   layerToBeMerged: any[];
-  layerOrder: number[];
+  layerOrder: string[];
   filters: Filter[];
   filterToBeMerged: any[];
   datasets: Datasets;
@@ -571,10 +571,10 @@ export class LayerSchemaV0 extends Schema {
     const [visState] = parents.slice(-1);
 
     return {
-      [this.key as 'layers']: visState.layerOrder.reduce((saved, index) => {
+      [this.key as 'layers']: visState.layerOrder.reduce((saved, layerId) => {
         // save layers according to their rendering order
-        const layer = layers[index];
-        if (layer.isValidToSave()) {
+        const layer = findById<Layer>(layerId)(layers);
+        if (layer?.isValidToSave()) {
           saved.push(this.savePropertiesOrApplySchema(layer).layers);
         }
         return saved;

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -141,7 +141,8 @@ export {
   filterObjectByPredicate,
   isFunction,
   hasMobileWidth,
-  hasPortableWidth
+  hasPortableWidth,
+  findById
 } from './utils';
 export {
   addNewLayersToSplitMap,

--- a/src/utils/src/utils.ts
+++ b/src/utils/src/utils.ts
@@ -211,3 +211,18 @@ export function filterObjectByPredicate(obj, predicate) {
 export function isFunction(func) {
   return typeof func === 'function';
 }
+
+export function findById<X extends {id: string}>(id: string): (arr: X[]) => X | undefined {
+  return arr => arr.find(a => a.id === id);
+}
+
+/**
+ * Returns array difference from
+ */
+export function arrayDifference<X extends {id: string}>(origin: X[]): (compare: X[]) => X[] {
+  return compare =>
+    origin.reduce((acc, element) => {
+      const foundElement = findById<X>(element.id)(compare);
+      return foundElement ? [...acc, foundElement] : acc;
+    }, [] as X[]);
+}

--- a/test/helpers/layer-utils.js
+++ b/test/helpers/layer-utils.js
@@ -240,12 +240,15 @@ function testAttributeUpdate(t, attributeValues, layer, shouldUpdate) {
 export function renderLayerByState(t, state, layerManager) {
   const layerCallbacks = () => {};
   const layer = state.visState.layers[0];
+  const data = state.visState.layerData[0];
 
   let layerOverlay;
   t.doesNotThrow(() => {
     layerOverlay = renderDeckGlLayer(
       {
         ...state.visState,
+        layer,
+        data,
         mapState: state.mapState
       },
       layerCallbacks,

--- a/test/helpers/mock-state.js
+++ b/test/helpers/mock-state.js
@@ -116,11 +116,16 @@ export function mockStateWithFileUpload() {
   drainTasksForTesting();
   // replace layer id and color with controlled value for testing
   updatedState.visState.layers.forEach((l, i) => {
+    const oldLayerId = l.id;
     l.id = `${l.type}-${i}`;
     l.config.color = [i, i, i];
     if (l.config.visConfig.strokeColor) {
       l.config.visConfig.strokeColor = [i + 10, i + 10, i + 10];
     }
+    // update layerOrder with newly created IDs
+    updatedState.visState.layerOrder = updatedState.visState.layerOrder.map(layerId =>
+      layerId === oldLayerId ? l.id : layerId
+    );
   });
 
   test(t => {
@@ -144,8 +149,13 @@ function mockStateWithTripGeojson() {
 
   // replace layer id and color with controlled value for testing
   updatedState.visState.layers.forEach((l, i) => {
+    const oldLayerId = l.id;
     l.id = `${l.type}-${i}`;
     l.config.color = [i, i, i];
+    // update layerOrder with newly created IDs
+    updatedState.visState.layerOrder = updatedState.visState.layerOrder.map(layerId =>
+      layerId === oldLayerId ? l.id : layerId
+    );
   });
 
   return updatedState;
@@ -409,7 +419,7 @@ export function mockStateWithLayerDimensions(state) {
     }
   ]);
 
-  const reorderPayload = [[2, 0, 1]];
+  const reorderPayload = [['hexagon-2', 'point-0', 'geojson-1']];
 
   const resultState = applyActions(keplerGlReducer, prepareState, [
     // reorder Layer

--- a/test/node/reducers/composer-state-test.js
+++ b/test/node/reducers/composer-state-test.js
@@ -206,6 +206,8 @@ test('#composerStateReducer - addDataToMapUpdater: keepExistingConfig', t => {
     }
   });
 
+  t.deepEqual(nextState1.visState.layerOrder, ['avlgol'], 'Should contain nextState1 layer order');
+
   cmpDataset(t, expectedMergedDataset, nextState1.visState.datasets[hexDataId]);
 
   t.deepEqual(nextState1.visState.splitMaps, [], 'should clear out splitMaps');
@@ -231,8 +233,9 @@ test('#composerStateReducer - addDataToMapUpdater: keepExistingConfig', t => {
 
   const actualVisState = nextState2.visState;
 
+  const newLayers = [...oldLayers, mergedH3Layer];
   const expectedVisState = {
-    layers: [...oldLayers, mergedH3Layer],
+    layers: newLayers,
     filters: [...oldFilters, ...mergedFilters],
     datasets: 'test seperate',
     interactionConfig: {
@@ -272,7 +275,7 @@ test('#composerStateReducer - addDataToMapUpdater: keepExistingConfig', t => {
         }
       }
     ],
-    layerOrder: [2, 0, 1]
+    layerOrder: [newLayers[2].id, newLayers[0].id, newLayers[1].id]
   };
 
   cmpLayers(t, expectedVisState.layers, actualVisState.layers);

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -280,7 +280,7 @@ test('#visStateReducer -> ADD_LAYER.1', t => {
     },
     layers: [{id: 'existing_layer'}],
     layerData: [[{data: [1, 2, 3]}, {data: [4, 5, 6]}]],
-    layerOrder: [0],
+    layerOrder: ['existing_layer'],
     splitMaps: [
       {
         layers: {existing_layer: false}
@@ -321,7 +321,11 @@ test('#visStateReducer -> ADD_LAYER.1', t => {
     [oldState.layerData[0], {}],
     'newState should have empty layer datat'
   );
-  t.deepEqual(newReducer.layerOrder, [1, 0], 'should add to layerOrder');
+  t.deepEqual(
+    newReducer.layerOrder,
+    [newReducer.layers[1].id, newReducer.layers[0].id],
+    'should add to layerOrder'
+  );
   t.deepEqual(newReducer.splitMaps, expectedSplitMaps, 'should add to SplitMaps');
 
   t.end();
@@ -356,7 +360,7 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.1', t => {
     },
     layers: [{id: 'existing_layer'}, layer],
     layerData: [[{data: [1, 2, 3]}, {data: [4, 5, 6]}]],
-    layerOrder: [1, 0],
+    layerOrder: ['more_layer', 'existing_layer'],
     hoverInfo: {
       layer: {props: {id: 'more_layer'}},
       picked: true
@@ -1075,7 +1079,7 @@ test('#visStateReducer -> REMOVE_LAYER', t => {
   const oldState = {
     layers: [layer1, layer2],
     layerData: [{data: 1}, {data: 2}],
-    layerOrder: [1, 0],
+    layerOrder: ['b', 'a'],
     hoverInfo: {
       layer: {props: {id: 'b'}},
       picked: true
@@ -1095,7 +1099,7 @@ test('#visStateReducer -> REMOVE_LAYER', t => {
     {
       layers: [layer1],
       layerData: [{data: 1}],
-      layerOrder: [0],
+      layerOrder: ['a'],
       hoverInfo: undefined,
       clicked: {
         layer: {props: {id: 'a'}},
@@ -1116,7 +1120,11 @@ test('#visStateReducer -> DUPLICATE_LAYER', t => {
   // layers: ['point-0', 'geojson-1', 'hexagon-2'],
   const layerToCopy = serializeLayer(oldState.layers[0], oldState.schema);
   t.equal(oldState.layers.length, 3, 'should have 3 layers to begin');
-  t.deepEqual(oldState.layerOrder, [2, 0, 1], 'should have 3 layers to begin');
+  t.deepEqual(
+    oldState.layerOrder,
+    [oldState.layers[2].id, oldState.layers[0].id, oldState.layers[1].id],
+    'should have 3 layers to begin'
+  );
 
   const nextState = reducer(oldState, VisStateActions.duplicateLayer(0));
   t.equal(nextState.layers.length, 4, 'should add 1 layer');
@@ -1139,7 +1147,12 @@ test('#visStateReducer -> DUPLICATE_LAYER', t => {
   );
   t.deepEqual(
     nextState.layerOrder,
-    [2, 3, 0, 1],
+    [
+      nextState.layers[2].id,
+      nextState.layers[3].id,
+      nextState.layers[0].id,
+      nextState.layers[1].id
+    ],
     'should insert copied layer in front of older layer'
   );
 
@@ -1164,7 +1177,13 @@ test('#visStateReducer -> DUPLICATE_LAYER', t => {
   );
   t.deepEqual(
     nextState1.layerOrder,
-    [2, 3, 4, 0, 1],
+    [
+      nextState1.layers[2].id,
+      nextState1.layers[3].id,
+      nextState1.layers[4].id,
+      nextState1.layers[0].id,
+      nextState1.layers[1].id
+    ],
     'should insert copied layer in front of older layer'
   );
 
@@ -1186,175 +1205,6 @@ test('#visStateReducer -> DUPLICATE_LAYER', t => {
   // test remove
   t.end();
 });
-
-// TODO: not sure if this test is correct, it basically checks if the loaded visState is empty
-// if we load configuration through the schema manager all layers will be changing from having visualChannels to visualConfig
-// test('#visStateReducer -> SERIALIZE', t => {
-//   const configuration = {
-//     version: 'v1',
-//     config: {
-//       visState: {
-//         filters: [
-//           {
-//             dataId: ['earthquakes'],
-//             id: 'vo18yorx',
-//             name: ['DateTime'],
-//             type: 'timeRange',
-//             value: [663046722470, 1301519405470],
-//             enlarged: true,
-//             plotType: 'histogram',
-//             animationWindow: 'free',
-//             yAxis: null,
-//             speed: 1
-//           }
-//         ],
-//         layers: [
-//           {
-//             id: 'hty62yd',
-//             type: 'point',
-//             config: {
-//               dataId: 'earthquakes',
-//               label: 'Point',
-//               color: [23, 184, 190],
-//               highlightColor: [252, 242, 26, 255],
-//               columns: {
-//                 lat: 'Latitude',
-//                 lng: 'Longitude',
-//                 altitude: null
-//               },
-//               isVisible: true,
-//               visConfig: {
-//                 radius: 10,
-//                 fixedRadius: false,
-//                 opacity: 0.39,
-//                 outline: false,
-//                 thickness: 2,
-//                 strokeColor: [23, 184, 190],
-//                 colorRange: {
-//                   name: 'ColorBrewer PRGn-6',
-//                   type: 'diverging',
-//                   category: 'ColorBrewer',
-//                   colors: ['#762a83', '#af8dc3', '#e7d4e8', '#d9f0d3', '#7fbf7b', '#1b7837'],
-//                   reversed: false
-//                 },
-//                 strokeColorRange: {
-//                   name: 'ColorBrewer PRGn-6',
-//                   type: 'diverging',
-//                   category: 'ColorBrewer',
-//                   colors: ['#762a83', '#af8dc3', '#e7d4e8', '#d9f0d3', '#7fbf7b', '#1b7837'],
-//                   reversed: false
-//                 },
-//                 radiusRange: [4.2, 96.2],
-//                 filled: true
-//               },
-//               hidden: false,
-//               textLabel: [
-//                 {
-//                   field: null,
-//                   color: [255, 255, 255],
-//                   size: 18,
-//                   offset: [0, 0],
-//                   anchor: 'start',
-//                   alignment: 'center'
-//                 }
-//               ]
-//             },
-//             visualChannels: {
-//               colorField: {
-//                 name: 'Magnitude',
-//                 type: 'real'
-//               },
-//               colorScale: 'quantize',
-//               strokeColorField: null,
-//               strokeColorScale: 'quantile',
-//               sizeField: {
-//                 name: 'Magnitude',
-//                 type: 'real'
-//               },
-//               sizeScale: 'sqrt'
-//             }
-//           }
-//         ],
-//         interactionConfig: {
-//           tooltip: {
-//             fieldsToShow: {
-//               earthquakes: [
-//                 {
-//                   name: 'DateTime',
-//                   format: null
-//                 },
-//                 {
-//                   name: 'Latitude',
-//                   format: null
-//                 },
-//                 {
-//                   name: 'Longitude',
-//                   format: null
-//                 },
-//                 {
-//                   name: 'Depth',
-//                   format: null
-//                 },
-//                 {
-//                   name: 'Magnitude',
-//                   format: null
-//                 }
-//               ]
-//             },
-//             compareMode: false,
-//             compareType: 'absolute',
-//             enabled: true
-//           },
-//           brush: {
-//             size: 0.5,
-//             enabled: false
-//           },
-//           geocoder: {
-//             enabled: false
-//           },
-//           coordinate: {
-//             enabled: false
-//           }
-//         },
-//         layerBlending: 'normal',
-//         splitMaps: [],
-//         animationConfig: {
-//           currentTime: null,
-//           speed: 1
-//         }
-//       },
-//       mapState: {
-//         bearing: 0,
-//         dragRotate: false,
-//         latitude: 37.05881309947238,
-//         longitude: -122.80009283836715,
-//         pitch: 0,
-//         zoom: 5.740491857794806,
-//         isSplit: false
-//       },
-//       mapStyle: {
-//         styleType: 'light',
-//         topLayerGroups: {},
-//         visibleLayerGroups: {
-//           border: false,
-//           building: true,
-//           label: true,
-//           land: true,
-//           road: true,
-//           water: true
-//         },
-//         threeDBuildingColor: [9.665468314072013, 17.18305478057247, 31.1442867897876],
-//         mapStyles: {}
-//       }
-//     }
-//   };
-//
-//   const loadedVisState = visStateSchema[CURRENT_VERSION].load(configuration.config.visState);
-//
-//   t.deepEqual(loadedVisState, {}, 'Should have the same configuration');
-//
-//   t.end();
-// });
 
 test('#visStateReducer -> UPDATE_VIS_DATA.1 -> No data', t => {
   const oldState = CloneDeep(InitialState).visState;
@@ -1523,7 +1373,11 @@ test('#visStateReducer -> UPDATE_VIS_DATA.2 -> to empty state', t => {
   cmpLayers(t, expectedLayers, newStateLayers);
 
   t.equal(newState.layerData.length, expectedLayers.length, 'should calculate layerdata');
-  t.deepEqual(newState.layerOrder, [0, 1, 2, 3], 'should calculate layerOrder');
+  t.deepEqual(
+    newState.layerOrder,
+    [newStateLayers[0].id, newStateLayers[1].id, newStateLayers[2].id, newStateLayers[3].id],
+    'should calculate layerOrder'
+  );
 
   t.end();
 });
@@ -1578,7 +1432,7 @@ test('#visStateReducer -> UPDATE_VIS_DATA.3 -> merge w/ existing state', t => {
         }
       }
     },
-    layerOrder: [0],
+    layerOrder: [mockLayer.id],
     layerBlending: 'additive',
     splitMaps: []
   };
@@ -1644,7 +1498,13 @@ test('#visStateReducer -> UPDATE_VIS_DATA.3 -> merge w/ existing state', t => {
   t.equal(newState.layers.length, 5, 'should find 1 arc aline and 2 point layers');
   t.deepEqual(
     newState.layerOrder,
-    [1, 2, 3, 4, 0],
+    [
+      newState.layers[1].id,
+      newState.layers[2].id,
+      newState.layers[3].id,
+      newState.layers[4].id,
+      newState.layers[0].id
+    ],
     'should add new layer index to layer order, put them on top'
   );
   t.equal(newState.layers[1].config.dataId, 'smoothie', 'should save dataId to layer');
@@ -1963,14 +1823,6 @@ test('#visStateReducer -> UPDATE_VIS_DATA -> mergeFilters', t => {
     datasets: expectedDatasets
   };
 
-  // cmpFilters(t, expectedState.filters, newState.filters);
-  //
-  // t.deepEqual(
-  //   newState.filterToBeMerged,
-  //   expectedState.filterToBeMerged,
-  //   'should saved unmerged filter to filterToBeMerged'
-  // );
-
   cmpDatasets(t, expectedState.datasets, newState.datasets);
 
   t.end();
@@ -2001,6 +1853,8 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
     isVisible: false
   });
 
+  const layers = [layer0, layer1, layer2, layer3];
+
   const oldState = {
     ...INITIAL_VIS_STATE,
     layers: [layer0, layer1, layer2, layer3],
@@ -2028,7 +1882,7 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
       }
     },
     layerData: [],
-    layerOrder: [2, 1, 0, 3]
+    layerOrder: [layers[2].id, layers[1].id, layers[0].id, layers[3].id]
   };
 
   const newState = reducer(
@@ -2061,7 +1915,20 @@ test('#visStateReducer -> UPDATE_VIS_DATA.SPLIT_MAPS', t => {
   ];
 
   t.equal(newState.layers.length, 8, 'should create 1 arc 1 line and 2 point layers');
-  t.deepEqual(newState.layerOrder, [4, 5, 6, 7, 2, 1, 0, 3], 'should move new layers to front');
+  t.deepEqual(
+    newState.layerOrder,
+    [
+      newState.layers[4].id,
+      newState.layers[5].id,
+      newState.layers[6].id,
+      newState.layers[7].id,
+      newState.layers[2].id,
+      newState.layers[1].id,
+      newState.layers[0].id,
+      newState.layers[3].id
+    ],
+    'should move new layers to front'
+  );
   t.deepEqual(newState.splitMaps, expectedSplitMaps, 'should add new layers to split maps');
 
   t.end();
@@ -2100,7 +1967,7 @@ test('#visStateReducer -> setFilter.dynamicDomain & cpu', t => {
 
   const expectedLayers = [expectedLayer1];
   // test default layer
-  t.equal(initialState.layers.length, 1, 'should find two layers');
+  t.equal(initialState.layers.length, 1, 'should find one layer');
 
   cmpLayers(t, expectedLayers, initialState.layers);
 
@@ -3008,7 +2875,7 @@ test('#visStateReducer -> REMOVE_DATASET w filter and layer', t => {
     layers: [oldState.layers[1]],
     filters: [oldState.filters[1]],
     layerData: [oldState.layerData[1]],
-    layerOrder: [0],
+    layerOrder: [oldState.layers[1].id],
     datasets: {
       [testGeoJsonDataId]: oldState.datasets[testGeoJsonDataId]
     },
@@ -3124,10 +2991,11 @@ test('#visStateReducer -> SPLIT_MAP: TOGGLE', t => {
 test('#visStateReducer -> SPLIT_MAP: REMOVE_LAYER', t => {
   const layer1 = new PointLayer({id: 'a'});
   const layer2 = new PointLayer({id: 'b'});
+  const layers = [layer1, layer2];
   const oldState = {
-    layers: [layer1, layer2],
+    layers,
     layerData: [{data: 1}, {data: 2}],
-    layerOrder: [1, 0],
+    layerOrder: [layers[1].id, layers[0].id],
     hoverInfo: {
       layer: {props: {id: 'b'}},
       picked: true
@@ -3160,7 +3028,7 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_LAYER', t => {
     {
       layers: [layer1],
       layerData: [{data: 1}],
-      layerOrder: [0],
+      layerOrder: [layer1.id],
       hoverInfo: undefined,
       clicked: {
         layer: {props: {id: 'a'}},
@@ -3253,11 +3121,10 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_DATASET', t => {
   const expectedState = {
     layers: [oldState.layers[0]],
     layerData: [oldState.layerData[0]],
-    layerOrder: [0],
+    layerOrder: [oldState.layers[0].id],
     datasets: {
       [testCsvDataId]: oldState.datasets[testCsvDataId]
     },
-
     filters: [],
     interactionConfig: {
       tooltip: {
@@ -5377,7 +5244,7 @@ test('VisStateUpdater -> prepareStateForDatasetReplace', t => {
   t.deepEqual(nextState.filterToBeMerged[0].dataId, [dataIdToUse], 'should replace filter dataId');
 
   // preserveLayerOrder
-  t.deepEqual(nextState.layerOrder, [0], 'should remove layer from layer order');
+  t.deepEqual(nextState.layerOrder, ['geojson-1'], 'should remove layer from layer order');
   t.deepEqual(
     nextState.preserveLayerOrder,
     ['geojson-1', 'point-0'],

--- a/test/node/utils/composer-helpers-test.js
+++ b/test/node/utils/composer-helpers-test.js
@@ -18,24 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import './data-utils-test';
-import './data-processor-test';
-import './kepler-table-test';
-import './data-container-test';
-import './filter-utils-test';
-import './gpu-filter-utils-test';
-import './layer-utils-test';
-import './data-scale-utils-test';
-import './interaction-utils-test';
-import './mapbox-gl-style-editor-test';
-import './mapbox-utils-test';
-import './notifications-utils-test';
-import './aggregate-utils-test';
-import './color-util-test';
-import './util-test';
-import './export-utils-test';
-import './s2-utils-test';
-import './editor-utils-test';
-import './kepler-gl-utils-test';
-import './timeline-test';
-import './composer-helpers-test';
+import test from 'tape';
+import {filterOutById, removeElementAtIndex} from '@kepler.gl/reducers';
+
+test('#composeHelpers -> RemoveElementAtIndex', t => {
+  const list = [1, 2, 3, 4, 5];
+  t.deepEqual(removeElementAtIndex(1)(list), [1, 3, 4, 5], 'Should remove element at index');
+  t.end();
+});
+
+test('#composeHelpers -> filterOutById', t => {
+  const list = [{id: 1}, {id: 2}, {id: 3}];
+  t.deepEqual(filterOutById(1)(list), [{id: 2}, {id: 3}], 'Should remove element with specific id');
+  t.end();
+});

--- a/test/node/utils/layer-utils-test.js
+++ b/test/node/utils/layer-utils-test.js
@@ -23,7 +23,7 @@ import cloneDeep from 'lodash.clonedeep';
 import {processCsvData, processGeojson} from '@kepler.gl/processors';
 import {LayerClasses, KeplerGlLayers} from '@kepler.gl/layers';
 import {GEOJSON_FIELDS} from '@kepler.gl/constants';
-import {findDefaultLayer, getLayerHoverProp} from '@kepler.gl/reducers';
+import {findDefaultLayer, getLayerHoverProp, getLayerOrderFromLayers} from '@kepler.gl/reducers';
 import {StateWTripGeojson, StateWFiles} from 'test/helpers/mock-state';
 
 const {PointLayer, ArcLayer, GeojsonLayer, LineLayer} = KeplerGlLayers;
@@ -925,5 +925,13 @@ test('layerUtils -> getLayerHoverProp', t => {
 
   t.deepEqual(getLayerHoverProp(args), null, 'should get correct layerHoverProp');
 
+  t.end();
+});
+
+test('layerUtils -> getLayerOrderFromLayers', t => {
+  const visState = cloneDeep(StateWFiles).visState;
+  const layerOrder = getLayerOrderFromLayers(visState.layers);
+
+  t.deepEqual(layerOrder, ['point-0', 'geojson-1'], 'Should generate layerOrder correctly');
   t.end();
 });


### PR DESCRIPTION
- converts visState.layerOrder from storing layer indexes to layer IDs
- merge layers can read existing map configuration with layerOrder indexes and load them into layer Ids