### PR TITLE
[fix] time ticks are the same when using Minute to set interval

### DIFF
--- a/src/components/src/common/time-slider-marker.tsx
+++ b/src/components/src/common/time-slider-marker.tsx
@@ -72,7 +72,7 @@ const TimeSliderContainer = styled.svg`
 const TICK_FORMATS = {
   millisecond: '.SSS',
   second: ':ss',
-  minute: 'HH:ss',
+  minute: 'HH:mm',
   hour: 'HH A',
   day: 'ddd DD',
   week: 'MMM DD',


### PR DESCRIPTION
- When using Minute to set interval, the time ticket format was set to HH:ss, which is Hour+Seconds. All ticks are the same because the value of the minute is missing. This pr will change the format to HH:mm: