### PR TITLE
[fix] fix csv table examples for layers

### DIFF
--- a/src/layers/src/example-table.tsx
+++ b/src/layers/src/example-table.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import styled from 'styled-components';
+
+export const StyledTable = styled.table`
+  width: 100%;
+  border-spacing: 0;
+
+  thead {
+    tr th {
+      background: ${props => props.theme.panelBackgroundLT};
+      color: ${props => props.theme.titleColorLT};
+      padding: 18px 12px;
+      text-align: start;
+    }
+  }
+
+  tbody {
+    tr td {
+      border-bottom: ${props => props.theme.panelBorderLT};
+      padding: 12px;
+    }
+  }
+`;
+
+export default StyledTable;

--- a/src/layers/src/geojson-layer/geojson-info-modal.tsx
+++ b/src/layers/src/geojson-layer/geojson-info-modal.tsx
@@ -8,7 +8,7 @@ import {useIntl} from 'react-intl';
 
 import {FormattedMessage} from '@kepler.gl/localization';
 
-import Table from '../table';
+import Table from '../example-table';
 
 const InfoModal = styled.div`
   font-size: 13px;

--- a/src/layers/src/icon-layer/icon-info-modal.tsx
+++ b/src/layers/src/icon-layer/icon-info-modal.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 import styled from 'styled-components';
 import {line} from 'd3-shape';
 import {FormattedMessage} from '@kepler.gl/localization';
-import Table from '../table';
+
+import Table from '../example-table';
 
 const CenterFlexbox = styled.div`
   display: flex;

--- a/src/layers/src/scenegraph-layer/scenegraph-info-modal.tsx
+++ b/src/layers/src/scenegraph-layer/scenegraph-info-modal.tsx
@@ -4,26 +4,7 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export const Table = styled.table`
-  width: 100%;
-  border-spacing: 0;
-
-  thead {
-    tr th {
-      background: ${props => props.theme.panelBackgroundLT};
-      color: ${props => props.theme.titleColorLT};
-      padding: 18px 12px;
-      text-align: start;
-    }
-  }
-
-  tbody {
-    tr td {
-      border-bottom: ${props => props.theme.panelBorderLT};
-      padding: 12px;
-    }
-  }
-`;
+import Table from '../example-table';
 
 const StyledTitle = styled.div`
   font-size: 20px;

--- a/src/layers/src/trip-layer/trip-info-modal.tsx
+++ b/src/layers/src/trip-layer/trip-info-modal.tsx
@@ -8,7 +8,7 @@ import {useIntl} from 'react-intl';
 
 import {FormattedMessage} from '@kepler.gl/localization';
 
-import Table from '../table';
+import Table from '../example-table';
 
 const InfoModal = styled.div`
   font-size: 13px;


### PR DESCRIPTION
Examples for csv tables for several layers are broken:

<img width="993" alt="Screenshot 2025-01-20 at 3 20 46 PM" src="https://github.com/user-attachments/assets/e7d0f1b6-7d52-473e-855c-53bb2cbba3e4" />

After the fix:
<img width="945" alt="Screenshot 2025-01-20 at 3 21 09 PM" src="https://github.com/user-attachments/assets/2f86e9eb-141c-4405-9cbe-163a48fba3d6" />
<img width="932" alt="Screenshot 2025-01-20 at 3 19 26 PM" src="https://github.com/user-attachments/assets/13968ea4-5896-498c-9528-f8ead61b680d" />
<img width="930" alt="Screenshot 2025-01-20 at 3 07 06 PM" src="https://github.com/user-attachments/assets/4e82ddf7-588e-4e34-a090-5f5127b4252e" />
