### PR TITLE
[Enhancement] Allow empty column when layer created from config

### DIFF
--- a/src/reducers/src/vis-state-merger.ts
+++ b/src/reducers/src/vis-state-merger.ts
@@ -170,9 +170,12 @@ export function createLayerFromConfig(state: VisState, layerConfig: any): Layer 
     return null;
   }
   // first validate config against dataset
-  const {validated, failed} = validateLayersByDatasets(state.datasets, state.layerClasses, [
-    parsedLayerConfig
-  ]);
+  const {validated, failed} = validateLayersByDatasets(
+    state.datasets,
+    state.layerClasses,
+    [parsedLayerConfig],
+    {allowEmptyColumn: true}
+  );
 
   if (failed?.length || !validated.length) {
     // failed
@@ -657,10 +660,15 @@ export function validateSavedVisualChannels(
   return newLayer;
 }
 
+type ValidateLayerOption = {
+  allowEmptyColumn?: boolean;
+};
+
 export function validateLayersByDatasets(
   datasets: Datasets,
   layerClasses: VisState['layerClasses'],
-  layers: NonNullable<ParsedConfig['visState']>['layers'] = []
+  layers: NonNullable<ParsedConfig['visState']>['layers'] = [],
+  options?: ValidateLayerOption
 ) {
   const validated: Layer[] = [];
   const failed: NonNullable<ParsedConfig['visState']>['layers'] = [];
@@ -671,7 +679,12 @@ export function validateLayersByDatasets(
     if (layer?.config?.dataId) {
       if (datasets[layer.config.dataId]) {
         // datasets are already loaded
-        validateLayer = validateLayerWithData(datasets[layer.config.dataId], layer, layerClasses);
+        validateLayer = validateLayerWithData(
+          datasets[layer.config.dataId],
+          layer,
+          layerClasses,
+          options
+        );
       }
     }
 
@@ -693,9 +706,7 @@ export function validateLayerWithData(
   {fields, id: dataId}: KeplerTable,
   savedLayer: ParsedLayer,
   layerClasses: VisState['layerClasses'],
-  options: {
-    allowEmptyColumn?: boolean;
-  } = {}
+  options: ValidateLayerOption = {}
 ): Layer | null {
   const {type} = savedLayer;
   // layer doesnt have a valid type

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -5414,3 +5414,41 @@ test('VisStateUpdater -> prepareStateForDatasetReplace', t => {
 
   t.end();
 });
+
+test('VisStateUpdater -> addLayer with empty column', t => {
+  const initialState = StateWFiles.visState;
+  const oldLayers = initialState.layers;
+  let nextState;
+  t.doesNotThrow(() => {
+    nextState = reducer(
+      initialState,
+      VisStateActions.addLayer({
+        type: 'point',
+        id: 'taro-xxx',
+        config: {
+          dataId: testCsvDataId
+          // no column
+        }
+      })
+    );
+  }, 'should not throw error when add layer with empty column');
+
+  t.equal(nextState.layers.length, oldLayers.length + 1, 'should create 1 layer');
+  const newLayer = nextState.layers[nextState.layers.length - 1];
+
+  t.equal(newLayer.id, 'taro-xxx', 'newlayer should have correct id');
+  t.equal(newLayer.type, 'point', 'newlayer should have correct type');
+  t.deepEqual(
+    newLayer.config.columns.lat,
+    {value: null, fieldIdx: -1},
+    'newlayer column should be value: null'
+  );
+
+  t.deepEqual(
+    nextState.layerData[nextState.layerData.length - 1],
+    {},
+    'newlayer layerData should be empty'
+  );
+
+  t.end();
+});


### PR DESCRIPTION
- when user create a layer by calling addLayer(config), kepler will allow columns to be undefined