### PR TITLE
[feat] Pass in custom transformRequest function

### DIFF
--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -161,7 +161,10 @@ export const mapFieldsSelector = (props: KeplerGLProps, index: number = 0) => ({
 
   // mapStyle
   topMapContainerProps: props.topMapContainerProps,
-  bottomMapContainerProps: props.bottomMapContainerProps
+  bottomMapContainerProps: props.bottomMapContainerProps,
+
+  // transformRequest for Mapbox basemaps
+  transformRequest: props.transformRequest
 });
 
 export function getVisibleDatasets(datasets) {
@@ -317,6 +320,8 @@ type KeplerGLBasicProps = {
 
   topMapContainerProps?: object;
   bottomMapContainerProps?: object;
+
+  transformRequest?: (url: string) => {url: string};
 };
 
 type KeplerGLProps = KeplerGlState & KeplerGlActions & KeplerGLBasicProps;

--- a/src/utils/src/map-style-utils/mapbox-utils.ts
+++ b/src/utils/src/map-style-utils/mapbox-utils.ts
@@ -25,10 +25,7 @@ export function isStyleUsingMapboxTiles(mapStyle) {
 }
 
 export const transformRequest = (url: string): {url: string} => {
-  const isMapboxRequest =
-    url.slice(8, 22) === 'api.mapbox.com' || url.slice(10, 26) === 'tiles.mapbox.com';
-
   return {
-    url: isMapboxRequest ? url.replace('?', '?pluginName=Keplergl&') : url
+    url
   };
 };


### PR DESCRIPTION
- This adds a `transformRequest` function to kepler's public API, so that the Map SDK can pass in a custom `transformRequest` function to the renderer.