### PR TITLE
[chore] fix for package publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          corepack-enable: true
           registry-url: https://registry.npmjs.org/
       - run: npm install -g yarn
       - run: yarn bootstrap


### PR DESCRIPTION
- possible fix for failing npm-publish

```
error This project's package.json defines "packageManager": "yarn@4.4.0". However the current global version of Yarn is 1.22.22.
Presence of the "packageManager" field indicates that the project is meant to be used with Corepack, a tool included by default with all official Node.js distributions starting from 16.[9]
```