### PR TITLE
[fix] fix horizontal "over scrolling" and misalignment of header row vs. data cells

### DIFF
--- a/src/components/src/common/data-table/index.tsx
+++ b/src/components/src/common/data-table/index.tsx
@@ -343,6 +343,7 @@ export const TableSection = ({
           columnWidth,
           width: fixedWidth || width
         };
+        const headerGridWidth = fixedWidth || width - browserScrollBarWidth;
         const dataGridHeight = fixedHeight || height;
 
         return (
@@ -356,6 +357,7 @@ export const TableSection = ({
                 {...headerGridProps}
                 {...gridDimension}
                 height={headerGridProps.height + browserScrollBarWidth}
+                width={headerGridWidth}
                 scrollLeft={scrollLeft}
                 onScroll={onScroll}
               />


### PR DESCRIPTION
## PR Description

- Fix: Dataset window becomes misaligned after horizontal scroll
- `const headerGridWidth = fixedWidth || width - browserScrollBarWidth;` now takes into account the **width of the vertical scrollbar** which is the root cause of the misalignment. https://css-tricks.com/scrollbar-reflowing/
- `fixedWidth` is used for the pinned columns area, that's why it is still an either/or to get the width.