### PR TITLE
[Bug] Fix issue with React StrictMode causing Dataset table to not display

### DIFF
--- a/src/components/src/common/data-table/index.tsx
+++ b/src/components/src/common/data-table/index.tsx
@@ -422,6 +422,7 @@ function DataTableFactory(HeaderCell: ReturnType<typeof HeaderCellFactory>) {
 
     pinnedGrid: HTMLDivElement | null = null;
     unpinnedGrid: HTMLDivElement | null = null;
+    hasMounted = false;
 
     state: DataTableState = {
       cellSizeCache: {},
@@ -430,6 +431,7 @@ function DataTableFactory(HeaderCell: ReturnType<typeof HeaderCellFactory>) {
     };
 
     componentDidMount() {
+      this.hasMounted = true;
       window.addEventListener('resize', this.scaleCellsToWidth);
       this.scaleCellsToWidth();
     }
@@ -444,11 +446,9 @@ function DataTableFactory(HeaderCell: ReturnType<typeof HeaderCellFactory>) {
     }
 
     componentWillUnmount() {
+      this.hasMounted = false;
       window.removeEventListener('resize', this.scaleCellsToWidth);
       // fix Warning: Can't perform a React state update on an unmounted component
-      this.setState = () => {
-        return;
-      };
     }
 
     root = createRef<HTMLDivElement>();
@@ -458,12 +458,16 @@ function DataTableFactory(HeaderCell: ReturnType<typeof HeaderCellFactory>) {
       !Array.isArray(pinnedColumns) ? columns : columns.filter(c => !pinnedColumns.includes(c))
     );
 
-    toggleMoreOptions = moreOptionsColumn =>
-      this.setState({
-        moreOptionsColumn:
-          this.state.moreOptionsColumn === moreOptionsColumn ? null : moreOptionsColumn
-      });
-    toggleShowStats = () => this.setState({showStats: !this.state.showStats});
+    toggleMoreOptions = moreOptionsColumn => {
+      if (this.hasMounted)
+        this.setState({
+          moreOptionsColumn:
+            this.state.moreOptionsColumn === moreOptionsColumn ? null : moreOptionsColumn
+        });
+    };
+    toggleShowStats = () => {
+      if (this.hasMounted) this.setState({showStats: !this.state.showStats});
+    };
     getCellSizeCache = () => {
       const {cellSizeCache: propsCache = {}, fixedWidth, pinnedColumns = []} = this.props;
       const unpinnedColumns = this.unpinnedColumns(this.props);
@@ -486,7 +490,7 @@ function DataTableFactory(HeaderCell: ReturnType<typeof HeaderCellFactory>) {
     };
 
     doScaleCellsToWidth = () => {
-      this.setState(this.getCellSizeCache());
+      if (this.hasMounted) this.setState(this.getCellSizeCache());
     };
 
     scaleCellsToWidth = debounce(this.doScaleCellsToWidth, 300);

--- a/src/components/src/common/portaled.tsx
+++ b/src/components/src/common/portaled.tsx
@@ -168,6 +168,7 @@ class Portaled extends Component<PortaledProps, PortaledState> {
   _unmounted = false;
 
   componentDidMount() {
+    this._unmounted = false;
     // relative
     this.unsubscribe = subscribe(this.handleScroll);
     this.handleScroll();


### PR DESCRIPTION
**Describe the bug**
When clicking the "View Data Table" button in a React or Next.js application while using Strict Mode, the dataset table is not visible. This issue occurs because this.setState is set to an empty function in the componentDidUnmount lifecycle method.

In Strict Mode, componentDidUnmount is called at the start (detect potential issues), which causes this.setState to be set as an empty function prematurely. As a result, any subsequent calls to setState do not change the state of the component.

The issue has been fixed by introducing a hasMounted flag to ensure that setState is only called when the component is mounted.

A similar issue occurs when the data table is visible, and the three vertical dots near each column are clicked. In Strict Mode, the dropdown menu does not appear.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to examples/demo-app/src/main.js or create a new React/Next.js application.
2. Wrap the component in React.StrictMode.
3. Open the application in the browser, upload a dataset, and click the "View Data Table" button.
4. Observe that the dataset table is blank.

**Expected behavior**
The dataset table should be visible, and the dropdown near each column name should be functional in Strict Mode.

**Desktop (please complete the following information):**
 - OS: Ubuntu
 - Browser: Chrome, firefox
 - Version: Ubuntu 24.04.1 LTS

![kepler_dataset_issue](https://github.com/user-attachments/assets/bf6ab254-6bd2-48d0-ac1a-5cece971a418)

