### PR TITLE
[feat] reorder tooltips

### DIFF
--- a/src/components/src/common/field-selector.tsx
+++ b/src/components/src/common/field-selector.tsx
@@ -113,6 +113,7 @@ interface FieldSelectorFactoryProps {
   suggested?: ReadonlyArray<string | number | boolean | object> | null;
   CustomChickletComponent?: ComponentType<any>;
   size?: string;
+  reorderItems?: (newOrder: any) => void;
 }
 
 function FieldSelectorFactory(
@@ -124,6 +125,7 @@ function FieldSelectorFactory(
       error: false,
       fields: [],
       onSelect: () => {},
+      reorderItems: () => {},
       placement: 'bottom',
       value: null,
       multiSelect: false,
@@ -194,6 +196,7 @@ function FieldSelectorFactory(
             placeholder={this.props.placeholder}
             placement={this.props.placement}
             onChange={this.props.onSelect}
+            reorderItems={this.props.reorderItems}
             DropDownLineItemRenderComponent={this.fieldListItemSelector(this.props)}
             DropdownHeaderComponent={this.props.suggested ? SuggestedFieldHeader : null}
             CustomChickletComponent={this.props.CustomChickletComponent}

--- a/src/components/src/common/item-selector/item-selector.tsx
+++ b/src/components/src/common/item-selector/item-selector.tsx
@@ -154,6 +154,7 @@ export type ItemSelectorProps = {
   CustomChickletComponent?: ComponentType<any>;
   intl: IntlShape;
   className?: string;
+  reorderItems?: (newOrder: any) => void;
   showDropdownOnMount?: boolean;
 };
 
@@ -164,7 +165,8 @@ class ItemSelectorUnmemoized extends Component<ItemSelectorProps> {
     closeOnSelect: true,
     searchable: true,
     DropDownRenderComponent: DropdownList,
-    DropDownLineItemRenderComponent: ListItem
+    DropDownLineItemRenderComponent: ListItem,
+    reorderItems: undefined
   };
 
   state = {
@@ -342,6 +344,7 @@ class ItemSelectorUnmemoized extends Component<ItemSelectorProps> {
               selectedItems={toArray(this.props.selectedItems)}
               placeholder={this.props.placeholder}
               removeItem={this._removeItem}
+              reorderItems={this.props.reorderItems}
               CustomChickletComponent={this.props.CustomChickletComponent}
               inputTheme={inputTheme}
             />


### PR DESCRIPTION
## PR Description
This PR adds support for tooltips reordering in chickleted input using dnd-kit.

1. Add `DndContext`, `SortableContext`, and `useSortable` in chickleted-input.tsx, and `handleDragEnd` to reorder tooltips by drag-and-drop. 
2. To get reorder function and datasetId, we need to trace the DOM tree: `TooltipConfig -> (multi) DatasetTooltipConfig -> FieldSelector -> ItemSelector -> ChickletedInput & Typeahead`, and create `reorderItems` as a prop of FieldSelector. In tooltip-config, replace onClick and onSelect with useCallback.
3. As we are using `CustomChickletComponent` created by TooltipChickletFactory, drag-and-drop props are passed to TooltipChicklet. 

## Concerns
- Potential bug: selectedItemIds might have duplicates.
- Potential UI bug: To solve the dnd-kit problem "[Sortable elements with variable size looks weird when dragging an element](https://github.com/clauderic/dnd-kit/issues/44)", DndContext applies onDragOver and pointerWithin and SortableContext has strategy set as null. However, onDragOver will prevent the animation to function properly, as discussed [here](https://github.com/clauderic/dnd-kit/issues/1146).



 
