### PR TITLE
[Fix] GeoArrow demo not working

### DIFF
--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -83,8 +83,6 @@ function makeLocalDevConfig(env, EXAMPLE_DIR = LIB_DIR, externals = {}) {
     externals['loaders.gl'].forEach(mdl => {
       resolveAlias[`@loaders.gl/${mdl}`] = `${EXTERNAL_LOADERS_SRC}/modules/${mdl}/src`;
     });
-    // kepler.gl and loaders.gl need to use same apache-arrow
-    resolveAlias['apache-arrow'] = resolve(__dirname, '../node_modules/apache-arrow');
   }
 
   if (env.hubble_src) {

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
     "tape": "^4.9.2",
     "tape-catch": "^1.0.6",
     "typedoc-plugin-markdown": "^3.0.11",
-    "typescript": "4.5.5",    
+    "typescript": "4.5.5",
     "url-loader": "^4.1.1",
     "watchify": "^3.6.1",
     "webpack": "^4.29.0",
@@ -218,6 +218,7 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "resolutions": {
+    "apache-arrow": "^13.0.0",
     "@loaders.gl/core": "^4.1.0-alpha.4",
     "@loaders.gl/csv": "^4.1.0-alpha.4",
     "@loaders.gl/gltf": "^4.1.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -218,7 +218,6 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "resolutions": {
-    "apache-arrow": "^13.0.0",
     "@loaders.gl/core": "^4.1.0-alpha.4",
     "@loaders.gl/csv": "^4.1.0-alpha.4",
     "@loaders.gl/gltf": "^4.1.0-alpha.4",

--- a/webpack/shared-webpack-configuration.js
+++ b/webpack/shared-webpack-configuration.js
@@ -15,9 +15,9 @@ const resolveAlias = {
   'styled-components': `${NODE_MODULES_DIR}/styled-components`,
   'react-intl': `${NODE_MODULES_DIR}/react-intl`,
   // Suppress useless warnings from react-date-picker's dep
-  'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`,
+  'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`
   // kepler.gl and loaders.gl need to use same apache-arrow
-  'apache-arrow': `${NODE_MODULES_DIR}/apache-arrow`
+  // 'apache-arrow': `${NODE_MODULES_DIR}/apache-arrow`
 };
 
 // add kepler.gl submodule aliases

--- a/webpack/shared-webpack-configuration.js
+++ b/webpack/shared-webpack-configuration.js
@@ -15,9 +15,9 @@ const resolveAlias = {
   'styled-components': `${NODE_MODULES_DIR}/styled-components`,
   'react-intl': `${NODE_MODULES_DIR}/react-intl`,
   // Suppress useless warnings from react-date-picker's dep
-  'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`
+  'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`,
   // kepler.gl and loaders.gl need to use same apache-arrow
-  // 'apache-arrow': `${NODE_MODULES_DIR}/apache-arrow`
+  'apache-arrow': `${NODE_MODULES_DIR}/apache-arrow`
 };
 
 // add kepler.gl submodule aliases

--- a/webpack/shared-webpack-configuration.js
+++ b/webpack/shared-webpack-configuration.js
@@ -15,7 +15,9 @@ const resolveAlias = {
   'styled-components': `${NODE_MODULES_DIR}/styled-components`,
   'react-intl': `${NODE_MODULES_DIR}/react-intl`,
   // Suppress useless warnings from react-date-picker's dep
-  'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`
+  'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`,
+  // kepler.gl and loaders.gl need to use same apache-arrow
+  'apache-arrow': `${NODE_MODULES_DIR}/apache-arrow`
 };
 
 // add kepler.gl submodule aliases


### PR DESCRIPTION
The new GeoArrow sample seems not working on kepler.gl site. From the log, it seems different `apache-arrow` modules have been used and caused the error. This PR tries to fix this.

<img width="385" alt="Screenshot 2023-12-20 at 4 14 16 PM" src="https://github.com/keplergl/kepler.gl/assets/2423887/16bd97a1-921e-4d4f-a004-982004ff675b">
<img width="479" alt="Screenshot 2023-12-20 at 4 14 59 PM" src="https://github.com/keplergl/kepler.gl/assets/2423887/a5be58d9-b7f7-4910-863a-5a1cd0f47b34">
