### PR TITLE
[fix] Layer column config: sometimes a suggested field pair will hard crash

### DIFF
--- a/src/components/src/side-panel/layer-panel/layer-column-config.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-column-config.tsx
@@ -42,6 +42,21 @@ const TopRow = styled.div`
   justify-content: space-between;
 `;
 
+/**
+ * only provide suggested field pairs if there is a match,
+ * otherwise the user can select a suggested field pair that will create invalid columns and a hard crash
+ */
+function getFieldPairsSuggestionsForColumn(
+  enhancedFieldPairs,
+  columnPairs: ColumnPairs | null | undefined,
+  columnKey: string
+) {
+  const matchingFieldPairs = enhancedFieldPairs?.filter(({pair}) =>
+    pair.hasOwnProperty(columnPairs?.[columnKey]?.fieldPairKey)
+  );
+  return matchingFieldPairs.length > 0 ? matchingFieldPairs : null;
+}
+
 LayerColumnConfigFactory.deps = [ColumnSelectorFactory];
 
 function LayerColumnConfigFactory(ColumnSelector: ReturnType<typeof ColumnSelectorFactory>) {
@@ -103,7 +118,7 @@ function LayerColumnConfigFactory(ColumnSelector: ReturnType<typeof ColumnSelect
                 label={(columnLabels && columnLabels[key]) || key}
                 key={key}
                 allFields={fields}
-                fieldPairs={enhancedFieldPairs}
+                fieldPairs={getFieldPairsSuggestionsForColumn(enhancedFieldPairs, columnPairs, key)}
                 onSelect={val => onUpdateColumn(key, val)}
               />
             ))}

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -553,6 +553,12 @@ class Layer {
     }
 
     const {pair: partnerKey, fieldPairKey} = this.columnPairs?.[key];
+
+    if (!pair[fieldPairKey]) {
+      // do not allow `key: undefined` to creep into the `updatedColumn` object
+      return this.config.columns;
+    }
+
     const {fieldPairKey: partnerFieldPairKey} = this.columnPairs?.[partnerKey];
 
     return {

--- a/test/node/utils/kepler-table-test.js
+++ b/test/node/utils/kepler-table-test.js
@@ -371,6 +371,50 @@ test('KeplerTable -> findPointFieldPairs', t => {
           suffix: ['latitude', 'longitude']
         }
       ]
+    },
+    {
+      fields: ['point_lat', 'point_lng', 'alt'],
+      expected: [
+        {
+          defaultName: 'point',
+          pair: {
+            // no matching "alt" altitude found for this pair
+            lat: {
+              fieldIdx: 0,
+              value: 'point_lat'
+            },
+            lng: {
+              fieldIdx: 1,
+              value: 'point_lng'
+            }
+          },
+          suffix: ['lat', 'lng']
+        }
+      ]
+    },
+    {
+      fields: ['point_lat', 'point_lng', 'point_alt'],
+      expected: [
+        {
+          defaultName: 'point',
+          pair: {
+            // a matching "point_alt" altitude was found for this pair
+            lat: {
+              fieldIdx: 0,
+              value: 'point_lat'
+            },
+            lng: {
+              fieldIdx: 1,
+              value: 'point_lng'
+            },
+            alt: {
+              fieldIdx: 2,
+              value: 'point_alt'
+            }
+          },
+          suffix: ['lat', 'lng']
+        }
+      ]
     }
   ];
 


### PR DESCRIPTION
- Fixes a hard crash that can occur when the user selects a suggested field pair for a layer geometry column that would lead to an `undefined` column in the base layer `assignColumnPairs` method.

- The solution adds an additional short-circuit in the base layer method `assignColumnPairs` if that is the case, but more importantly also first prevents the UI from providing invalid suggested field pair choices that would lead to this condition.

- Adds a couple of test cases to help document to devs what the underlying `findPointFieldPairs` data method is intended to do.