### PR TITLE
[fix] hide ColorBreaksDisplay when allBins is empty

### DIFF
--- a/src/components/src/side-panel/layer-panel/color-breaks-panel.tsx
+++ b/src/components/src/side-panel/layer-panel/color-breaks-panel.tsx
@@ -194,7 +194,7 @@ function ColorBreaksPanelFactory(
               onApply={onApply}
               onCancel={onCilckCancel}
             />
-          ) : currentBreaks ? (
+          ) : currentBreaks && allBins.length > 1 ? (
             <ColorBreaksDisplay
               currentBreaks={currentBreaks}
               onEdit={isCustomBreaks ? onClickEditCustomBreaks : null}


### PR DESCRIPTION
- hide ColorBreaksDisplay when allBins is empty