### PR TITLE
[fix] Long field names in filter UI obscure the delete icon

### DIFF
--- a/src/components/src/common/field-selector.tsx
+++ b/src/components/src/common/field-selector.tsx
@@ -38,6 +38,9 @@ const StyledToken = styled.div`
 `;
 const StyledFieldListItem = styled.div`
   line-height: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 `;
 
 export type FieldListItemFactoryProps = {

--- a/src/components/src/filters/filter-panels/time-range-filter-panel.tsx
+++ b/src/components/src/filters/filter-panels/time-range-filter-panel.tsx
@@ -19,6 +19,7 @@
 // THE SOFTWARE.
 
 import React, {useCallback, useMemo} from 'react';
+import styled from 'styled-components';
 import TimeRangeFilterFactory from '../time-range-filter';
 import {Clock} from '../../common/icons';
 import FieldPanelWithFieldSelectFactory from './filter-panel-with-field-select';
@@ -31,6 +32,12 @@ function TimeRangeFilterPanelFactory(
   FieldPanelWithFieldSelect: ReturnType<typeof FieldPanelWithFieldSelectFactory>,
   TimeRangeFilter: ReturnType<typeof TimeRangeFilterFactory>
 ) {
+  const StyledFieldPanelWithFieldSelect = styled(FieldPanelWithFieldSelect)`
+    .field-selector {
+      width: 90%;
+    }
+  `;
+
   const TimeRangeFilterPanel: TimeRangeFilterPanelComponent = React.memo(
     ({
       idx,
@@ -63,7 +70,7 @@ function TimeRangeFilterPanelFactory(
 
       return (
         <>
-          <FieldPanelWithFieldSelect
+          <StyledFieldPanelWithFieldSelect
             allAvailableFields={allAvailableFields}
             datasets={datasets}
             filter={filter}
@@ -84,7 +91,7 @@ function TimeRangeFilterPanelFactory(
                 />
               </div>
             )}
-          </FieldPanelWithFieldSelect>
+          </StyledFieldPanelWithFieldSelect>
         </>
       );
     }

--- a/src/components/src/side-panel/filter-panel/filter-panel-header.tsx
+++ b/src/components/src/side-panel/filter-panel/filter-panel-header.tsx
@@ -36,6 +36,7 @@ export const StyledFilterHeader = styled(StyledPanelHeader)<StyledFilterHeaderPr
   padding: 10px 12px;
 
   .field-selector {
+    width: 100%;
     flex: 2;
   }
 
@@ -49,6 +50,7 @@ export const StyledFilterHeader = styled(StyledPanelHeader)<StyledFilterHeaderPr
 const StyledChildrenContainer = styled.div`
   display: flex;
   flex: 2;
+  width: 90%;
 `;
 
 export type FilterPanelHeaderProps = {

--- a/src/styles/src/base.ts
+++ b/src/styles/src/base.ts
@@ -885,6 +885,9 @@ const dropdownListAnchor = css`
   padding-left: 3px;
   font-size: ${props => props.theme.selectFontSize};
   line-height: ${props => props.theme.dropdownListLineHeight}px;
+  display: inline-block;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   &.disabled {
     color: ${props => props.theme.subtextColor};
@@ -1049,7 +1052,7 @@ const scrollBar = css`
   ::-webkit-scrollbar-thumb {
     border-radius: 10px;
     background: ${props => props.theme.labelColor};
-    border: 3px solid ${props => props.theme.panelBackground}
+    border: 3px solid ${props => props.theme.panelBackground};
 
     :vertical:hover {
       background: ${props => props.theme.textColorHl};


### PR DESCRIPTION
- Updates CSS to account for very long field names in the filter UI

<img width="287" alt="Screen Shot 2023-06-20 at 11 42 49 PM" src="https://github.com/keplergl/kepler.gl/assets/8210766/0da21d1e-48a2-4233-8368-eb53082a5064">
