### PR TITLE
[fix] heatmap renders nothing with black color or duplicate color

### DIFF
--- a/src/layers/src/heatmap-layer/heatmap-layer.ts
+++ b/src/layers/src/heatmap-layer/heatmap-layer.ts
@@ -2,7 +2,7 @@
 // Copyright contributors to the kepler.gl project
 
 import {createSelector} from 'reselect';
-import {CHANNEL_SCALES, SCALE_FUNC, ALL_FIELD_TYPES} from '@kepler.gl/constants';
+import {CHANNEL_SCALES, ALL_FIELD_TYPES} from '@kepler.gl/constants';
 import MapboxGLLayer, {MapboxLayerGLConfig} from '../mapboxgl-layer';
 import HeatmapLayerIcon from './heatmap-layer-icon';
 import {LayerBaseConfigPartial, LayerWeightConfig, VisualChannels} from '../base-layer';


### PR DESCRIPTION
- `scale.invertExtent(level)` returns values for the first encountered color in the range and doesn't work with duplicate values. And as result Mapbox Heatmap crashes during verification.
- fixes heatmaps with black color
- fixes heatmaps with cyclical palettes
- fixes the issue for non-unique colors from custom palettes.

- [x] no visual differences

<img width="943" alt="Screenshot 2025-02-06 at 3 39 23 AM" src="https://github.com/user-attachments/assets/a17ef136-2c54-47bb-aba9-49ee49e01758" />
