### PR TITLE
[fix] Fixed time filter bug where points located at the borders of the domains were not correctly displayed

### DIFF
--- a/src/components/src/common/range-brush.tsx
+++ b/src/components/src/common/range-brush.tsx
@@ -219,8 +219,9 @@ function RangeBrushFactory(): React.ComponentType<RangeBrushProps> {
       const invert = (x: number) => (x * (max - min)) / width + min;
       let d0 = invert(sel0);
       let d1 = invert(sel1);
-
-      d0 = normalizeSliderValue(d0, min, step, marks);
+      // this makes sure if points are right at the beginning of the domains are displayed correctly
+      // the problem here is bisectLeftx
+      d0 = d0 === min ? d0 : normalizeSliderValue(d0, min, step, marks);
       d1 = normalizeSliderValue(d1, min, step, marks);
 
       if (isRanged) this._move(d0, d1);

--- a/src/components/src/common/range-plot.tsx
+++ b/src/components/src/common/range-plot.tsx
@@ -16,7 +16,7 @@ import {Datasets} from '@kepler.gl/table';
 const StyledRangePlot = styled.div`
   margin-bottom: ${props => props.theme.sliderBarHeight}px;
   display: flex;
-  position: 'relative';
+  position: relative;
 `;
 
 interface RangePlotProps {
@@ -57,6 +57,13 @@ const isHistogramPlot = plotType => plotType?.type === PLOT_TYPES.histogram;
 const isLineChart = plotType => plotType?.type === PLOT_TYPES.lineChart;
 const hasHistogram = (plotType, bins) => isHistogramPlot(plotType) && bins;
 const hasLineChart = (plotType, lineChart) => isLineChart(plotType) && lineChart;
+
+const LOADING_SPINNER_CONTAINER_STYLE = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%'
+};
 
 export default function RangePlotFactory(
   RangeBrush: ReturnType<typeof RangeBrushFactory>,
@@ -221,14 +228,7 @@ export default function RangePlotFactory(
     return (
       <StyledRangePlot style={rangePlotStyle} className="kg-range-slider__plot">
         {isLoading ? (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: '100%'
-            }}
-          >
+          <div style={LOADING_SPINNER_CONTAINER_STYLE}>
             <LoadingSpinner borderColor="transparent" size={40} />
           </div>
         ) : (


### PR DESCRIPTION
- When we initially created the time filters all points are correctly displayed and highlighted but after we start dragging the time line If one point of the dataset is located within the first mark, that point will never be highlighted correctly because of the bisectLeft operation.
- Fixed time filter bug where points located at the borders of the domains were not correctly displayed