### PR TITLE
Update Ipywidgets>=8.x to fix security vulnerabilities

### DIFF
--- a/bindings/kepler.gl-jupyter/setup.py
+++ b/bindings/kepler.gl-jupyter/setup.py
@@ -64,7 +64,7 @@ setup_args = {
     'long_description': LONG_DESCRIPTION,
     'include_package_data': True,
     'install_requires': [
-        'ipywidgets>=7.0.0,<8',
+        'ipywidgets>=8.0.0',
         'traittypes>=0.2.1',
         'geopandas>=0.5.0',
         'pandas>=0.23.0',


### PR DESCRIPTION
Fix https://github.com/keplergl/kepler.gl/issues/2546

Is the project `dependabot` running on the python dependency tree?  The `setup.py` seems to be the place to patch this; the `bindings/kepler.gl-jupyter/requirements.txt` has not been touched in 5 years.

Since the current constraints prevent >= 8.x, this might cause an issue with the consumers of the ipywidgets API.

Bump ipywidgets >=8.0 to resolve CVEs:

```
-> Vulnerability found in ipywidgets version 7.8.1
   Vulnerability ID: 50664
   Affected spec: <8.0.0
   ADVISORY: Ipywidgets 8.0.0 sanitizes descriptions by default.https://github.com/jupyter-widgets/ipywidgets/pull/2785
   PVE-2022-50664
   For more information about this vulnerability, visit https://data.safetycli.com/v/50664/97c
   To ignore this vulnerability, use PyUp vulnerability id 50664 in safety’s ignore command-line argument or add the ignore to your safety policy file.


-> Vulnerability found in ipywidgets version 7.8.1
   Vulnerability ID: 50463
   Affected spec: <8.0.0rc2
   ADVISORY: Ipywidgets 8.0.0rc2 makes descriptions plaintext by default for security.https://github.com/jupyter-widgets/ipywidgets/pull/2785
   PVE-2022-50463
   For more information about this vulnerability, visit https://data.safetycli.com/v/50463/97c
   To ignore this vulnerability, use PyUp vulnerability id 50463 in safety’s ignore command-line argument or add the ignore to your safety policy file.
```

https://pypi.org/project/ipywidgets/#history
