### PR TITLE
[fix] arrow tables - save timestamps as iso date string

### DIFF
--- a/src/schemas/package.json
+++ b/src/schemas/package.json
@@ -40,6 +40,7 @@
     "@types/keymirror": "^0.1.1",
     "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.pick": "^4.4.6",
+    "apache-arrow": ">=15.0.0",
     "global": "^4.3.0",
     "keymirror": "^0.1.1",
     "lodash.clonedeep": "^4.0.1",

--- a/src/schemas/src/dataset-schema.ts
+++ b/src/schemas/src/dataset-schema.ts
@@ -3,6 +3,7 @@
 
 import pick from 'lodash.pick';
 import {console as globalConsole} from 'global/window';
+import {Type as ArrowTypes} from 'apache-arrow';
 
 import {DATASET_FORMATS} from '@kepler.gl/constants';
 import {ProtoDataset, RGBColor, JsonObject} from '@kepler.gl/types';
@@ -102,6 +103,7 @@ export const propertiesV1 = {
 };
 
 /**
+ * TODO Consider moving this cast to ArrowDataContainer?
  * Prepare a data container for export as part of json / html.
  * 1) Arrow tables can store Timestamps as BigInts, so convert numbers to ISOStrings compatible with Kepler.gl's TIMESTAMP.
  * @param dataContainer A data container to flatten.
@@ -115,8 +117,12 @@ const getAllDataForSaving = (dataContainer: DataContainerInterface): any[][] => 
 
     for (let columnIndex = 0; columnIndex < numColumns; ++columnIndex) {
       const column = dataContainer.getColumn(columnIndex);
-      // TODO why arrow.Type.Timestamp is undefined?
-      if (column.type.typeId === 10) {
+      const typeId = column.type?.typeId;
+      if (
+        typeId === ArrowTypes.Timestamp ||
+        typeId === ArrowTypes.Date ||
+        typeId === ArrowTypes.Time
+      ) {
         allData.forEach(row => {
           row[columnIndex] = new Date(row[columnIndex]).toISOString();
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3605,6 +3605,7 @@ __metadata:
     "@types/keymirror": "npm:^0.1.1"
     "@types/lodash.clonedeep": "npm:^4.5.7"
     "@types/lodash.pick": "npm:^4.4.6"
+    apache-arrow: "npm:>=15.0.0"
     global: "npm:^4.3.0"
     keymirror: "npm:^0.1.1"
     lodash.clonedeep: "npm:^4.0.1"


### PR DESCRIPTION
- convert numerical timestamps from arrow tables into iso date strings before saving.