### PR TITLE
[Fix] Example node-app Arrow Errors

### DIFF
--- a/examples/node-app/webpack.config.js
+++ b/examples/node-app/webpack.config.js
@@ -38,6 +38,12 @@ const CONFIG = {
         test: /\.json$/,
         loader: 'json-loader',
         exclude: [/node_modules/]
+      },
+      {
+        // fix for arrow-related errors
+        test: /\.mjs$/,
+        include: /node_modules/,
+        type: "javascript/auto"
       }
     ]
   },


### PR DESCRIPTION
Trying to run the `node-app` example fails with import errors like this:

```
ERROR in ./node_modules/apache-arrow/ipc/metadata/message.mjs 46:14-33
Can't import the named export 'Builder' from non EcmaScript module (only default export is available)
 @ ./node_modules/apache-arrow/Arrow.mjs
 @ ./node_modules/apache-arrow/Arrow.dom.mjs
 @ ./node_modules/@kepler.gl/utils/dist/arrow-data-container.js
 @ ./node_modules/@kepler.gl/utils/dist/index.js
 @ ./node_modules/@kepler.gl/components/dist/side-panel/layer-panel/layer-list.js
 @ ./node_modules/@kepler.gl/components/dist/index.js
 @ ./src/app.js
 @ ./src/main.js
```

Copying this fix from the `demo-app` resolves them:
https://github.com/keplergl/kepler.gl/blob/f897057379e4c5483fd3cfe788036e71d791dbaa/examples/demo-app/webpack.config.js#L40-L45