### PR TITLE
[fix] Use floating-ui to deal with closing on click outside

### DIFF
--- a/src/components/src/common/animation-control/animation-speed-slider.tsx
+++ b/src/components/src/common/animation-control/animation-speed-slider.tsx
@@ -3,9 +3,11 @@
 
 import React, {useCallback} from 'react';
 import styled from 'styled-components';
-import RangeSliderFactory from '../range-slider';
+import {useDismiss, useFloating, useInteractions} from '@floating-ui/react';
+
 import {SPEED_CONTROL_RANGE, SPEED_CONTROL_STEP} from '@kepler.gl/constants';
-import useOnClickOutside from '../../hooks/use-on-click-outside';
+
+import RangeSliderFactory from '../range-slider';
 
 const SliderWrapper = styled.div`
   position: relative;
@@ -41,13 +43,27 @@ export default function AnimationSpeedSliderFactory(
     onHide,
     speed,
     updateAnimationSpeed
-  }) => {
-    const ref = useOnClickOutside<HTMLDivElement>(onHide);
+  }: AnimationSpeedSliderProps) => {
+    // floating-ui boilerplate to establish close on outside click
+    const {refs, context} = useFloating({
+      open: true,
+      onOpenChange: v => {
+        if (!v) {
+          onHide();
+        }
+      }
+    });
+    const dismiss = useDismiss(context);
+    const {getFloatingProps} = useInteractions([dismiss]);
 
     const onChange = useCallback(v => updateAnimationSpeed(v[1]), [updateAnimationSpeed]);
 
     return (
-      <SpeedSliderContainer className="animation-control__speed-slider" ref={ref}>
+      <SpeedSliderContainer
+        className="animation-control__speed-slider"
+        ref={refs.setFloating}
+        {...getFloatingProps()}
+      >
         <SliderWrapper>
           <RangeSlider
             range={SPEED_CONTROL_RANGE}

--- a/src/components/src/modals/export-map-modal/export-json-map.tsx
+++ b/src/components/src/modals/export-map-modal/export-json-map.tsx
@@ -72,7 +72,9 @@ const ExportJsonMapUnmemoized = ({config = {}}: ExportJsonPropTypes) => {
           <div className="viewer">
             <JSONPretty id="json-pretty" json={config} />
             <CopyToClipboard text={JSON.stringify(config)} onCopy={() => setCopy(true)}>
-              <Button width="80px" className="copy-button">{copied ? 'Copied!' : 'Copy'}</Button>
+              <Button width="80px" className="copy-button">
+                {copied ? 'Copied!' : 'Copy'}
+              </Button>
             </CopyToClipboard>
           </div>
           <div className="disclaimer">

--- a/src/schemas/src/schema-manager.ts
+++ b/src/schemas/src/schema-manager.ts
@@ -104,12 +104,12 @@ export class KeplerGLSchema {
     validVersions = VERSIONS,
     version = CURRENT_VERSION,
     composedReducerSchema
-}: KeplerGLSchemaProps = {}) {
+  }: KeplerGLSchemaProps = {}) {
     this._validVersions = validVersions;
     this._version = version;
     this._reducerSchemas = reducers;
     this._datasetSchema = datasets;
-    this._composedReducerSchema = composedReducerSchema || null; 
+    this._composedReducerSchema = composedReducerSchema || null;
 
     this._datasetLastSaved = null;
     this._savedDataset = null;

--- a/src/utils/src/color-utils.ts
+++ b/src/utils/src/color-utils.ts
@@ -7,7 +7,14 @@ import {
   DEFAULT_CUSTOM_PALETTE,
   colorPaletteToColorRange
 } from '@kepler.gl/constants';
-import {ColorMap, ColorRange, ColorRangeConfig, HexColor, RGBColor} from '@kepler.gl/types';
+import {
+  ColorMap,
+  ColorRange,
+  ColorRangeConfig,
+  HexColor,
+  RGBAColor,
+  RGBColor
+} from '@kepler.gl/types';
 import {rgb as d3Rgb} from 'd3-color';
 import {interpolate} from 'd3-interpolate';
 import {arrayInsert, arrayMove} from './utils';
@@ -51,7 +58,7 @@ function PadNum(c) {
  * @param rgb
  * @returns hex string
  */
-export function rgbToHex([r, g, b]: RGBColor): HexColor {
+export function rgbToHex([r, g, b]: RGBColor | RGBAColor): HexColor {
   return `#${[r, g, b].map(n => PadNum(n)).join('')}`.toUpperCase();
 }
 


### PR DESCRIPTION
- use `floating-ui` in `AnimationSpeedSlider` and `ColorSelector` to deal with closing on click outside.
- For both of the above components, this fixes the component from disappearing immediately in a programable environment even when clicking internally, bypassing important onClick event logic.
