### PR TITLE
[fix] align upload icon

### DIFF
--- a/src/components/src/common/file-uploader/file-upload.tsx
+++ b/src/components/src/common/file-uploader/file-upload.tsx
@@ -17,8 +17,6 @@ import ReactMarkdown from 'react-markdown';
 import {FormattedMessage} from '@kepler.gl/localization';
 import {media} from '@kepler.gl/styles';
 
-/** @typedef {import('./file-upload').FileUploadProps} FileUploadProps */
-
 const fileIconColor = '#D3D8E0';
 
 const LinkRenderer = props => {
@@ -81,6 +79,9 @@ const MsgWrapper = styled.div`
 const StyledDragNDropIcon = styled.div`
   color: ${fileIconColor};
   margin-bottom: 48px;
+
+  display: flex;
+  justify-content: center;
 
   ${media.portable`
     margin-bottom: 16px;


### PR DESCRIPTION
- add data modal: align icon to center.

<img width="993" alt="Screen Shot 2024-11-28 at 11 15 23 PM" src="https://github.com/user-attachments/assets/081b35fe-765c-4b5e-ae25-d410c0d64c20">
