### PR TITLE
Update the path to relative path in utils

### DIFF
--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -147,5 +147,5 @@ export {getCentroid, getHexFields, h3IsValid, idToPolygonGeo} from './h3-utils';
 export type {Centroid} from './h3-utils';
 
 // Application config
-export {getApplicationConfig, initApplicationConfig} from '../../utils/src/application-config';
-export type {KeplerApplicationConfig, MapLibInstance} from '../../utils/src/application-config';
+export {getApplicationConfig, initApplicationConfig} from './application-config';
+export type {KeplerApplicationConfig, MapLibInstance} from './application-config';


### PR DESCRIPTION
When built and used in an external web app, the `@kepler.gl/utils` was giving error because the application config was imported from `../../utils/src/application-config`. After building the `src` folder is missing so updated the imports to use the relative path to get rid of the error.

* Before in the build code:

![Screenshot 2024-11-20 231658](https://github.com/user-attachments/assets/139ef1fb-b02e-4a88-aa85-a4f71dcb5725)

* After in the build code:

![Screenshot 2024-11-20 231841](https://github.com/user-attachments/assets/c7d56b2f-af42-4042-b195-6467d6de3265)
