### PR TITLE
[fix] range slider doesn't work when step < 1 in dataset filter

### DIFF
--- a/src/utils/src/data-utils.ts
+++ b/src/utils/src/data-utils.ts
@@ -182,7 +182,17 @@ export function getRoundingDecimalFromStep(step: number): number {
     assert(step);
   }
 
-  const splitZero = step.toString().split('.');
+  const stepStr = step.toString();
+
+  // in case the step is a very small number e.g. 1e-7, return decimal e.g. 7 directly
+  const splitExponential = stepStr.split('e-');
+  if (splitExponential.length === 2) {
+    const coeffZero = splitExponential[0].split('.');
+    const coeffDecimal = coeffZero.length === 1 ? 0 : coeffZero[1].length;
+    return parseInt(splitExponential[1], 10) + coeffDecimal;
+  }
+
+  const splitZero = stepStr.split('.');
   if (splitZero.length === 1) {
     return 0;
   }

--- a/test/node/utils/data-utils-test.js
+++ b/test/node/utils/data-utils-test.js
@@ -75,6 +75,8 @@ test('dataUtils -> getRoundingDecimalFromStep', t => {
   t.equal(getRoundingDecimalFromStep(10), 0, 'decimal of step=10 should be 0');
   t.equal(getRoundingDecimalFromStep(0.5), 1, 'decimal of step=0.5 should be 0');
   t.equal(getRoundingDecimalFromStep(1.5), 1, 'decimal of step=1.5 should be 1');
+  t.equal(getRoundingDecimalFromStep(0.0000001), 7, 'decimal of step=1e-7 should be 7');
+  t.equal(getRoundingDecimalFromStep(0.0000000000123), 13, 'decimal of step=1.23e-11 should be 13');
   t.end();
 });
 


### PR DESCRIPTION
- In the dataset filter, the value range could be small [-122.4548828, -122.4545319], which is common when e.g. filtering by latitude or longitude column. In this case, the range slider doesn't work correctly. It is caused by the normalizeSliderValue() function in range-brush.js, which works when step >= 1. When step < 1, the normalizeSliderValue() always returns a rounded value (or mark).