### PR TITLE
[Fix] Dispatch click event instead of click()

### DIFF
--- a/src/utils/src/export-utils.ts
+++ b/src/utils/src/export-utils.ts
@@ -138,7 +138,15 @@ export function downloadFile(fileBlob: Blob, fileName: string) {
     link.setAttribute('download', fileName);
 
     document.body.appendChild(link);
-    link.click();
+    // in some cases where maps are embedded, e.g. need to
+    // create and dispatch an event so that the browser downloads
+    // the file instead of navigating to the url
+    const evt = new MouseEvent('click', {
+      view: window,
+      bubbles: false,
+      cancelable: true
+    });
+    link.dispatchEvent(evt);
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   }


### PR DESCRIPTION
- Before this fix, clicking export would navigate to the URL for the file download and display it instead of downloading it. With this change, the file downloads as expected.