### PR TITLE
[fix] arrow text labels from non-string source vectors

### DIFF
--- a/src/deckgl-arrow-layers/src/layers/geo-arrow-text-layer.ts
+++ b/src/deckgl-arrow-layers/src/layers/geo-arrow-text-layer.ts
@@ -196,9 +196,10 @@ export class GeoArrowTextLayer<ExtraProps extends object = object> extends Compo
       const geometryData = geometryColumn.data[recordBatchIdx];
       const flatCoordsData = ga.child.getPointChild(geometryData);
       const flatCoordinateArray = flatCoordsData.values;
+
       const textData = this.props.getText.data[recordBatchIdx];
+      const numLabels = textData.length;
       const textValues = textData.values;
-      // ! TODO valueOffsets are only present for string columns
       const characterOffsets = textData.valueOffsets;
 
       // @ts-expect-error how to properly retrieve batch offset?
@@ -226,7 +227,8 @@ export class GeoArrowTextLayer<ExtraProps extends object = object> extends Compo
               value: expandArrayToCoords(
                 flatCoordinateArray,
                 geometryData.type.listSize,
-                characterOffsets
+                characterOffsets,
+                numLabels
               ),
               size: geometryData.type.listSize
             },

--- a/src/deckgl-arrow-layers/src/utils/utils.ts
+++ b/src/deckgl-arrow-layers/src/utils/utils.ts
@@ -214,21 +214,24 @@ export function assignAccessor(args: AssignAccessorProps) {
  * @param input: the input array to expand
  * @param size : the number of nested elements in the input array per geometry. So for example, for RGB data this would be 3, for RGBA this would be 4. For radius, this would be 1.
  * @param geomOffsets : an offsets array mapping from the geometry to the coordinate indexes. So in the case of a LineStringArray, this is retrieved directly from the GeoArrow storage. In the case of a PolygonArray, this comes from the resolved indexes that need to be given to the SolidPolygonLayer anyways.
+ * @param numPositions : end position in geomOffsets, as geomOffsets can potentially contain preallocated zeroes in the end of the buffer.
  *
  * @return  {TypedArray} values expanded to be per-coordinate
  */
 export function expandArrayToCoords<T extends TypedArray>(
   input: T,
   size: number,
-  geomOffsets: Int32Array
+  geomOffsets: Int32Array,
+  numPositions?: number
 ): T {
-  const numCoords = geomOffsets[geomOffsets.length - 1];
+  const lastIndex = numPositions || geomOffsets.length - 1;
+  const numCoords = geomOffsets[lastIndex];
   // @ts-expect-error
   const outputArray: T = new input.constructor(numCoords * size);
 
   // geomIdx is an index into the geomOffsets array
   // geomIdx is also the geometry/table index
-  for (let geomIdx = 0; geomIdx < geomOffsets.length - 1; geomIdx++) {
+  for (let geomIdx = 0; geomIdx < lastIndex; geomIdx++) {
     // geomOffsets maps from the geometry index to the coord index
     // So here we get the range of coords that this geometry covers
     const lastCoordIdx = geomOffsets[geomIdx];

--- a/src/deckgl-layers/src/deckgl-extensions/filter-shader-module.ts
+++ b/src/deckgl-layers/src/deckgl-extensions/filter-shader-module.ts
@@ -15,10 +15,11 @@ const vs = `
 const fs = ``;
 
 const inject = {
-  // create degenerate vertices instead of discarding pixels in the fragment shader
-  'vs:DECKGL_FILTER_GL_POSITION': `
+  // create degenerate vertices in vertex shader instead of discarding pixels in the fragment shader.
+  'vs:#main-start': `
     if (FILTER_ARROW_ATTRIB == 0.) {
-      position = vec4(0., 0., 0., 0.);
+      gl_Position = vec4(0.0, 0.0, 0.0, 1.0);
+      return;
     }
   `
 };


### PR DESCRIPTION
#2922

- add missing support for apache-arrow point columns and text labels from numeric fields (calculate offsets).
- geoarrow-text-layer requires Utf8 vector.
- in case of non Utf8 vector create a temporary Utf8 vector with the same layout of batches as in the source vector.
