### PR TITLE
[fix] DuckDB: make query result title more reusable

### DIFF
--- a/src/duckdb/src/components/sql-panel.tsx
+++ b/src/duckdb/src/components/sql-panel.tsx
@@ -186,7 +186,7 @@ export const SqlPanel: React.FC<SqlPanelProps> = ({initialSql = ''}) => {
       },
       info: {
         id: generateHashId(),
-        label: `query-result${counter > 0 ? `-${counter}` : ''}`,
+        label: `query_result${counter > 0 ? `_${counter}` : ''}`,
         format: 'arrow'
       }
     };


### PR DESCRIPTION
Change default query result table from `Query Result (1)` to `query_result_1`

<img width="715" alt="Screenshot 2025-01-29 at 5 14 53 PM" src="https://github.com/user-attachments/assets/bf3bf0dc-fcb6-43c7-89dc-58e3fdbb85c5" />

