### PR TITLE
[Fix] vis state schema column save undefined typeerror

### DIFF
--- a/src/schemas/src/vis-state-schema.ts
+++ b/src/schemas/src/vis-state-schema.ts
@@ -382,7 +382,8 @@ class ColumnSchemaV1 extends Schema {
       [this.key]: Object.keys(columns).reduce(
         (accu, ckey) => ({
           ...accu,
-          [ckey]: columns[ckey].value
+          // if value is null, don't save it
+          ...(columns[ckey]?.value ? {[ckey]: columns[ckey].value} : {})
         }),
         {}
       )

--- a/test/helpers/mock-state.js
+++ b/test/helpers/mock-state.js
@@ -684,8 +684,7 @@ export const expectedSavedLayer1 = {
     color: [0, 0, 0],
     columns: {
       lat: 'gps_data.lat',
-      lng: 'gps_data.lng',
-      altitude: null
+      lng: 'gps_data.lng'
     },
     textLabel: [
       {
@@ -740,8 +739,7 @@ export const expectedLoadedLayer1 = {
     color: [0, 0, 0],
     columns: {
       lat: 'gps_data.lat',
-      lng: 'gps_data.lng',
-      altitude: null
+      lng: 'gps_data.lng'
     },
     hidden: false,
     isVisible: true,


### PR DESCRIPTION
- check for column existence to avoid TypeError: Cannot read properties of undefined (reading 'value')