### PR TITLE
[Fix] Feature Action Panel menu and editing tooltip are cut-off in dual map mode 

### DIFF
--- a/src/components/src/editor/editor.tsx
+++ b/src/components/src/editor/editor.tsx
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React, {Component, CSSProperties, KeyboardEvent} from 'react';
+import {createPortal} from 'react-dom';
 import styled from 'styled-components';
 import window from 'global/window';
 import classnames from 'classnames';
@@ -36,6 +37,7 @@ import {Layer, EditorLayerUtils} from '@kepler.gl/layers';
 import {Filter, FeatureSelectionContext, Feature} from '@kepler.gl/types';
 import {FeatureOf, Polygon} from '@nebula.gl/edit-modes';
 import {Datasets} from '@kepler.gl/table';
+import {RootContext} from '../';
 
 const DECKGL_RENDER_LAYER = 'default-deckgl-overlay-wrapper';
 
@@ -160,20 +162,27 @@ export default function EditorFactory(
       const {rightClick, position, mapIndex} = selectionContext || {};
 
       return (
-        <StyledWrapper className={classnames('editor', className)} style={style}>
-          {Boolean(rightClick) && selectedFeature && index === mapIndex ? (
-            <FeatureActionPanel
-              selectedFeature={selectedFeature as FeatureOf<Polygon>}
-              datasets={datasets}
-              layers={availableLayers}
-              currentFilter={currentFilter}
-              onClose={this._closeFeatureAction}
-              onDeleteFeature={this._onDeleteSelectedFeature}
-              onToggleLayer={this._togglePolygonFilter}
-              position={position || null}
-            />
-          ) : null}
-        </StyledWrapper>
+        <RootContext.Consumer>
+          {context =>
+            createPortal(
+              <StyledWrapper className={classnames('editor', className)} style={style}>
+                {Boolean(rightClick) && selectedFeature && index === mapIndex ? (
+                  <FeatureActionPanel
+                    selectedFeature={selectedFeature as FeatureOf<Polygon>}
+                    datasets={datasets}
+                    layers={availableLayers}
+                    currentFilter={currentFilter}
+                    onClose={this._closeFeatureAction}
+                    onDeleteFeature={this._onDeleteSelectedFeature}
+                    onToggleLayer={this._togglePolygonFilter}
+                    position={position || null}
+                  />
+                ) : null}
+              </StyledWrapper>,
+              context?.current ?? document.body
+            )
+          }
+        </RootContext.Consumer>
       );
     }
   }


### PR DESCRIPTION
1) shape selection/filter menu showing under the map on the right when in dual map mode. 
The fix uses a react portal to change where that menu is inserted in the DOM. Instead of being nested inside the map on the left's DOM, it's appended to our context. That way it displays over both maps instead of being hidden by the left map.

2) switch the tooltip's position that shows on hover for shapes on the map. Too close to the right side - show the tooltip on the cursor's left side, etc.