### PR TITLE
[Bug] Prevent dragging legend component outside of container

### DIFF
--- a/src/components/src/map/map-legend-panel.tsx
+++ b/src/components/src/map/map-legend-panel.tsx
@@ -24,6 +24,7 @@ import {withState} from '../injector';
 import MapControlPanelFactory from './map-control-panel';
 import MapControlTooltipFactory from './map-control-tooltip';
 import MapLegendFactory from './map-legend';
+import {restrictToWindowEdges} from '@dnd-kit/modifiers';
 
 const DRAG_RESIZE_ID = 'map-legend-resize';
 const DRAG_MOVE_ID = 'map-legend-move';
@@ -203,6 +204,7 @@ const DraggableLegend = withState(
         onDragStart={handleDragStart}
         onDragMove={handleDragMove}
         onDragEnd={handleDragEnd}
+        modifiers={[restrictToWindowEdges]}
       >
         <DraggableLegendContent
           ref={legendContentRef}


### PR DESCRIPTION
The legend may overlap if other components are positioned below the Kepler container

https://github.com/user-attachments/assets/7680e361-673f-4613-98e6-7b3fe26c31b8

