### PR TITLE
[fix] exported image has a thin white bar at the bottom

### DIFF
--- a/src/components/src/plot-container.tsx
+++ b/src/components/src/plot-container.tsx
@@ -152,7 +152,12 @@ export default function PlotContainerFactory(
 
     _retrieveNewScreenshot = () => {
       if (this.plottingAreaRef.current) {
-        convertToPng(this.plottingAreaRef.current, {filter: DOM_FILTER_FUNC})
+        const {imageSize} = this.props.exportImageSetting;
+        convertToPng(this.plottingAreaRef.current, {
+          filter: DOM_FILTER_FUNC,
+          width: imageSize.imageW,
+          height: imageSize.imageH
+        })
           .then(this.props.setExportImageDataUri)
           .catch(err => {
             this.props.setExportImageError(err);


### PR DESCRIPTION
- fix for: When I export images from maps I seem to be getting a thin white bar at the bottom of the image
e.g.