### PR TITLE
[fix] fix for Icon layer UI

### DIFF
--- a/src/components/src/side-panel/layer-panel/layer-configurator.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-configurator.tsx
@@ -148,23 +148,21 @@ export default function LayerConfiguratorFactory(
 ): React.ComponentType<LayerConfiguratorProps> {
   class LayerConfigurator extends Component<LayerConfiguratorProps> {
     _renderPointLayerConfig(props) {
-      return this._renderScatterplotLayerConfig(props);
+      return this._renderScatterplotLayerConfig(props, true);
     }
 
     _renderIconLayerConfig(props) {
-      return this._renderScatterplotLayerConfig(props);
+      return this._renderScatterplotLayerConfig(props, false);
     }
 
     _renderVectorTileLayerConfig(props) {
       return <VectorTileLayerConfigurator {...props} />;
     }
 
-    _renderScatterplotLayerConfig({
-      layer,
-      visConfiguratorProps,
-      layerChannelConfigProps,
-      layerConfiguratorProps
-    }) {
+    _renderScatterplotLayerConfig(
+      {layer, visConfiguratorProps, layerChannelConfigProps, layerConfiguratorProps},
+      showInteractionControls
+    ) {
       return (
         <StyledLayerVisualConfigurator>
           {/* Fill Color */}
@@ -259,19 +257,21 @@ export default function LayerConfiguratorFactory(
           />
 
           {/* Interaction */}
-          <LayerConfigGroup label={'layer.interaction'} collapsible>
-            <VisConfigSwitch {...layer.visConfigSettings.allowHover} {...visConfiguratorProps} />
-            <ConfigGroupCollapsibleContent>
-              <VisConfigSwitch
-                {...layer.visConfigSettings.showNeighborOnHover}
-                {...visConfiguratorProps}
-              />
-              <VisConfigSwitch
-                {...layer.visConfigSettings.showHighlightColor}
-                {...visConfiguratorProps}
-              />
-            </ConfigGroupCollapsibleContent>
-          </LayerConfigGroup>
+          {showInteractionControls ? (
+            <LayerConfigGroup label={'layer.interaction'} collapsible>
+              <VisConfigSwitch {...layer.visConfigSettings.allowHover} {...visConfiguratorProps} />
+              <ConfigGroupCollapsibleContent>
+                <VisConfigSwitch
+                  {...layer.visConfigSettings.showNeighborOnHover}
+                  {...visConfiguratorProps}
+                />
+                <VisConfigSwitch
+                  {...layer.visConfigSettings.showHighlightColor}
+                  {...visConfiguratorProps}
+                />
+              </ConfigGroupCollapsibleContent>
+            </LayerConfigGroup>
+          ) : null}
         </StyledLayerVisualConfigurator>
       );
     }


### PR DESCRIPTION
- The Icon layer UI is rendered using the same logic as the UI for the Scatterplot layer. However, the Icon layer does not support the interaction logic available in the Scatterplot layer.
- Disable interaction controls for the Icon layer.

<img width="275" alt="Screenshot 2025-02-26 at 1 00 38 AM" src="https://github.com/user-attachments/assets/71ed6526-ed40-4795-85c1-ab650293058e" />
