### PR TITLE
[Release] Kepler-Jupyter 0.3.4 alpha release

### DIFF
--- a/bindings/kepler.gl-jupyter/README.md
+++ b/bindings/kepler.gl-jupyter/README.md
@@ -45,6 +45,21 @@ jupyter nbextension install --py --sys-prefix keplergl # can be skipped for note
 jupyter nbextension enable --py --sys-prefix keplergl # can be skipped for notebook 5.3 and above
 ```
 
+NOTE: For No Module named 'keplergl' error, please make sure your virtual environment is activated and has been added to the Jupyter kernel.
+
+Use the following command to check the kernel list:
+```shell
+jupyter kernelspec list
+```
+
+Use the following command to add the virtual environment to the Jupyter kernel:
+```shell
+python -m ipykernel install --user --name=myenv
+```
+
+The `--name` parameter is your preferred name to identify the virtual environment
+
+
 ### 2. For Google Colab:
 
 `keplergl` (>0.3.0) works with Google Colab. You can install it using pip.
@@ -119,6 +134,8 @@ jupyter labextension install keplergl-jupyter
 ## Quick Start
 
 ### For Jupyter Notebook and JupyterLab:
+
+NOTE: please make sure the python kernel is correctly specified in the notebook.
 
 ```python
 # Load kepler.gl with an empty map

--- a/bindings/kepler.gl-jupyter/js/package.json
+++ b/bindings/kepler.gl-jupyter/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keplergl-jupyter",
-  "version": "0.3.4",
+  "version": "0.3.4a0",
   "description": "This is a simple jupyter widget for kepler.gl, an advanced geo-spatial visualization tool, to render large-scale interactive maps.",
   "author": "Shan He",
   "license": "MIT",

--- a/bindings/kepler.gl-jupyter/pyproject.toml
+++ b/bindings/kepler.gl-jupyter/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["geopandas~=0.14.3", "ipywidgets~=7.8.1", "notebook~=6.0.1", "jupyter_packaging~=0.12.3", "jupyterlab~=4.1.6", "pyarrow~=16.0.0", "setuptools>=69.5.1", "wheel"]
+requires = ["geopandas~=0.14.3", "ipywidgets~=7.8.1", "notebook~=6.0.1", "jupyter_packaging~=0.12.3", "jupyter-contrib-nbextensions~=0.7.0", "jupyterlab~=4.1.6", "pyarrow~=16.0.0", "setuptools>=69.5.1", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/bindings/kepler.gl-jupyter/requirements.txt
+++ b/bindings/kepler.gl-jupyter/requirements.txt
@@ -1,9 +1,9 @@
 geopandas==0.14.3
 ipywidgets==7.8.1
-Shapely==1.6.4.post2
-traitlets==4.3.2
-traittypes==0.2.1
+ipykernel==6.29.4
+Shapely==2.0.4
 jupyter_packaging==0.12.3
+jupyter-contrib-nbextensions==0.7.0
 notebook==6.0.1
 setuptools==69.5.1
 jupyter==1.0.0

--- a/docs/keplergl-jupyter/README.md
+++ b/docs/keplergl-jupyter/README.md
@@ -74,13 +74,17 @@ $ jupyter labextension install @jupyter-widgets/jupyterlab-manager keplergl-jupy
 
       Datasets as a dictionary, key is the name of the dataset. Read more on [Accepted data format][data_format]
 
+  - __`use_arrow`__ `bool` _optional_ default: `False`
+
+      Allow load and render data faster using GeoArrow
+
   - __`config`__ `dict` _optional_
-      
+
       Map config as a dictionary. The `dataId` in the layer and filter settings should match the `name` of the dataset they are created under
 
   - __`show_docs`__ `bool` _optional_
-      
-      By default, the User Guide URL (<https://docs.kepler.gl/docs/keplergl-jupyter>) will be printed when a map is created. To hide the User Guide URL, set `show_docs=False`.   
+
+      By default, the User Guide URL (<https://docs.kepler.gl/docs/keplergl-jupyter>) will be printed when a map is created. To hide the User Guide URL, set `show_docs=False`.
 
 The following command will load kepler.gl widget below a cell.
 **The map object created here is `map_1` it will be used throughout the code example in this doc.**
@@ -112,6 +116,7 @@ map_2
 - Inputs
     - __`data`__ _required_ CSV, GeoJSON or DataFrame. Read more on [Accepted data format][data_format]
     - __`name`__ _required_ Name of the data entry.
+    - __`use_arrow`__ _optional_ Allow load and render data faster using GeoArrow.
 
 `name` of the dataset will be the saved to the `dataId` property of each `layer`, `filter` and `interactionConfig` in the config.
 
@@ -252,7 +257,7 @@ Interact with kepler.gl and customize layers and filters. Map data and config wi
 ## 5. Save and load config
 
 ### `.config`
-you can print your current map configuration at any time in the notebook 
+you can print your current map configuration at any time in the notebook
 ```python
 map_1.config
 ## {u'config': {u'mapState': {u'bearing': 2.6192893401015205,
@@ -355,7 +360,7 @@ app = Flask(__name__)
 @app.route('/')
 def index():
     return map_1._repr_html_()
-    
+
 if __name__ == '__main__':
     app.run(debug=True)
 ```


### PR DESCRIPTION
Get ready to tag keplergl 0.3.4-alpha release.

- Update dependencies
- Update docs
- Update version number

Note: For https://github.com/keplergl/kepler.gl/pull/2545, I did a test and noticed that the current implementation doesn't work with the latest ipywidgets 8.1.2. Therefore, the ipywidgets is still pinned to 7.8.1