### PR TITLE
[feat] minZoom and maxZoom for examples

### DIFF
--- a/examples/demo-app/src/reducers/index.js
+++ b/examples/demo-app/src/reducers/index.js
@@ -175,6 +175,16 @@ const loadRemoteDatasetProcessedSuccess = (state, action) => {
 
   const parsedConfig = config ? KeplerGlSchema.parseSavedConfig(config) : null;
 
+  // a hack to use minZoom and maxZoom from examples
+  if (parsedConfig?.mapState) {
+    if (typeof config?.config?.mapState?.maxZoom === 'number') {
+      parsedConfig.mapState.maxZoom = config.config.mapState.maxZoom;
+    }
+    if (typeof config?.config?.mapState?.minZoom === 'number') {
+      parsedConfig.mapState.minZoom = config.config.mapState.maxZoom;
+    }
+  }
+
   const keplerGlInstance = combinedUpdaters.addDataToMapUpdater(
     state.keplerGl.map, // "map" is the id of your kepler.gl instance
     {


### PR DESCRIPTION
- KeplerGlSchema drops minZoom and maxZoom for mapState.
- for examples inject custom minZoom and maxZoom from remote configs.