### PR TITLE
[Fix] Resize observer crashes when passed a non-Element target

### DIFF
--- a/src/utils/src/observe-dimensions.ts
+++ b/src/utils/src/observe-dimensions.ts
@@ -44,12 +44,16 @@ function getObserverRegistry() {
     });
     _observerRegistry = {
       subscribe(target, callback) {
-        resizeObserver.observe(target);
-        callbacks.set(target, callback);
+        if (target instanceof Element) {
+          resizeObserver.observe(target);
+          callbacks.set(target, callback);
+        }
       },
       unsubscribe(target) {
-        resizeObserver.unobserve(target);
-        callbacks.delete(target);
+        if (target instanceof Element) {
+          resizeObserver.unobserve(target);
+          callbacks.delete(target);
+        }
       }
     };
   }


### PR DESCRIPTION
- fix for Resize observer crashes when passed a non-Element target