### PR TITLE
[fix] fix for starting demo-app 

### DIFF
--- a/examples/webpack.config.local.js
+++ b/examples/webpack.config.local.js
@@ -118,7 +118,8 @@ function makeLocalDevConfig(env, EXAMPLE_DIR = LIB_DIR, externals = {}) {
           exclude: [
             /node_modules\/react-palm/,
             /node_modules\/react-data-grid/,
-            /node_modules\/@probe\.gl/
+            /node_modules\/@probe\.gl/,
+            /node_modules\/@loaders\.gl/
           ]
         },
         // for compiling apache-arrow ESM module
@@ -231,7 +232,7 @@ function addBabelSettings(env, config, exampleDir) {
           test: /\.(js|ts)$/,
           loader: 'babel-loader',
           options: BABEL_LOADER_OPTIONS,
-          include: [/node_modules\/@probe.gl/]
+          include: [/node_modules\/@probe\.gl/, /node_modules\/@loaders\.gl/]
         }
       ]
     }


### PR DESCRIPTION
Fir for starting demo-app.

At the moment running `yarn start` produces the following error:

```
ERROR in ./node_modules/@loaders.gl/core/node_modules/@probe.gl/log/dist/utils/hi-res-timestamp.js 7:27
Module parse failed: Unexpected token (7:27)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
|     let timestamp;
|     if (isBrowser() && window.performance) {
>         timestamp = window?.performance?.now?.();
|     }
|     else if ('hrtime' in process) {
```

Possibly related to #2593 