### PR TITLE
[fix] opening multiple examples breaks url

### DIFF
--- a/examples/demo-app/src/actions.js
+++ b/examples/demo-app/src/actions.js
@@ -90,7 +90,7 @@ export function onLoadCloudMapSuccess({provider, loadParams}) {
   return dispatch => {
     const mapUrl = provider?.getMapUrl(loadParams);
     if (mapUrl) {
-      const url = `demo/map/${provider.name}?path=${mapUrl}`;
+      const url = `/demo/map/${provider.name}?path=${mapUrl}`;
       dispatch(push(url));
     }
   };


### PR DESCRIPTION
  - fix for opening multiple examples breaks url

After opening several examples:
<img width="699" alt="Screenshot 2025-01-13 at 11 11 52 PM" src="https://github.com/user-attachments/assets/8f3debd7-d309-4f8f-90db-33b4fb9a95f3" />

With the fix:
<img width="835" alt="Screenshot 2025-01-13 at 11 11 24 PM" src="https://github.com/user-attachments/assets/75cb9ba3-e632-4c6b-ab1e-8c727faa89c3" />
