### PR TITLE
[fix] adjust getZoomFactor for Icon layer

### DIFF
--- a/src/layers/src/icon-layer/icon-layer.ts
+++ b/src/layers/src/icon-layer/icon-layer.ts
@@ -197,6 +197,10 @@ export default class IconLayer extends Layer {
     };
   }
 
+  getZoomFactor({zoom, zoomOffset = 0}: {zoom: number, zoomOffset?: number}) {
+    return Math.pow(2, 14 - zoom + zoomOffset);
+  }
+
   getSvgIcons() {
     const fetchConfig = {
       method: 'GET',


### PR DESCRIPTION
For https://github.com/keplergl/kepler.gl/issues/1352

- At higher zoom levels, icons, including the geocoder marker, become too large due to the default logic in `getZoomFactor` in the `BaseLayer`.
- Disable zoom factor clamping to 1 after zoom level 14.

Before:
<img width="988" alt="Screenshot 2025-02-26 at 3 07 37 PM" src="https://github.com/user-attachments/assets/95b0c153-a2cc-4674-9aba-f526ca64438f" />

After: 
<img width="896" alt="Screenshot 2025-02-26 at 3 04 52 PM" src="https://github.com/user-attachments/assets/827eecc8-e2e6-470f-8f6b-bfb972a912e7" />
