### PR TITLE
[chore] Avoid confusion in viewstate context

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -695,6 +695,7 @@ export default function MapContainerFactory(
       const {
         mapStyle,
         visState,
+        mapState,
         visStateActions,
         mapboxApiAccessToken,
         mapboxApiUrl,
@@ -716,7 +717,8 @@ export default function MapContainerFactory(
       const isEditorDrawingMode = EditorLayerUtils.isDrawingActive(editorMenuActive, editor.mode);
 
       const internalViewState = this.context?.getInternalViewState(index);
-      const viewport = getViewportFromMapState(internalViewState);
+      const internalMapState = {...mapState, ...internalViewState};
+      const viewport = getViewportFromMapState(internalMapState);
 
       const editorFeatureSelectedIndex = this.selectedPolygonIndexSelector(this.props);
 
@@ -726,7 +728,7 @@ export default function MapContainerFactory(
       const deckGlLayers = generateDeckGLLayersMethod(
         {
           visState,
-          mapState: internalViewState,
+          mapState: internalMapState,
           mapStyle
         },
         {

--- a/src/components/src/map-view-state-context.tsx
+++ b/src/components/src/map-view-state-context.tsx
@@ -1,6 +1,7 @@
 import React, {useState, useEffect, createContext} from 'react';
 import isEqual from 'lodash.isequal';
 import pick from 'lodash.pick';
+import {pickViewportPropsFromMapState} from '@kepler.gl/reducers';
 
 import {MapState} from '@kepler.gl/types';
 
@@ -38,7 +39,7 @@ export const MapViewStateContextProvider = ({
       }
     } else {
       if (hasChanged(primaryState, mapState)) {
-        setViewStates([mapState]);
+        setViewStates([pickViewportPropsFromMapState(mapState)] as MapState[]);
       }
     }
     // Only update internalViewState when viewState changes

--- a/src/reducers/src/index.ts
+++ b/src/reducers/src/index.ts
@@ -63,7 +63,7 @@ export * from './provider-state';
 export * from './ui-state';
 export * from './map-state';
 export {getInitialInputStyle, loadMapStylesUpdater, INITIAL_MAP_STYLE} from './map-style-updaters';
-export {fitBoundsUpdater, INITIAL_MAP_STATE} from './map-state-updaters';
+export {fitBoundsUpdater, pickViewportPropsFromMapState, INITIAL_MAP_STATE} from './map-state-updaters';
 
 // Helpers
 export * from './composer-helpers';

--- a/src/reducers/src/map-state-updaters.ts
+++ b/src/reducers/src/map-state-updaters.ts
@@ -378,9 +378,9 @@ export const toggleSplitMapViewportUpdater = (
     // if current viewport is synced, and we are unsyncing it
     // or already in unsynced mode and NOT toggling locked zoom
     // make a fresh copy of the current viewport object, assign it to splitMapViewports[]
-    // getViewportFromMapState is called twice to avoid memory allocation conflicts
-    const leftViewport = getViewportFromMapState(newMapState);
-    const rightViewport = getViewportFromMapState(newMapState);
+    // pickViewportPropsFromMapState is called twice to avoid memory allocation conflicts
+    const leftViewport = pickViewportPropsFromMapState(newMapState);
+    const rightViewport = pickViewportPropsFromMapState(newMapState);
     newMapState.splitMapViewports = [leftViewport, rightViewport];
   }
 
@@ -468,7 +468,7 @@ function updateViewportBasedOnBounds(state: MapState, newMapState: MapState) {
   return newMapState;
 }
 
-function getViewportFromMapState(state) {
+export function pickViewportPropsFromMapState(state: MapState): Viewport {
   return pick(state, [
     'width',
     'height',


### PR DESCRIPTION
MapViewStateContext sometimes stores complete mapState, sometimes only viewport. This changes it so that MapViewStateContext only keeps the viewport with the other props stripped out, and we merge it with mapState where it is needed.

Also, renaming `getViewportFromMapState` in `map-state-updaters.ts` into `pickViewportPropsFromMapState` to avoid confusion with another function with the same name.