### PR TITLE
[fix] Making sure animated spinner has border width CSS prop set

### DIFF
--- a/src/components/src/common/loading-spinner.tsx
+++ b/src/components/src/common/loading-spinner.tsx
@@ -54,7 +54,8 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({
       color={color}
       style={{
         width: `${size - strokeWidth * 2 - gap * 2}px`,
-        height: `${size - strokeWidth * 2 - gap * 2}px`
+        height: `${size - strokeWidth * 2 - gap * 2}px`,
+        borderWidth: strokeWidth
       }}
     />
   </LoadingWrapper>


### PR DESCRIPTION
- Making sure animated spinner has border width CSS prop set. Setting the borderWidth prop explicitly ensures that the blue rotating arc is visible.