### PR TITLE
[fix] Handle selecting geojson polygon with missing properties

### DIFF
--- a/src/components/src/map/map-popover.tsx
+++ b/src/components/src/map/map-popover.tsx
@@ -11,7 +11,7 @@ import {RootContext} from '../context';
 import {parseGeoJsonRawFeature} from '@kepler.gl/layers';
 import {generateHashId, idToPolygonGeo} from '@kepler.gl/common-utils';
 import {LAYER_TYPES} from '@kepler.gl/constants';
-import {LayerHoverProp} from '@kepler.gl/reducers';
+import {LayerHoverProp, getLayerHoverPropValue} from '@kepler.gl/reducers';
 import {Feature, FeatureSelectionContext} from '@kepler.gl/types';
 import {
   FloatingPortal,
@@ -144,21 +144,30 @@ export function getSelectedFeature(layerHoverProp: LayerHoverProp | null): Featu
   switch (layer?.type) {
     case LAYER_TYPES.hexagonId:
       fieldIdx = layer.config?.columns?.hex_id?.fieldIdx;
-      selectedFeature = idToPolygonGeo({id: layerHoverProp?.data?.[fieldIdx]}, {isClosed: true});
+      selectedFeature = idToPolygonGeo(
+        {id: getLayerHoverPropValue(layerHoverProp?.data, fieldIdx)},
+        {isClosed: true}
+      );
       break;
     case LAYER_TYPES.geojson:
       fieldIdx = layer.config?.columns?.geojson?.fieldIdx;
-      selectedFeature = parseGeoJsonRawFeature(layerHoverProp?.data?.[fieldIdx]);
+      selectedFeature = parseGeoJsonRawFeature(
+        getLayerHoverPropValue(layerHoverProp?.data, fieldIdx)
+      );
       break;
     default:
       break;
   }
 
-  return {
-    ...selectedFeature,
-    // unique id should be assigned to features in the editor
-    id: generateHashId(8)
-  };
+  if (selectedFeature) {
+    return {
+      ...selectedFeature,
+      // unique id should be assigned to features in the editor
+      id: generateHashId(8)
+    };
+  } else {
+    return null;
+  }
 }
 
 export type MapPopoverProps = {

--- a/src/layers/src/geojson-layer/geojson-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.ts
@@ -44,6 +44,7 @@ type FeatureTypeMap = {
 /* eslint-enable */
 
 export function parseGeoJsonRawFeature(rawFeature: unknown): Feature | null {
+  const properties = null; // help ensure that properties is present on the returned geojson feature
   if (typeof rawFeature === 'object') {
     // Support GeoJson feature as object
     // probably need to normalize it as well
@@ -53,9 +54,12 @@ export function parseGeoJsonRawFeature(rawFeature: unknown): Feature | null {
       return null;
     }
 
-    return normalized.features[0];
+    return {properties, ...normalized.features[0]};
   } else if (typeof rawFeature === 'string') {
-    return parseGeometryFromString(rawFeature);
+    const parsedGeometry = parseGeometryFromString(rawFeature);
+    if (!parsedGeometry) return null;
+    // @ts-expect-error verify whether parsedGeometry always contains properties
+    return {properties, ...parsedGeometry};
   } else if (Array.isArray(rawFeature)) {
     // Support GeoJson  LineString as an array of points
     return {
@@ -65,7 +69,7 @@ export function parseGeoJsonRawFeature(rawFeature: unknown): Feature | null {
         coordinates: rawFeature.map(pts => [pts[1], pts[0]]),
         type: 'LineString'
       },
-      properties: {}
+      properties
     };
   }
 

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -473,3 +473,12 @@ export function addLayerToLayerOrder(
 ): string[] {
   return [layerId, ...layerOrder];
 }
+
+export function getLayerHoverPropValue(
+  data: DataRow | AggregationLayerHoverData | null | undefined,
+  fieldIndex: number
+) {
+  if (!data) return undefined;
+  if (data instanceof DataRow) return data.valueAt(fieldIndex);
+  return data[fieldIndex];
+}

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -2983,7 +2983,7 @@ export function setFeaturesUpdater(
       ...state.editor,
       // only save none filter features to editor
       features: features.filter(f => !getFilterIdInFeature(f)),
-      mode: lastFeature && lastFeature.properties.isClosed ? EDITOR_MODES.EDIT : state.editor.mode
+      mode: lastFeature && lastFeature.properties?.isClosed ? EDITOR_MODES.EDIT : state.editor.mode
     }
   };
 


### PR DESCRIPTION
- fix crashing geojson polygon isClosed check for the editor selected feature when the feature `properties` are nullish
- don't set the selected feature in map popover if it is effectively empty