### PR TITLE
[Bug] preserveLayerOrder when replace data

### DIFF
--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -286,6 +286,7 @@ export const geoCoderPanelSelector = (
   mapboxApiAccessToken: props.mapboxApiAccessToken,
   mapState: props.mapState,
   uiState: props.uiState,
+  layerOrder: props.visState.layerOrder,
   updateVisData: props.visStateActions.updateVisData,
   removeDataset: props.visStateActions.removeDataset,
   updateMap: props.mapStateActions.updateMap,

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -2723,6 +2723,8 @@ export function prepareStateForDatasetReplace<T extends VisState>(
 ): T {
   const serializedState = serializeVisState(state, state.schema);
   const nextState = replaceDatasetAndDeps(state, dataId, dataIdToUse);
+  // make a copy of layerOrder, because layer id will be removed from it by calling removeLayerUpdater
+  const preserveLayerOrder = [...state.layerOrder];
 
   // preserve dataset order
   nextState.preserveDatasetOrder = Object.keys(state.datasets).map(d =>
@@ -2733,6 +2735,7 @@ export function prepareStateForDatasetReplace<T extends VisState>(
   if (nextState.layerToBeMerged?.length) {
     // copy split maps to be merged, because it will be reset in remove layer
     nextState.splitMapsToBeMerged = serializedState?.splitMaps ?? [];
+    nextState.layerOrder = [...preserveLayerOrder];
   }
 
   return nextState;

--- a/test/browser/components/geocoder-panel-test.js
+++ b/test/browser/components/geocoder-panel-test.js
@@ -43,7 +43,7 @@ test('GeocoderPanel - render', t => {
     width: 800,
     height: 800
   };
-
+  const layerOrder = ['layer_1', 'layer_2'];
   const mockUiState = InitialState.uiState;
 
   const mockGeoItem = {
@@ -139,7 +139,8 @@ test('GeocoderPanel - render', t => {
               }
             }
           }
-        ]
+        ],
+        layerOrder: ['geocoder_layer', 'layer_1', 'layer_2']
       }
     }
   ];
@@ -157,6 +158,7 @@ test('GeocoderPanel - render', t => {
           updateVisData={updateVisData}
           removeDataset={removeDataset}
           updateMap={updateMap}
+          layerOrder={layerOrder}
         />
       </IntlWrapper>
     );

--- a/test/node/reducers/composer-state-test.js
+++ b/test/node/reducers/composer-state-test.js
@@ -492,3 +492,50 @@ test('#composerStateReducer - replaceDataInMapUpdater', t => {
   t.deepEqual(nextState.visState.splitMapsToBeMerged, [], 'should reset splitMapsToBeMerged');
   t.end();
 });
+
+test('#composerStateReducer - replaceDataInMapUpdater: same dataId', t => {
+  const datasets = {
+    data: processCsvData(testCsvData),
+    info: {
+      id: sampleConfig.dataId
+    }
+  };
+  const datasetToUse = {
+    data: processCsvData(dataWithNulls),
+    info: {
+      id: sampleConfig.dataId
+    }
+  };
+  const state = keplerGlReducer({}, registerEntry({id: 'test'})).test;
+
+  // old state contain splitMaps
+  const oldState = addDataToMapUpdater(state, {
+    payload: {
+      datasets,
+      config: sampleConfig.config
+    }
+  });
+
+  const oldSavedConfig = state.visState.schema.getConfigToSave(oldState).config;
+
+  const nextState = replaceDataInMapUpdater(oldState, {
+    payload: {
+      datasetToReplaceId: sampleConfig.dataId,
+      datasetToUse
+    }
+  });
+
+  // dataset should be replaced
+  t.ok(nextState.visState.datasets[sampleConfig.dataId], ' dataset should be replaced');
+  const nextSavedConfig = nextState.visState.schema.getConfigToSave(nextState).config;
+
+  const expectedLayers = oldSavedConfig.visState.layers.map(l => ({
+    ...l,
+    config: {
+      ...l.config,
+      dataId: sampleConfig.dataId
+    }
+  }));
+  t.deepEqual(nextSavedConfig.visState.layers, expectedLayers, 'should replace layer dataId');
+  t.end();
+});

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -5244,7 +5244,11 @@ test('VisStateUpdater -> prepareStateForDatasetReplace', t => {
   t.deepEqual(nextState.filterToBeMerged[0].dataId, [dataIdToUse], 'should replace filter dataId');
 
   // preserveLayerOrder
-  t.deepEqual(nextState.layerOrder, ['geojson-1'], 'should remove layer from layer order');
+  t.deepEqual(
+    nextState.layerOrder,
+    ['geojson-1', 'point-0'],
+    'should not remove layer from layer order'
+  );
   t.deepEqual(
     nextState.preserveLayerOrder,
     ['geojson-1', 'point-0'],


### PR DESCRIPTION
- Fix geocoder layer by adding layerOrder in config
- copy layerOrder to save it to state when prepare state for replace
- Add test