### PR TITLE
[chore] Split out column mode config into separate component

### DIFF
--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -22,7 +22,10 @@ import {
   LayerColorRangeSelectorFactory,
   ArcLayerColorSelectorFactory
 } from './side-panel/layer-panel/layer-color-selector';
-import LayerColumnModeConfigFactory from './side-panel/layer-panel/layer-column-mode-config';
+import {
+  default as LayerColumnModeConfigFactory,
+  ColumnModeConfigFactory
+} from './side-panel/layer-panel/layer-column-mode-config';
 import {appInjector} from './container';
 
 // Components
@@ -427,6 +430,7 @@ export {
   ColorSelectorFactory,
   LayerColorSelectorFactory,
   LayerColumnModeConfigFactory,
+  ColumnModeConfigFactory,
   LayerColorRangeSelectorFactory,
   ArcLayerColorSelectorFactory
 };

--- a/src/components/src/side-panel/layer-panel/layer-column-config.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-column-config.tsx
@@ -6,7 +6,6 @@ import React, {useCallback, useMemo} from 'react';
 import {LayerBaseConfig} from '@kepler.gl/layers';
 import {
   FieldPair,
-  Field,
   ColumnPairs,
   LayerColumns,
   ColumnLabels,
@@ -21,7 +20,7 @@ import {SidePanelSection} from '../../common/styled-components';
 export type LayerColumnConfigProps<FieldOption extends MinimalField> = {
   columns: LayerColumns;
   fields: FieldOption[];
-  assignColumnPairs: (key: string, pair: string) => LayerColumns;
+  assignColumnPairs: (key: string, pair: FieldPair) => LayerColumns;
   assignColumn: (key: string, field: FieldOption) => LayerColumns;
   updateLayerConfig: (newConfig: Partial<LayerBaseConfig>) => void;
   updateLayerType?: (newType: string) => void;
@@ -54,7 +53,7 @@ function getValidFieldPairsSuggestionsForColumn(
 LayerColumnConfigFactory.deps = [ColumnSelectorFactory];
 
 function LayerColumnConfigFactory(ColumnSelector: ReturnType<typeof ColumnSelectorFactory>) {
-  const LayerColumnConfig: React.FC<LayerColumnConfigProps<Field>> = ({
+  const LayerColumnConfig: React.FC<LayerColumnConfigProps<MinimalField>> = ({
     columnPairs,
     fieldPairs,
     columns,

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -63,7 +63,8 @@ import {
   LayerColumn,
   ColumnPairs,
   ColumnLabels,
-  SupportedColumnModes
+  SupportedColumnMode,
+  FieldPair
 } from '@kepler.gl/types';
 import {KeplerTable, Datasets, GpuFilter} from '@kepler.gl/table';
 
@@ -390,7 +391,7 @@ class Layer {
   /**
    * Returns which column modes this layer supports
    */
-  get supportedColumnModes(): SupportedColumnModes[] | null {
+  get supportedColumnModes(): SupportedColumnMode[] | null {
     return null;
   }
 
@@ -438,10 +439,10 @@ class Layer {
       return null;
     }
 
-    return this.getAllPossibleColumnParis(requiredColumns);
+    return this.getAllPossibleColumnPairs(requiredColumns);
   }
 
-  static getAllPossibleColumnParis(requiredColumns) {
+  static getAllPossibleColumnPairs(requiredColumns) {
     // for multiple matched field for one required column, return multiple
     // combinations, e. g. if column a has 2 matched, column b has 3 matched
     // 6 possible column pairs will be returned
@@ -571,9 +572,9 @@ class Layer {
    * Assign a field pair to column config, return column config
    * @param key - Column Key
    * @param pair - field Pair
-   * @returns {object} - Column config
+   * @returns Column config
    */
-  assignColumnPairs(key: string, pair: string): LayerColumns {
+  assignColumnPairs(key: string, pair: FieldPair): LayerColumns {
     if (!this.columnPairs || !this.columnPairs?.[key]) {
       // should not end in this state
       return this.config.columns;
@@ -931,7 +932,7 @@ class Layer {
     const {columns} = this.config;
     return (
       columns &&
-      Object.values(columns).every(column => {
+      Object.values(columns).every((column?: LayerColumn) => {
         return Boolean(column && (column.optional || (column.value && column.fieldIdx > -1)));
       })
     );

--- a/src/layers/src/layer-utils.ts
+++ b/src/layers/src/layer-utils.ts
@@ -3,7 +3,7 @@
 
 import * as arrow from 'apache-arrow';
 import {Feature, BBox} from 'geojson';
-import {Field, FieldPair, SupportedColumnModes, LayerColumns} from '@kepler.gl/types';
+import {Field, FieldPair, SupportedColumnMode, LayerColumns} from '@kepler.gl/types';
 import {DataContainerInterface} from '@kepler.gl/utils';
 import {
   getBinaryGeometriesFromArrow,
@@ -135,7 +135,7 @@ export function getHoveredObjectFromArrow(
  * find requiredColumns of supported column mode based on column mode
  */
 export function getColumnModeRequiredColumns(
-  supportedColumnModes: SupportedColumnModes[] | null,
+  supportedColumnModes: SupportedColumnMode[] | null,
   columnMode?: string
 ): string[] | undefined {
   return supportedColumnModes?.find(({key}) => key === columnMode)?.requiredColumns;
@@ -150,7 +150,7 @@ export function assignColumnsByColumnMode({
   columnMode
 }: {
   columns: LayerColumns;
-  supportedColumnModes: SupportedColumnModes[] | null;
+  supportedColumnModes: SupportedColumnMode[] | null;
   columnMode: string | undefined;
 }): LayerColumns {
   const requiredColumns = getColumnModeRequiredColumns(supportedColumnModes, columnMode);

--- a/src/types/layers.d.ts
+++ b/src/types/layers.d.ts
@@ -54,11 +54,12 @@ export type EnhancedFieldPair = {
   pair: FieldPair['pair'];
 };
 
-export type SupportedColumnModes = {
+export type SupportedColumnMode = {
   key: string;
   label: string;
   requiredColumns?: string[];
   optionalColumns?: string[];
+  hasHelp?: boolean;
 };
 
 export type LayerColorConfig = {

--- a/test/browser/layer-tests/base-layer-sepcs.js
+++ b/test/browser/layer-tests/base-layer-sepcs.js
@@ -111,7 +111,7 @@ test('#AggregationLayer -> updateLayerDomain', t => {
   t.end();
 });
 
-test('#BaseLayer -> getAllPossibleColumnParis', t => {
+test('#BaseLayer -> getAllPossibleColumnPairs', t => {
   const columnes1 = {
     a: [1, 2],
     b: [3, 4]
@@ -124,8 +124,8 @@ test('#BaseLayer -> getAllPossibleColumnParis', t => {
   const columnes3 = {
     a: [1]
   };
-  t.equal(Layer.getAllPossibleColumnParis(columnes1).length, 4, 'should find 4 pairs');
-  t.equal(Layer.getAllPossibleColumnParis(columnes2).length, 2, 'should find 4 pairs');
-  t.equal(Layer.getAllPossibleColumnParis(columnes3).length, 1, 'should find 4 pairs');
+  t.equal(Layer.getAllPossibleColumnPairs(columnes1).length, 4, 'should find 4 pairs');
+  t.equal(Layer.getAllPossibleColumnPairs(columnes2).length, 2, 'should find 4 pairs');
+  t.equal(Layer.getAllPossibleColumnPairs(columnes3).length, 1, 'should find 4 pairs');
   t.end();
 });


### PR DESCRIPTION
- This PR splits out a more general-purpose ColumnModeConfig that we can use separately outside of the layer panel.
- Looks the same as before, changes here should not affect user experience: