### PR TITLE
[Fix] mapbox logo has not been styled correctly

### DIFF
--- a/src/components/src/common/styled-components.tsx
+++ b/src/components/src/common/styled-components.tsx
@@ -574,6 +574,7 @@ export const StyledAttrbution = styled.div.attrs({
     a.mapboxgl-ctrl-logo {
       width: 72px;
       margin-left: 4px;
+      background-size: contain;
     }
   }
   a,


### PR DESCRIPTION
In this PR, the `background-size: contain;` has been added to the style of a.mapboxgl-ctrl-logo to make sure that the background image (mapbox logo) could be scaled properly within its container without cropping or stretching the image.

