### PR TITLE
[fix] Improve mapbox/deckgl syncing when panning

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -873,13 +873,15 @@ export default function MapContainerFactory(
         // lead to inadvertent changes to the state of the main map)
         return;
       }
-      onViewPortChange(
-        viewState,
-        this.props.mapStateActions.updateMap,
-        this.props.onViewStateChange,
-        this.props.primary,
-        this.props.index
-      );
+      requestAnimationFrame(() => {
+        onViewPortChange(
+          viewState,
+          this.props.mapStateActions.updateMap,
+          this.props.onViewStateChange,
+          this.props.primary,
+          this.props.index
+        );
+      });
     };
 
     _toggleMapControl = panelId => {


### PR DESCRIPTION
- This is a temporary solution to improve the situation with laggin/out of sync rendering that we should revisit once we upgrade to react-map-gl@7.
- [flushSync](https://react.dev/reference/react-dom/flushSync) seem to reduce the lagging.

Refer to https://github.com/visgl/deck.gl/issues/7158