### PR TITLE
[fix] Update layer domain in addLayer

### DIFF
--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -1320,7 +1320,8 @@ export const addLayerUpdater = (
     });
     newLayerData = {};
   }
-  return {
+
+  let newState = {
     ...state,
     layers: [...state.layers, newLayer],
     layerData: [...state.layerData, newLayerData],
@@ -1328,6 +1329,12 @@ export const addLayerUpdater = (
     layerOrder: [newLayer.id, ...state.layerOrder],
     splitMaps: addNewLayersToSplitMap(state.splitMaps, newLayer)
   };
+
+  if (newLayer.config.animation.enabled) {
+    newState = updateAnimationDomain(newState);
+  }
+
+  return newState;
 };
 
 /**


### PR DESCRIPTION
- The `addLayerUpdater` function doesn't call `updateAnimationDomain` like the other animation-related action updaters. As a result, the layers may not show up at all on load in certain use cases.