### PR TITLE
[fix] Time Sync bugfixes

### DIFF
--- a/src/components/src/bottom-widget.tsx
+++ b/src/components/src/bottom-widget.tsx
@@ -86,6 +86,11 @@ export default function BottomWidgetFactory(
     const enlargedFilterIdx = useMemo(() => filters.findIndex(f => !isSideFilter(f)), [filters]);
     const animatedFilterIdx = useMemo(() => filters.findIndex(f => f.isAnimating), [filters]);
     const animatedFilter = animatedFilterIdx > -1 ? filters[animatedFilterIdx] : null;
+    // we need to hide layer timeline when filter is synced and not enlarged
+    const isTimelineLinkedWithFilter = useMemo(
+      () => (filters as TimeRangeFilter[]).some(f => f.syncedWithLayerTimeline),
+      [filters]
+    );
 
     const isMobile = useMemo(() => hasPortableWidth(breakPointValues), []);
     const isLegendPinned =
@@ -159,7 +164,7 @@ export default function BottomWidgetFactory(
         hasPadding={showAnimationControl || showTimeWidget}
         ref={rootRef}
       >
-        {!filter?.syncedWithLayerTimeline ? (
+        {!isTimelineLinkedWithFilter ? (
           <LayerAnimationController
             animationConfig={enhancedAnimationConfig}
             setLayerAnimationTime={visStateActions.setLayerAnimationTime}

--- a/src/components/src/common/histogram-plot.tsx
+++ b/src/components/src/common/histogram-plot.tsx
@@ -94,6 +94,7 @@ function HistogramPlotFactory() {
     );
 
     const barWidth = useMemo(() => {
+      if (groupKeys.length === 0) return 0;
       // find histogramsByGroup with max number of bins
       const maxGroup = groupKeys.reduce((accu, key, idx) => {
         if (histogramsByGroup[key].length > accu.length) {
@@ -110,6 +111,9 @@ function HistogramPlotFactory() {
       return width / maxBins / groupKeys.length;
     }, [histogramsByGroup, domain, groupKeys, width]);
 
+    if (groupKeys.length === 0) {
+      return null;
+    }
     return (
       <HistogramWrapper width={width} height={height} style={{marginTop: `${margin.top}px`}}>
         {groupKeys.map((key, i) => (

--- a/src/components/src/filters/filter-panels/filter-synced-dataset-panel.tsx
+++ b/src/components/src/filters/filter-panels/filter-synced-dataset-panel.tsx
@@ -284,14 +284,14 @@ function FilterSyncedDatasetPanelFactory(
           <UnsyncLayerTimelineButton onSyncLayerTimeline={onRemoveSyncWithLayerTimeline} />
         ) : (
           <>
-            {tripLayers.length && (
+            {tripLayers.length ? (
               <SyncLayerTimelineButton onSyncLayerTimeline={onSyncLayerTimeline} />
-            )}
+            ) : null}
           </>
         )}
-        {filterDatasetsNum < datasetsWithTimeNum && (
+        {filterDatasetsNum < datasetsWithTimeNum ? (
           <SyncedDatasetButton onAddSyncedFilter={onAddSyncedFilter} />
-        )}
+        ) : null}
       </SyncedDatasetsArea>
     );
   };

--- a/src/utils/src/plot.ts
+++ b/src/utils/src/plot.ts
@@ -137,6 +137,9 @@ export function getTimeBins(
 export function binByTime(indexes, dataset, interval, filter) {
   // gpuFilters need to be apply to filteredIndex
   const mappedValue = getFilterMappedValue(dataset, filter);
+  if (!mappedValue) {
+    return null;
+  }
   const intervalBins = getBinThresholds(interval, filter.domain);
 
   const bins = histogramFromThreshold(intervalBins, mappedValue, indexes);


### PR DESCRIPTION
- hide layer timelines if a filter is synced and not enlarged
- Add guard to prevent crash in binByTime
- fix 0 display in synced dataset filter panel