### PR TITLE
Replaced deprecated "assert" with "with"

### DIFF
--- a/examples/demo-app/esbuild.config.mjs
+++ b/examples/demo-app/esbuild.config.mjs
@@ -5,7 +5,7 @@ import process from 'node:process';
 import fs from 'node:fs';
 import {spawn} from 'node:child_process';
 import {join} from 'node:path';
-import KeplerPackage from '../../package.json' assert {type: 'json'};
+import KeplerPackage from '../../package.json' with {type: 'json'};
 
 const args = process.argv;
 const LIB_DIR = '../../';


### PR DESCRIPTION
The "assert" was removed in NodeJS 22. Instead "with" should be used. This was added in v17.1.0, v16.14.0.

https://nodejs.org/docs/latest-v22.x/api/esm.html#import-attributes