### PR TITLE
[fix] use saved map config for maps saved in storage instead of zoom in to data

### DIFF
--- a/src/actions/src/vis-state-actions.ts
+++ b/src/actions/src/vis-state-actions.ts
@@ -840,7 +840,7 @@ export function setColumnDisplayFormat(
 }
 
 export type AddDataToMapUpdaterOptions = {
-  centrMap?: boolean;
+  centerMap?: boolean;
   readOnly?: boolean;
   keepExistingConfig?: boolean;
 };

--- a/src/reducers/src/provider-state-updaters.ts
+++ b/src/reducers/src/provider-state-updaters.ts
@@ -338,7 +338,11 @@ async function parseLoadMapResponseTask({
   return {
     datasets: parsedDatasets,
     info,
-    ...(map.config ? {config: map.config} : {})
+    ...(map.config ? {config: map.config} : {}),
+    options: {
+      // do not center map when loading cloud map
+      centerMap: false
+    }
   };
 }
 


### PR DESCRIPTION
- use saved map config for maps saved in storage instead of zoom in to data