### PR TITLE
[fix] Fix for valid coordinates not recognized in Geocoder

### DIFF
--- a/src/components/src/geocoder-panel.tsx
+++ b/src/components/src/geocoder-panel.tsx
@@ -148,8 +148,7 @@ export default function GeocoderPanelFactory(): ComponentType<GeocoderPanelProps
       this.props.removeDataset(GEOCODER_DATASET_NAME);
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    onSelected = (viewport: Viewport | null = null, geoItem: Result) => {
+    onSelected = (_viewport: Viewport | null = null, geoItem: Result) => {
       const {
         center: [lon, lat],
         text,

--- a/src/components/src/geocoder/geocoder.tsx
+++ b/src/components/src/geocoder/geocoder.tsx
@@ -18,13 +18,21 @@ type StyledContainerProps = {
 
 // matches only valid coordinates
 const COORDINATE_REGEX_STRING =
-  '^[-+]?([1-8]?\\d(\\.\\d+)?|90(\\.0+)?),\\s*[-+]?(180(\\.0+)?|((1[0-7]\\d)|([1-9]?\\d))(\\.\\d+)?)';
+  '(^[-+]?(?:[1-8]?\\d(?:\\.\\d+)?|90(?:\\.0+)?)),\\s*([-+]?(?:180(?:\\.0+)?|(?:(?:1[0-7]\\d)|(?:[1-9]?\\d))(?:\\.\\d+)?))$';
+
 const COORDINATE_REGEX = RegExp(COORDINATE_REGEX_STRING);
 
 const PLACEHOLDER = 'Enter an address or coordinates, ex 37.79,-122.40';
 
 let debounceTimeout: NodeJS.Timeout | null = null;
 
+/**
+ * Tests if a given query string contains valid coordinates.
+ * @param query The input string to test for coordinates.
+ * @returns A tuple where:
+ *   - If valid, returns `[true, longitude, latitude]`.
+ *   - If invalid, returns `[false, query]`.
+ */
 export const testForCoordinates = (query: string): [true, number, number] | [false, string] => {
   const isValid = COORDINATE_REGEX.test(query.trim());
 
@@ -33,8 +41,10 @@ export const testForCoordinates = (query: string): [true, number, number] | [fal
   }
 
   const tokens = query.trim().split(',');
+  const latitude = Number(tokens[0]);
+  const longitude = Number(tokens[1]);
 
-  return [isValid, Number(tokens[0]), Number(tokens[1])];
+  return [isValid, longitude, latitude];
 };
 
 const StyledContainer = styled.div<StyledContainerProps>`
@@ -121,7 +131,6 @@ type IntlProps = {
   intl: IntlShape;
 };
 
-/** @type {import('./geocoder').GeocoderComponent} */
 const GeoCoder: React.FC<GeocoderProps & IntlProps> = ({
   mapboxApiAccessToken,
   className = '',
@@ -155,9 +164,8 @@ const GeoCoder: React.FC<GeocoderProps & IntlProps> = ({
       setInputValue(queryString);
       const resultCoordinates = testForCoordinates(queryString);
       if (resultCoordinates[0]) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const [_, latitude, longitude] = resultCoordinates;
-        setResults([{center: [latitude, longitude], place_name: queryString}]);
+        const [_isValid, longitude, latitude] = resultCoordinates;
+        setResults([{center: [longitude, latitude], place_name: queryString}]);
       } else {
         if (debounceTimeout) {
           clearTimeout(debounceTimeout);

--- a/test/browser/components/geocoder-panel-test.js
+++ b/test/browser/components/geocoder-panel-test.js
@@ -223,8 +223,14 @@ test('GeocoderPanel - render', t => {
 test('Geocoder -> testForCoordinates', t => {
   t.deepEqual(
     testForCoordinates('21.22,-138.0'),
-    [true, 21.22, -138.0],
+    [true, -138.0, 21.22],
     'should recognize valid coordinates'
+  );
+
+  t.deepEqual(
+    testForCoordinates(' -21.122, -123.4321 '),
+    [true, -123.4321, -21.122],
+    'should recognize valid coordinates and trim spaces, and a whitespace after the comma'
   );
 
   t.deepEqual(
@@ -236,13 +242,20 @@ test('Geocoder -> testForCoordinates', t => {
   t.deepEqual(
     testForCoordinates('91,123'),
     [false, '91,123'],
-    'should recognize invalid coordinates'
+    'should recognize invalid integer coordinates'
   );
 
   t.deepEqual(
-    testForCoordinates('-21.122, -123.4321'),
-    [true, -21.122, -123.4321],
-    'should recognize valid coordinates'
+    testForCoordinates('91.0,-138.0'),
+    [false, '91.0,-138.0'],
+    'should recognize out of bounds latitude'
   );
+
+  t.deepEqual(
+    testForCoordinates('50.0,200.0'),
+    [false, '50.0,200.0'],
+    'should recognize out of bounds longitude'
+  );
+
   t.end();
 });


### PR DESCRIPTION
Looks like geocoder was broken for a long time as lon/lat coords were interpreted as lat/lon.

- [x] 37.7749, -122.4194 works as expected
- [x] Make sure changes don't break regular geocoder search by location name
- [x] fix for regex for coords to fail on out of bounds lon/lat
- [x] extra tests