### PR TITLE
[Bug] Allow adding data from cloud providers without private storage

### DIFF
--- a/src/components/src/modal-container.tsx
+++ b/src/components/src/modal-container.tsx
@@ -356,7 +356,7 @@ export default function ModalContainerFactory(
                 onClose={this._closeModal}
                 onFileUpload={this._onFileUpload}
                 onLoadCloudMap={this._onLoadCloudMap}
-                cloudProviders={this.providerWithStorage(this.props)}
+                cloudProviders={this.cloudProviders(this.props)}
                 onSetCloudProvider={this.props.providerActions.setCloudProvider}
                 getSavedMaps={this.props.providerActions.getSavedMaps}
                 loadFiles={uiState.loadFiles}

--- a/test/browser/components/kepler-gl-test.js
+++ b/test/browser/components/kepler-gl-test.js
@@ -42,6 +42,8 @@ import {
 import {DEFAULT_MAP_STYLES, EXPORT_IMAGE_ID, GEOCODER_DATASET_NAME} from '@kepler.gl/constants';
 // mock state
 import {StateWithGeocoderDataset} from 'test/helpers/mock-state';
+import MockProvider from '../../helpers/mock-provider';
+import MockProviderWithoutPrivateStorage from '../../helpers/mock-provider-without-private-storage';
 
 const KeplerGl = appInjector.get(KeplerGlFactory);
 const SidePanel = appInjector.get(SidePanelFactory);
@@ -93,6 +95,46 @@ test('Components -> KeplerGl -> Mount', t => {
   t.equal(wrapper.find(NotificationPanel).length, 1, 'should render NotificationPanel');
   t.equal(wrapper.find(GeocoderPanel).length, 0, 'should not render GeocoderPanel');
 
+  t.end();
+});
+
+test('Components -> KeplerGl -> Mount -> Load From Storage', t => {
+  drainTasksForTesting();
+  // mount with empty store
+  const store = mockStore(initialState);
+  let wrapper;
+
+  t.doesNotThrow(() => {
+    wrapper = mount(
+      <Provider store={store}>
+        <KeplerGl
+          id="map"
+          mapboxApiAccessToken="smoothie-the-cat"
+          selector={state => state.keplerGl.map}
+          dispatch={store.dispatch}
+          cloudProviders={[new MockProvider(), new MockProviderWithoutPrivateStorage()]}
+        />
+      </Provider>
+    );
+  }, 'Should not throw error when mount KeplerGl');
+
+  t.equal(wrapper.find(KeplerGl).length, 1, 'should render KeplerGl');
+  t.equal(wrapper.find(SidePanel).length, 1, 'should render SidePanel');
+  t.equal(wrapper.find(MapContainer).length, 1, 'should render MapContainer');
+  t.equal(wrapper.find(BottomWidget).length, 1, 'should render BottomWidget');
+  t.equal(wrapper.find(ModalContainer).length, 1, 'should render ModalContainer');
+  t.equal(wrapper.find(PlotContainer).length, 0, 'should not render PlotContainer');
+  t.equal(wrapper.find(NotificationPanel).length, 1, 'should render NotificationPanel');
+  t.equal(wrapper.find(GeocoderPanel).length, 0, 'should not render GeocoderPanel');
+
+  // click load from storage tab
+  const loadFromStorageTab = wrapper
+    .findWhere(node => {
+      return node.type() === 'div' && node.text() === 'Load from Storage';
+    })
+    .at(0);
+  loadFromStorageTab.simulate('click');
+  t.equal(wrapper.find('.provider-tile__wrapper').length, 2, 'should render two providers');
   t.end();
 });
 

--- a/test/helpers/mock-provider-without-private-storage.js
+++ b/test/helpers/mock-provider-without-private-storage.js
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import React from 'react';
+
+const MockIcon = () => <div id="provider-icon" />;
+
+export default class MockProviderWithoutPrivateStorage {
+  constructor() {
+    // All cloud-providers providers must implement the following properties
+    this.name = 'taro2';
+    this.displayName = 'Taro2';
+    this.icon = MockIcon;
+    this.thumbnail = {width: 100, height: 60};
+  }
+  login(onSuccess) {
+    onSuccess();
+    return;
+  }
+  logout(onSuccess) {
+    onSuccess();
+    return;
+  }
+  hasPrivateStorage() {
+    return false;
+  }
+  hasSharingUrl() {
+    return true;
+  }
+  getAccessToken() {
+    return true;
+  }
+  async uploadMap(args) {
+    const promise = new Promise((resolve, reject) => {
+      () => resolve('done!')();
+    });
+    await promise;
+  }
+}


### PR DESCRIPTION
* Pass all cloud providers to the load data modal
* Add test
* Add mock provider that doesn't support private storage