### PR TITLE
convert datetimes to str so they can convert to json

### DIFF
--- a/bindings/kepler.gl-jupyter/keplergl/keplergl.py
+++ b/bindings/kepler.gl-jupyter/keplergl/keplergl.py
@@ -49,7 +49,11 @@ def _df_to_dict(df):
     - dictionary: a dictionary variable that can be used in Kepler.gl
 
     '''
-    return df.to_dict('split')
+    df_copy = df.copy()
+    for col in df_copy.columns:
+        if pd.api.types.is_datetime64_any_dtype(df_copy[col]):
+            df_copy[col] = df_copy[col].astype(str)
+    return df_copy.to_dict('split')
 
 
 def _df_to_arrow(df: pd.DataFrame):

--- a/bindings/kepler.gl-jupyter/keplergl/keplergl.py
+++ b/bindings/kepler.gl-jupyter/keplergl/keplergl.py
@@ -50,9 +50,14 @@ def _df_to_dict(df):
 
     '''
     df_copy = df.copy()
+    # Convert all columns that aren't JSON serializable to strings
     for col in df_copy.columns:
-        if pd.api.types.is_datetime64_any_dtype(df_copy[col]):
+        try:
+            # just check the first item in the colum
+            json.dumps(df_copy[col].iloc[0] if len(df_copy) > 0 else None)
+        except (TypeError, OverflowError):
             df_copy[col] = df_copy[col].astype(str)
+
     return df_copy.to_dict('split')
 
 


### PR DESCRIPTION
addresses https://github.com/keplergl/kepler.gl/issues/2967

I tested the MRE in the issue above locally and it works. Would probably be good to have handlign for other non-JSON serializable types as well.

I didn't find the root cause for why this wasn't an issue in earlier widget versions so I opted to make this type handling change in `_df_to_dict`. Let me know if you think there would be a better place to do this handling.