### PR TITLE
[fix] AI Assistant sends messages to 127.0.0.1 instead of remote Ollama URL (keplergl#2984)

### DIFF
--- a/src/ai-assistant/src/components/ai-assistant-component.tsx
+++ b/src/ai-assistant/src/components/ai-assistant-component.tsx
@@ -146,6 +146,7 @@ function AiAssistantComponentFactory() {
       modelProvider: aiAssistant.config.provider,
       model: aiAssistant.config.model,
       apiKey: aiAssistant.config.apiKey,
+      baseUrl: aiAssistant.config.baseUrl,
       instructions: INSTRUCTIONS,
       functions
     };


### PR DESCRIPTION
Fix #2984

**Description**
This PR fixes a bug where the AI Assistant incorrectly sends chat messages to `127.0.0.1:11434` instead of the configured Ollama Base URL. The issue occurs after the chat stream initializes correctly, but subsequent chat messages are sent to localhost.