### PR TITLE
[fix] Reset default values when DropdownList component unmounts

### DIFF
--- a/src/components/src/common/item-selector/dropdown-list.tsx
+++ b/src/components/src/common/item-selector/dropdown-list.tsx
@@ -132,7 +132,9 @@ export default class DropdownList extends Component<DropdownListProps, DropdownL
 
   componentWillUnmount() {
     if (this.loadingRef.current) {
-      this.observer?.unobserve(this.loadingRef.current);
+      this.observer?.unobserve(this.loadingRef?.current);
+      this.page = 0;
+      this.prevY = 0;
     }
   }
 


### PR DESCRIPTION
- Reset default values when DropdownList component unmounts. If a component re-renders, this.page is 1 instead of 0 and the dropdown will either not render at all (if the options list isn't paginated) or will not start at the beginning of paginated options.