### PR TITLE
[fix] Adjust the margin for the Map Save modal to show the Save button without scrolling

### DIFF
--- a/src/components/src/modals/save-map-modal.tsx
+++ b/src/components/src/modals/save-map-modal.tsx
@@ -61,6 +61,10 @@ const StyledSaveMapModal = styled.div.attrs({
   }
 `;
 
+const StyledCompactExportSection = styled(StyledExportSection)`
+  margin: 5px 0;
+`;
+
 const nop = () => {
   return;
 };
@@ -224,7 +228,7 @@ function SaveMapModalFactory() {
                     </div>
                   </StyledExportSection>
                 ) : null}
-                <StyledExportSection>
+                <StyledCompactExportSection>
                   <div className="description image-preview-panel">
                     <ImagePreview
                       exportImage={exportImage}
@@ -246,7 +250,7 @@ function SaveMapModalFactory() {
                       onChangeInput={onChangeInput}
                     />
                   )}
-                </StyledExportSection>
+                </StyledCompactExportSection>
               </>
             )}
             {providerError ? (


### PR DESCRIPTION
- Adjust the margin for the Map Save modal to show the Save button without scrolling

Before:
<img width="984" alt="Screenshot 2025-01-29 at 12 22 15 PM" src="https://github.com/user-attachments/assets/bdb14824-37dc-450f-b620-25c3ea9d9fd8" />

After:
<img width="1003" alt="Screenshot 2025-01-29 at 12 20 55 PM" src="https://github.com/user-attachments/assets/8eb2c5c9-3c1b-47af-a438-517df9ba1529" />
