### PR TITLE
[fix] Don't show 0 when saved map description is empty

### DIFF
--- a/src/components/src/modals/cloud-components/cloud-item.tsx
+++ b/src/components/src/modals/cloud-components/cloud-item.tsx
@@ -124,7 +124,9 @@ export const CloudItem = ({vis, onClick}) => {
         </MapIcon>
       )}
       <span className="vis_item-title">{vis.title}</span>
-      {vis.description?.length && <span className="vis_item-description">{vis.description}</span>}
+      {vis.description?.length > 0 && (
+        <span className="vis_item-description">{vis.description}</span>
+      )}
       <span className="vis_item-modification-date">
         Last modified {moment.utc(vis.updatedAt).fromNow()}
       </span>


### PR DESCRIPTION
- Don't show 0 when saved map description is empty

<img width="713" alt="Screenshot 2025-01-13 at 10 20 29 PM" src="https://github.com/user-attachments/assets/d401d248-a40b-46eb-a22f-9981409e23d4" />

<img width="486" alt="Screenshot 2025-01-13 at 10 20 07 PM" src="https://github.com/user-attachments/assets/7a2a8bff-41db-4843-aebc-1c35b3d0f868" />
