### PR TITLE
[Feat] Added new options parameter to override single action reducer default behavior

### DIFF
--- a/src/reducers/src/root.ts
+++ b/src/reducers/src/root.ts
@@ -126,6 +126,8 @@ function decorate(target, savedInitialState = {}) {
    * @mixin keplerGlReducer.plugin
    * @memberof keplerGlReducer
    * @param {Object|Function} customReducer - A reducer map or a reducer
+   * @param {Object} options - options to be applied to custom reducer logic
+   * @param {Object} options.override - objects that describe which action to override, e.g. {[ActionTypes.LAYER_TYPE_CHANGE]: true}
    * @public
    * @example
    * const myKeplerGlReducer = keplerGlReducer
@@ -150,15 +152,18 @@ function decorate(target, savedInitialState = {}) {
    *   })
    * }, {}));
    */
-  target.plugin = function plugin(customReducer) {
+  target.plugin = function plugin(customReducer, options) {
     if (typeof customReducer === 'object') {
       // if only provided a reducerMap, wrap it in a reducer
       customReducer = handleActions(customReducer, {});
     }
 
     // use 'function' keyword to enable 'this'
-    return decorate((state = {}, action = {}) => {
-      let nextState = this(state, action);
+    return decorate((state = {}, action: {type?: string} = {}) => {
+      let nextState = state;
+      if (action.type && !options?.override?.[action.type]) {
+        nextState = this(state, action);
+      }
 
       // for each entry in the staten
       Object.keys(nextState).forEach(id => {
@@ -169,7 +174,6 @@ function decorate(target, savedInitialState = {}) {
           customReducer(nextState[id], _actionFor(id, action))
         );
       });
-
       return nextState;
     });
   };

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -287,14 +287,19 @@ export const INITIAL_VIS_STATE: VisState = {
   schema: KeplerGLSchema
 };
 
+type UpdateStateWithLayerAndDataType = {
+  layers: Layer[];
+  layerData: any[];
+};
+
 /**
  * Update state with updated layer and layerData
  *
  */
-export function updateStateWithLayerAndData(
-  state: VisState,
+export function updateStateWithLayerAndData<S extends UpdateStateWithLayerAndDataType>(
+  state: S,
   {layerData, layer, idx}: {layerData?: any; layer: Layer; idx: number}
-): VisState {
+): S {
   return {
     ...state,
     layers: state.layers.map((lyr, i) => (i === idx ? layer : lyr)),
@@ -538,7 +543,7 @@ export function layerDataIdChangeUpdater(
   return updateStateWithLayerAndData(state, {layerData, layer, idx});
 }
 
-function setInitialLayerConfig(layer, datasets, layerClasses) {
+export function setInitialLayerConfig(layer, datasets, layerClasses): Layer {
   let newLayer = layer;
   if (!Object.keys(datasets).length) {
     // no data is loaded

--- a/test/node/reducers/root-test.js
+++ b/test/node/reducers/root-test.js
@@ -25,7 +25,10 @@ import {
   resetMapConfig,
   receiveMapConfig,
   toggleSplitMap,
-  toggleMapControl
+  toggleMapControl,
+  layerTypeChange,
+  addDataToMap,
+  ActionTypes
 } from '@kepler.gl/actions';
 import {createAction, handleActions} from 'redux-actions';
 
@@ -187,7 +190,7 @@ test('keplerGlReducer.plugin', t => {
   const testReducer = keplerGlReducer
     // 1. as reducer map
     .plugin({
-      HIDE_AND_SHOW_SIDE_PANEL: (state, action) => ({
+      HIDE_AND_SHOW_SIDE_PANEL: state => ({
         ...state,
         uiState: {
           ...state.uiState,
@@ -199,7 +202,7 @@ test('keplerGlReducer.plugin', t => {
       handleActions(
         {
           // 2. as reducer
-          HIDE_MAP_CONTROLS: (state, action) => ({
+          HIDE_MAP_CONTROLS: state => ({
             ...state,
             uiState: {
               ...state.uiState,
@@ -221,6 +224,92 @@ test('keplerGlReducer.plugin', t => {
   // dispatch action 2
   const updatedState2 = testReducer(testInitialState, hideMapControls());
   t.equal(updatedState2.test3.uiState.mapControls, hiddenMapControl, 'should call hideMapControls');
+
+  t.end();
+});
+
+test('keplerGlReducer.plugin override', t => {
+  // custom actions
+  const mockRawData = {
+    fields: [
+      {
+        name: 'start_point_lat',
+        id: 'start_point_lat',
+        displayName: 'start_point_lat',
+        type: 'real',
+        fieldIdx: 0
+      },
+      {
+        name: 'start_point_lng',
+        id: 'start_point_lng',
+        displayName: 'start_point_lng',
+        type: 'real',
+        fieldIdx: 2
+      },
+      {
+        name: 'end_point_lat',
+        id: 'end_point_lat',
+        displayName: 'end_point_lat',
+        type: 'real',
+        fieldIdx: 3
+      },
+      {
+        name: 'end_point_lng',
+        id: 'end_point_lng',
+        displayName: 'end_point_lng',
+        type: 'real',
+        fieldIdx: 4
+      }
+    ],
+    rows: [
+      [12.25, 37.75, 45.21, 100.12],
+      [null, 35.2, 45.0, 21.3],
+      [12.29, 37.64, 46.21, 99.127],
+      [null, null, 33.1, 29.34]
+    ]
+  };
+
+  const testReducer = keplerGlReducer
+    // 1. as reducer map
+    .plugin(
+      {
+        [ActionTypes.LAYER_TYPE_CHANGE]: (state, action) => {
+          return {
+            ...state,
+            visState: {
+              ...state.visState,
+              // do the default behavior and update layerOrder to empty
+              layerOrder: []
+            }
+          };
+        }
+      },
+      {override: {[ActionTypes.LAYER_TYPE_CHANGE]: true}}
+    );
+
+  let nextState = testReducer(undefined, registerEntry({id: 'test3'}));
+
+  nextState = testReducer(
+    nextState,
+    addDataToMap({
+      datasets: {
+        data: mockRawData,
+        info: {
+          id: 'foo'
+        }
+      }
+    })
+  );
+
+  t.equal(nextState.test3.visState.layers.length, 4, 'Should have 4 layer');
+
+  nextState = testReducer(nextState, layerTypeChange(nextState.test3.visState.layers[0], 'arc'));
+  t.equal(
+    nextState.test3.visState.layers[0].type,
+    'point',
+    'Should have not changed layer type to arc'
+  );
+  t.deepEqual(nextState.test3.visState.layerOrder, [], 'Should have changed layerOrder to empty');
 
   t.end();
 });


### PR DESCRIPTION
This PR implements the ability to override reducer single action default behavior through plugin.

Developers can override default behavior by doing the following:

` const customReducer = keplerGlReducer
    .plugin(
      {
        [ActionTypes.LAYER_TYPE_CHANGE]: (state, action) => {
          return {
            ...state,
            visState: {
              ...layerTypeChangeUpdater(state.visState, action),
              // do the default behavior and update layerOrder to empty
              layerOrder: []
            }
          };
        }
      },
      {override: {[ActionTypes.LAYER_TYPE_CHANGE]: true}}
    );`