### PR TITLE
[fix] collapsible layer config group ui improvements

### DIFF
--- a/src/components/src/side-panel/layer-panel/layer-config-group.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-config-group.tsx
@@ -91,9 +91,13 @@ export const StyledLayerConfigGroup = styled.div`
   }
 `;
 
+interface StyledConfigGroupHeaderProps {
+  collapsible?: boolean;
+}
+
 export const StyledConfigGroupHeader = styled.div.attrs({
   className: 'layer-config-group__header'
-})`
+})<StyledConfigGroupHeaderProps>`
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/test/node/utils/dom-to-image.js
+++ b/test/node/utils/dom-to-image.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 Uber Technologies, Inc.
+// Copyright (c) 2023 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- when the layer config group UI is not collapsible: (1) prevent the click event from toggling the collapsed state and (2) do not show cursor: pointer CSS on hover