### PR TITLE
(WIP) [feat] emulate geoarrow.wkb and geoarrow.linestring support in trip layer

### DIFF
--- a/src/layers/src/geojson-layer/geojson-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.ts
@@ -88,17 +88,19 @@ export function parseGeoJsonRawFeature(rawFeature: unknown): Feature | null {
 export function getGeojsonLayerMeta({
   dataContainer,
   getFeature,
-  config
+  config,
+  sortByColumn
 }: {
   dataContainer: DataContainerInterface;
   getFeature: GetFeature;
   config: LayerBaseConfig;
+  sortByColumn?: string;
 }): GeojsonLayerMetaProps {
   const dataToFeature =
     config.columnMode === COLUMN_MODE_GEOJSON
       ? getGeojsonDataMaps(dataContainer, getFeature)
       : // COLUMN_MODE_TABLE
-        groupColumnsAsGeoJson(dataContainer, config.columns, 'sortBy');
+        groupColumnsAsGeoJson(dataContainer, config.columns, sortByColumn || 'sortBy');
 
   // get bounds from features
   const bounds = getGeojsonBounds(dataToFeature);

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -1,25 +1,32 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
+import * as arrow from 'apache-arrow';
 import memoize from 'lodash.memoize';
 import uniq from 'lodash.uniq';
-import Layer, {LayerBaseConfig, defaultGetFieldValue} from '../base-layer';
+import {DATA_TYPES} from 'type-analyzer';
+
+import Layer, {LayerBaseConfig, defaultGetFieldValue, LayerBaseConfigPartial} from '../base-layer';
 import {TripsLayer as DeckGLTripsLayer} from '@deck.gl/geo-layers';
+import {containValidTime} from '@kepler.gl/common-utils';
 
 import {GEOJSON_FIELDS, PROJECTED_PIXEL_SIZE_MULTIPLIER} from '@kepler.gl/constants';
 import TripLayerIcon from './trip-layer-icon';
 
 import {
-  getGeojsonDataMaps,
-  getGeojsonBounds,
-  getGeojsonFeatureTypes,
   GeojsonDataMaps,
   detectTableColumns,
-  groupColumnsAsGeoJson,
-  applyFiltersToTableColumns
+  applyFiltersToTableColumns,
+  getGeojsonLayerMeta,
+  fieldIsGeoArrow
 } from '../geojson-layer/geojson-utils';
+import {getGeojsonLayerMetaFromArrow} from '../layer-utils';
 
-import {isTripGeoJsonField, parseTripGeoJsonTimestamp} from './trip-utils';
+import {
+  isTripGeoJsonField,
+  parseTripGeoJsonTimestamp,
+  parseTripGeoJsonFromGeoArrow
+} from './trip-utils';
 import TripInfoModalFactory from './trip-info-modal';
 import {bisectRight} from 'd3-array';
 import {
@@ -28,10 +35,17 @@ import {
   VisConfigColorRange,
   VisConfigNumber,
   VisConfigRange,
-  LayerColumn
+  LayerColumn,
+  ProtoDatasetField
 } from '@kepler.gl/types';
 import {default as KeplerTable, Datasets} from '@kepler.gl/table';
-import {DataContainerInterface} from '@kepler.gl/utils';
+import {DataContainerInterface, ArrowDataContainer} from '@kepler.gl/utils';
+
+const SUPPORTED_ANALYZER_TYPES = {
+  [DATA_TYPES.GEOMETRY]: true,
+  [DATA_TYPES.GEOMETRY_FROM_STRING]: true,
+  [DATA_TYPES.PAIR_GEOMETRY_FROM_STRING]: true
+};
 
 export type TripLayerVisConfigSettings = {
   opacity: VisConfigNumber;
@@ -99,13 +113,21 @@ export const tripVisConfigs: {
 export const featureAccessor =
   ({geojson}: TripLayerColumnsConfig) =>
   (dc: DataContainerInterface) =>
-  d =>
+  (d: {index: number}) =>
     dc.valueAt(d.index, geojson.fieldIdx);
+
 export const featureResolver = ({geojson}: TripLayerColumnsConfig) => geojson.fieldIdx;
-const getTableModeValueAccessor = f => {
+
+const geoColumnAccessor =
+  ({geojson}: TripLayerColumnsConfig) =>
+  (dc: DataContainerInterface): arrow.Vector | null =>
+    dc.getColumn?.(geojson.fieldIdx) as arrow.Vector;
+
+const getTableModeValueAccessor = feature => {
   // Called from gpu-filter-utils.getFilterValueAccessor()
-  return field => f.properties.values.map(v => field.valueAccessor(v));
+  return field => feature.properties.values.map(v => field.valueAccessor(v));
 };
+
 const getTableModeFieldValue = (field, data) => {
   let rv;
   if (typeof data === 'function') {
@@ -115,6 +137,11 @@ const getTableModeFieldValue = (field, data) => {
   }
   return rv;
 };
+
+const geoFieldAccessor =
+  ({geojson}: TripLayerColumnsConfig) =>
+  (dc: DataContainerInterface): ProtoDatasetField | null =>
+    dc.getField ? dc.getField(geojson.fieldIdx) : null;
 
 export const COLUMN_MODE_GEOJSON = 'geojson';
 export const COLUMN_MODE_TABLE = 'table';
@@ -137,24 +164,38 @@ export default class TripLayer extends Layer {
   declare visConfigSettings: TripLayerVisConfigSettings;
   declare config: TripLayerConfig;
   declare meta: TripLayerMeta;
-  declare dataContainer: DataContainerInterface | null;
+  declare geoArrowMode: boolean;
 
-  dataToFeature: GeojsonDataMaps;
-  dataToTimeStamp: any[];
+  dataToFeature: GeojsonDataMaps = [];
+  dataContainer: DataContainerInterface | null = null;
+
+  filteredIndex: Uint8ClampedArray | null = null;
+  filteredIndexTrigger: number[] | null = null;
+
+  dataToTimeStamp: any[] = [];
+
+  _layerInfoModal: {
+    [COLUMN_MODE_TABLE]: () => React.JSX.Element;
+    [COLUMN_MODE_GEOJSON]: () => React.JSX.Element;
+  };
+
   getFeature: (columns: TripLayerColumnsConfig) => (dataContainer: DataContainerInterface) => any;
-  _layerInfoModal: Record<string, () => JSX.Element>;
 
   constructor(props) {
     super(props);
-
-    this.dataToFeature = [];
-    this.dataToTimeStamp = [];
-    this.dataContainer = null;
     this.registerVisConfig(tripVisConfigs);
-    this.getFeature = memoize(featureAccessor, featureResolver);
     this._layerInfoModal = {
       [COLUMN_MODE_TABLE]: TripInfoModalFactory(COLUMN_MODE_TABLE),
       [COLUMN_MODE_GEOJSON]: TripInfoModalFactory(COLUMN_MODE_GEOJSON)
+    };
+
+    this.getFeature = memoize(featureAccessor, featureResolver);
+
+    this.getPositionAccessor = (dataContainer: DataContainerInterface) => {
+      if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
+        return this.getFeature(this.config.columns)(dataContainer);
+      }
+      return null;
     };
   }
 
@@ -165,6 +206,7 @@ export default class TripLayer extends Layer {
   static get type(): 'trip' {
     return 'trip';
   }
+
   get type() {
     return TripLayer.type;
   }
@@ -181,6 +223,25 @@ export default class TripLayer extends Layer {
     return this.defaultPointColumnPairs;
   }
 
+  get layerInfoModal() {
+    return {
+      [COLUMN_MODE_GEOJSON]: {
+        id: 'iconInfo',
+        template: this._layerInfoModal[COLUMN_MODE_GEOJSON],
+        modalProps: {
+          title: 'modal.tripInfo.title'
+        }
+      },
+      [COLUMN_MODE_TABLE]: {
+        id: 'iconInfo',
+        template: this._layerInfoModal[COLUMN_MODE_TABLE],
+        modalProps: {
+          title: 'modal.tripInfo.titleTable'
+        }
+      }
+    };
+  }
+
   accessVSFieldValue() {
     if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
       return defaultGetFieldValue;
@@ -190,7 +251,6 @@ export default class TripLayer extends Layer {
 
   get visualChannels() {
     const visualChannels = super.visualChannels;
-
     return {
       ...visualChannels,
       color: {
@@ -216,47 +276,69 @@ export default class TripLayer extends Layer {
     return this.config.animation.domain;
   }
 
-  get layerInfoModal() {
-    return {
-      [COLUMN_MODE_GEOJSON]: {
-        id: 'iconInfo',
-        template: this._layerInfoModal[COLUMN_MODE_GEOJSON],
-        modalProps: {
-          title: 'modal.tripInfo.title'
-        }
-      },
-      [COLUMN_MODE_TABLE]: {
-        id: 'iconInfo',
-        template: this._layerInfoModal[COLUMN_MODE_TABLE],
-        modalProps: {
-          title: 'modal.tripInfo.titleTable'
-        }
+  updateAnimationDomain(domain) {
+    this.updateLayerConfig({
+      animation: {
+        ...this.config.animation,
+        domain
       }
-    };
-  }
-
-  getPositionAccessor(dataContainer: DataContainerInterface) {
-    if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
-      return this.getFeature(this.config.columns)(dataContainer);
-    }
-    return null;
+    });
   }
 
   static findDefaultLayerProps(
     {label, fields = [], dataContainer, id}: KeplerTable,
     foundLayers: any[]
   ) {
-    const geojsonColumns = fields.filter(f => f.type === 'geojson').map(f => f.name);
+    const geojsonColumns = fields
+      .filter(
+        f =>
+          (f.type === 'geojson' || f.type === 'geoarrow') &&
+          f.analyzerType &&
+          SUPPORTED_ANALYZER_TYPES[f.analyzerType]
+      )
+      .map(f => f.name);
 
     const defaultColumns = {
       geojson: uniq([...GEOJSON_FIELDS.geojson, ...geojsonColumns])
     };
 
-    const geoJsonColumns = this.findDefaultColumnField(defaultColumns, fields);
+    const foundColumns = this.findDefaultColumnField(defaultColumns, fields);
 
-    const tripGeojsonColumns = (geoJsonColumns || []).filter(col =>
-      isTripGeoJsonField(dataContainer, fields[col.geojson.fieldIdx])
-    );
+    const tripGeojsonColumns = (foundColumns || []).filter(col => {
+      const geoField = fields[col.geojson.fieldIdx];
+      if (fieldIsGeoArrow(geoField)) {
+        const geoColumn = geoColumnAccessor(col)(dataContainer);
+        if (!geoColumn) return false;
+
+        // ! query only small sample of features
+        const info = getGeojsonLayerMetaFromArrow({
+          dataContainer,
+          geoColumn,
+          geoField,
+          chunkIndex: 0
+        });
+
+        // TODO use common check logic from trip-utils
+        const NUM_DIMENSIONS_FOR_TRIPS = 3; // TODO should check for 4
+        if (
+          info.featureTypes.line &&
+          // @ts-expect-error
+          info.dataToFeature?.[0]?.lines?.positions.size === NUM_DIMENSIONS_FOR_TRIPS
+        ) {
+          // @ts-expect-error
+          const values = info.dataToFeature[0].lines.positions.value;
+          const tsHolder: number[] = [];
+          values.forEach((value, index) => {
+            if (index % NUM_DIMENSIONS_FOR_TRIPS === NUM_DIMENSIONS_FOR_TRIPS - 1)
+              tsHolder.push(value);
+          });
+          return Boolean(containValidTime(tsHolder as any[]));
+        }
+      } else {
+        return isTripGeoJsonField(dataContainer, fields[col.geojson.fieldIdx]);
+      }
+      return false;
+    });
 
     if (tripGeojsonColumns.length) {
       return {
@@ -280,9 +362,10 @@ export default class TripLayer extends Layer {
     return {props: []};
   }
 
-  getDefaultLayerConfig(props) {
+  getDefaultLayerConfig(props: LayerBaseConfigPartial) {
+    const defaultLayerConfig = super.getDefaultLayerConfig(props ?? {});
     return {
-      ...super.getDefaultLayerConfig(props),
+      ...defaultLayerConfig,
       columnMode: props?.columnMode ?? DEFAULT_COLUMN_MODE,
       animation: {
         enabled: true,
@@ -301,6 +384,34 @@ export default class TripLayer extends Layer {
   }
 
   calculateDataAttribute(dataset: KeplerTable) {
+    this.geoArrowMode = fieldIsGeoArrow(
+      geoFieldAccessor(this.config.columns)(dataset.dataContainer)
+    );
+
+    const {dataContainer, filteredIndex} = dataset;
+    if (this.geoArrowMode) {
+      // filter geojson/arrow table by values and make a partial copy of the raw table is expensive
+      // so we will use filteredIndex to create an attribute e.g. filteredIndex [0|1] for GPU filtering
+      // in deck.gl layer, see: FilterArrowExtension in @kepler.gl/deckgl-layers
+      if (!this.filteredIndex || this.filteredIndex.length !== dataContainer.numRows()) {
+        // for incremental data loading, we need to update filteredIndex
+        this.filteredIndex = new Uint8ClampedArray(dataContainer.numRows());
+        this.filteredIndex.fill(1);
+      }
+
+      // check if filteredIndex is a range from 0 to numRows if it is, we don't need to update it
+      const isRange = filteredIndex && filteredIndex.length === dataContainer.numRows();
+      if (!isRange || this.filteredIndexTrigger !== null) {
+        this.filteredIndex.fill(0);
+        for (let i = 0; i < filteredIndex.length; ++i) {
+          this.filteredIndex[filteredIndex[i]] = 1;
+        }
+        this.filteredIndexTrigger = filteredIndex;
+      }
+      // for arrow, always return full dataToFeature instead of a filtered one, so there is no need to update attributes in GPU
+      return this.dataToFeature;
+    }
+
     switch (this.config.columnMode) {
       case COLUMN_MODE_GEOJSON: {
         return (
@@ -328,70 +439,107 @@ export default class TripLayer extends Layer {
     const {dataContainer, gpuFilter} = datasets[this.config.dataId];
     const {data} = this.updateData(datasets, oldLayerData);
 
-    let valueAccessor;
+    let filterValueAccessor;
     if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
-      valueAccessor = (dc: DataContainerInterface, f, fieldIndex: number) => {
+      filterValueAccessor = (dc: DataContainerInterface, f, fieldIndex: number) => {
         return dc.valueAt(f.properties.index, fieldIndex);
       };
     } else {
-      valueAccessor = getTableModeValueAccessor;
+      filterValueAccessor = getTableModeValueAccessor;
     }
     const indexAccessor = f => f.properties.index;
     const dataAccessor = () => d => ({index: d.properties.index});
     const accessors = this.getAttributeAccessors({dataAccessor, dataContainer});
+
+    const isFilteredAccessor = d => {
+      return this.filteredIndex ? this.filteredIndex[d.properties.index] : 1;
+    };
+
     const getFilterValue = gpuFilter.filterValueAccessor(dataContainer)(
       indexAccessor,
-      valueAccessor
+      filterValueAccessor
     );
 
     return {
       data,
       getFilterValue,
+      getFiltered: isFilteredAccessor,
       getPath: d => d.geometry.coordinates,
       getTimestamps: d => this.dataToTimeStamp[d.properties.index],
       ...accessors
     };
   }
 
-  updateAnimationDomain(domain) {
-    this.updateLayerConfig({
-      animation: {
-        ...this.config.animation,
-        domain
-      }
-    });
-  }
-
   updateLayerMeta(dataset: KeplerTable) {
     const {dataContainer} = dataset;
+
+    this.dataContainer = dataContainer;
+
+    this.geoArrowMode = fieldIsGeoArrow(
+      geoFieldAccessor(this.config.columns)(dataset.dataContainer)
+    );
+
     let getFeature;
-    if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
+
+    if (this.geoArrowMode && dataContainer instanceof ArrowDataContainer) {
+      const geoColumn = geoColumnAccessor(this.config.columns)(dataContainer);
+      const geoField = geoFieldAccessor(this.config.columns)(dataContainer);
+
+      // update the latest batch/chunk of geoarrow data when loading data incrementally
+      if (geoColumn && geoField && this.dataToFeature.length < dataContainer.numChunks()) {
+        // for incrementally loading data, we only load and render the latest batch; otherwise, we will load and render all batches
+        const isIncrementalLoad = dataContainer.numChunks() - this.dataToFeature.length === 1;
+
+        // TODO ! sortBy 'timestamp'
+        const {dataToFeature, bounds, fixedRadius, featureTypes} = getGeojsonLayerMetaFromArrow({
+          dataContainer,
+          geoColumn,
+          geoField,
+          ...(isIncrementalLoad ? {chunkIndex: this.dataToFeature.length} : null)
+        });
+        // if (centroids) this.centroids = this.centroids.concat(centroids);
+
+        // TODO separate binary and json features
+        this.dataToFeature = [...this.dataToFeature, ...dataToFeature];
+
+        const {dataToFeatureOut, dataToTimeStamp, animationDomain} = parseTripGeoJsonFromGeoArrow(
+          // @ts-expect-error
+          this.dataToFeature
+        );
+
+        // @ts-expect-error
+        this.dataToFeature = dataToFeatureOut;
+        this.dataToTimeStamp = dataToTimeStamp;
+        this.updateAnimationDomain(animationDomain);
+
+        this.updateMeta({bounds, fixedRadius, featureTypes});
+      }
+    } else if (this.dataToFeature.length === 0) {
       getFeature = this.getPositionAccessor(dataContainer);
       if (getFeature === this.meta.getFeature) {
         // TODO: revisit this after gpu filtering
         return;
       }
-      this.dataToFeature = getGeojsonDataMaps(dataContainer, getFeature);
-    } else {
-      this.dataContainer = dataContainer;
-      this.dataToFeature = groupColumnsAsGeoJson(dataContainer, this.config.columns, 'timestamp');
+
+      const {dataToFeature, bounds, featureTypes} = getGeojsonLayerMeta({
+        dataContainer,
+        getFeature,
+        config: this.config,
+        sortByColumn: 'timestamp'
+      });
+      // if (centroids) this.centroids = centroids;
+      this.dataToFeature = dataToFeature;
+
+      const {dataToTimeStamp, animationDomain} = parseTripGeoJsonTimestamp(this.dataToFeature);
+
+      this.dataToTimeStamp = dataToTimeStamp;
+      this.updateAnimationDomain(animationDomain);
+
+      this.updateMeta({bounds, featureTypes, getFeature});
     }
-
-    const {dataToTimeStamp, animationDomain} = parseTripGeoJsonTimestamp(this.dataToFeature);
-
-    this.dataToTimeStamp = dataToTimeStamp;
-    this.updateAnimationDomain(animationDomain);
-
-    // get bounds from features
-    const bounds = getGeojsonBounds(this.dataToFeature);
-
-    // keep a record of what type of geometry the collection has
-    const featureTypes = getGeojsonFeatureTypes(this.dataToFeature);
-
-    this.updateMeta({bounds, featureTypes, getFeature});
   }
 
-  setInitialLayerConfig(dataset) {
+  setInitialLayerConfig(dataset: KeplerTable) {
     const {dataContainer} = dataset;
     if (!dataContainer.numRows()) {
       return this;
@@ -401,7 +549,7 @@ export default class TripLayer extends Layer {
     // if not found, we try to set it to id / lat /lng /ts
     if (!this.config.columns.geojson.value) {
       // find columns from lat, lng, id, and ts
-      const columnConfig = detectTableColumns(dataset, this.config.columns);
+      const columnConfig = detectTableColumns(dataset, this.config.columns, 'timestamp');
       if (columnConfig) {
         this.updateLayerConfig({
           ...columnConfig,
@@ -411,6 +559,7 @@ export default class TripLayer extends Layer {
     }
 
     this.updateLayerMeta(dataset);
+
     return this;
   }
 


### PR DESCRIPTION
**There is a blocker in DuckDB as 4th coord with time is dropped in both st_asWKB and st_asGeojson**

WIP

- [x] emulate geoarrow.wkb support in trip layer
- [x] emulate geoarrow.linestring support in trip layer
- [ ] fix: DuckDb drops 4th dimension with timestamps (!!!)
- [ ] figure out a way to prepare attributes for deck.gl's Path layer (sublayer of TripsLayer).
