### PR TITLE
[fix] fix examples - proper publicPath do load dynamic lib imports

### DIFF
--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -156,7 +156,8 @@ const addProdConfig = config => {
   return Object.assign(config, {
     output: {
       path: resolve(__dirname, './dist'),
-      filename: 'bundle.js'
+      filename: 'bundle.js',
+      publicPath: "/"
     }
   });
 };


### PR DESCRIPTION
- this issue was caused by dynamic module loading for map libs (introduced two months ago), but this issue appeared only with the attempted release.
- bundle.js tried to import map-libre-gl from the wrong path.

PS: trigger release to update examples ?