### PR TITLE
[Bug] Have html export always use latest published version

### DIFF
--- a/examples/umd-client/index.html
+++ b/examples/umd-client/index.html
@@ -18,7 +18,7 @@
     <script src="https://unpkg.com/styled-components@4.1.3/dist/styled-components.min.js" crossorigin></script>
 
     <!-- Load Kepler.gl-->
-    <script src="https://unpkg.com/kepler.gl@3.0.0-alpha.0/umd/keplergl.min.js"></script>
+    <script src="https://unpkg.com/kepler.gl/umd/keplergl.min.js"></script>
     <!--If you want to load the build from filepath -->
     <!--<script src="../../umd/keplergl.min.js"></script>-->
 


### PR DESCRIPTION
Signed-off-by: Eric Sherman <ericandrewsherman@gmail.com>

fixes #2028 , fixes #2111, fixes #2202 

This previous commit:
https://github.com/keplergl/kepler.gl/commit/dbba7daa1e3982fc5f4dd8cab1d99f7ca5f73c72#diff-d487565baf71f3a3554594403f1de25ce00ba6b634da5248f461f14dbddfe5c2R21 updated the version of kepler.gl to a build that is not published to unpkg.com

To fix this problem and avoid in the future, I removed the specific version tag. According to https://unpkg.com/ , this means the latest published version will always be used (currently 2.5.5)

Thanks for the great project!