### PR TITLE
[Docs] Update Node.js version in contributing guide to v18

### DIFF
--- a/contributing/DEVELOPERS.md
+++ b/contributing/DEVELOPERS.md
@@ -22,7 +22,7 @@ machine:
 
 * [Git](http://git-scm.com/): The [Github Guide to Installing Git][git-setup] is a good source of information.
 
-* [Node.js ^14.x](http://nodejs.org): We use Node to generate the documentation, run a
+* [Node.js ^18.x](http://nodejs.org): We use Node to generate the documentation, run a
   development web server, run tests, and generate distributable files. Depending on your system,
   you can install Node either from source or as a pre-packaged bundle.
 


### PR DESCRIPTION
Updates the contributing guide to match the `package.json#engines` requirement:

https://github.com/keplergl/kepler.gl/blob/4932e76acf37167481df6b222e293c16d78af2c5/package.json#L260-L262