### PR TITLE
[fix] Conditionally apply escapeXhtml to prevent export image crash

### DIFF
--- a/src/components/src/plot-container.tsx
+++ b/src/components/src/plot-container.tsx
@@ -159,11 +159,12 @@ export default function PlotContainerFactory(
 
     _retrieveNewScreenshot = () => {
       if (this.plottingAreaRef.current) {
-        const {imageSize} = this.props.exportImageSetting;
+        const {imageSize, escapeXhtmlForWebpack} = this.props.exportImageSetting;
         convertToPng(this.plottingAreaRef.current, {
           filter: DOM_FILTER_FUNC,
           width: imageSize.imageW,
-          height: imageSize.imageH
+          height: imageSize.imageH,
+          escapeXhtmlForWebpack
         })
           .then(this.props.setExportImageDataUri)
           .catch(err => {

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -851,6 +851,7 @@ export type ExportImage = {
   exporting: boolean;
   processing: boolean;
   error: Error | false;
+  escapeXhtmlForWebpack?: boolean;
   // This field was not in the .d.ts file
   center: boolean;
 };

--- a/src/reducers/src/ui-state-updaters.ts
+++ b/src/reducers/src/ui-state-updaters.ts
@@ -138,6 +138,7 @@ export const DEFAULT_MAP_CONTROLS: MapControls = (Object.keys(MAP_CONTROLS) as A
  * @property imageDataUri Default: `''`,
  * @property exporting Default: `false`
  * @property error Default: `false`
+ * @property escapeXhtmlForWebpack Default: `true`
  * @public
  */
 export const DEFAULT_EXPORT_IMAGE: ExportImage = {
@@ -161,7 +162,9 @@ export const DEFAULT_EXPORT_IMAGE: ExportImage = {
   exporting: false,
   // processing: used as loading indicator when export image is being produced
   processing: false,
-  error: false
+  error: false,
+  // whether to apply fix for uglify error in dom-to-image (should be true for webpack builds)
+  escapeXhtmlForWebpack: true
 };
 
 export const DEFAULT_LOAD_FILES = {


### PR DESCRIPTION
`escapeXhtml()` is applied to export image data URIs to prevent an uglify issue (caused by newline characters in SVG attribute values) when used with `webpack`.  However, the function corrupts exported images, when used with `esbuild`. 

This PR adds a setting to `uiState.exportImage` which controls whether `escapeXhtml()` should be applied, so we can disable it in Studio, because it's built with `esbuild`.