### PR TITLE
[Fix] loading samples with CSV

### DIFF
--- a/examples/demo-app/src/reducers/index.js
+++ b/examples/demo-app/src/reducers/index.js
@@ -90,9 +90,16 @@ export const loadRemoteResourceSuccess = (state, action) => {
   // TODO: replace generate with a different function
   const datasetId = action.options.id || generateHashId(6);
   const {dataUrl} = action.options;
+
+  let data = action.response;
   let processorMethod = processRowObject;
+
   // TODO: create helper to determine file ext eligibility
-  if (dataUrl.includes('.json') || dataUrl.includes('.geojson')) {
+  if (dataUrl.includes('.csv')) {
+    processorMethod = processRowObject;
+    // loaders.gl csv loader returns ArrayRowTable{data, shape: 'arrary-row-table'}
+    data = action.response.data;
+  }  else if (dataUrl.includes('.json') || dataUrl.includes('.geojson')) {
     processorMethod = processGeojson;
   } else if (dataUrl.includes('.arrow')) {
     processorMethod = processArrowTable;
@@ -102,7 +109,7 @@ export const loadRemoteResourceSuccess = (state, action) => {
     info: {
       id: datasetId
     },
-    data: processorMethod(action.response)
+    data: processorMethod(data)
   };
 
   const config = action.config ? KeplerGlSchema.parseSavedConfig(action.config) : null;


### PR DESCRIPTION
Just took another round of tests and noticed the demo samples with CSV data are not correctly loaded. This is caused by switching to use loaders.gl to load csv, geojson and arrow data: 

For csv data, loaders.gl csv loader returns `ArrayRowTable` {data, shape: 'arrary-row-table'} instead of raw data, and it will work with `processRowObject()` method.

This PR fixes this issue.