### PR TITLE
[fix] don't auto create point layer from vector tiles

### DIFF
--- a/src/layers/src/point-layer/point-layer.ts
+++ b/src/layers/src/point-layer/point-layer.ts
@@ -331,7 +331,7 @@ export default class PointLayer extends Layer {
     }[] = [];
 
     if (type === DatasetType.VECTOR_TILE) {
-      return props;
+      return {props};
     }
 
     // Make layer for each pair


### PR DESCRIPTION
- temp fix to prevent auto creation of point layers from vector tiles with lat / lon fields