### PR TITLE
[fix] Fix Save map action for FSQ provider (overwrite logic)

### DIFF
--- a/src/components/src/modal-container.tsx
+++ b/src/components/src/modal-container.tsx
@@ -228,12 +228,12 @@ export default function ModalContainerFactory(
       const toSave = exportMap(this.props);
 
       this.props.providerActions.exportFileToCloud({
-        // @ts-ignore
         mapData: toSave,
         provider,
         options: {
           isPublic,
-          overwrite
+          overwrite,
+          mapIdToOverwrite: this.props.providerState.savedMapId
         },
         closeModal,
         onSuccess: this.props.onExportToCloudSuccess,

--- a/src/reducers/src/provider-state-updaters.ts
+++ b/src/reducers/src/provider-state-updaters.ts
@@ -49,6 +49,7 @@ export type ProviderState = {
   currentProvider: string | null;
   successInfo: any;
   mapSaved: null | string;
+  savedMapId: null | string;
   initialState?: any;
   visualizations: MapListItem[];
 };
@@ -60,6 +61,7 @@ export const INITIAL_PROVIDER_STATE: ProviderState = {
   currentProvider: null,
   successInfo: {},
   mapSaved: null,
+  savedMapId: null,
   visualizations: []
 };
 
@@ -154,7 +156,8 @@ export const exportFileSuccessUpdater = (
     successInfo: response,
     ...(!options.isPublic
       ? {
-          mapSaved: provider.name
+          mapSaved: provider.name,
+          savedMapId: response?.info?.id ?? null
         }
       : {})
   };

--- a/src/types/actions.d.ts
+++ b/src/types/actions.d.ts
@@ -11,6 +11,7 @@ export type MapData = {
 export type ExportFileOptions = {
   isPublic?: boolean;
   overwrite?: boolean;
+  mapIdToOverwrite?: string | null;
 };
 export type OnErrorCallBack = (error: Error) => any;
 export type OnSuccessCallBack = (p: {

--- a/test/node/reducers/provider-state-test.js
+++ b/test/node/reducers/provider-state-test.js
@@ -88,6 +88,7 @@ test('#providerStateReducer -> EXPORT_FILE_TO_CLOUD', t => {
       successInfo: {},
       initialState: {},
       mapSaved: null,
+      savedMapId: null,
       visualizations: []
     },
     'Should set isProviderLoading and current provider'
@@ -120,6 +121,7 @@ test('#providerStateReducer -> EXPORT_FILE_TO_CLOUD', t => {
       currentProvider: 'taro',
       initialState: {},
       mapSaved: 'taro',
+      savedMapId: null,
       successInfo: {url: 'taro_and_blue'},
       visualizations: []
     },
@@ -139,6 +141,7 @@ test('#providerStateReducer -> EXPORT_FILE_TO_CLOUD', t => {
       currentProvider: 'taro',
       initialState: {},
       mapSaved: null,
+      savedMapId: null,
       successInfo: {},
       visualizations: []
     },
@@ -227,6 +230,7 @@ test('#providerStateReducer -> EXPORT_FILE_TO_CLOUD -> onSuccess : onError', t =
       providerError: null,
       currentProvider: 'taro',
       mapSaved: 'taro',
+      savedMapId: null,
       initialState: {},
       successInfo: {url: 'taro_and_blue'},
       visualizations: []
@@ -256,6 +260,7 @@ test('#providerStateReducer -> EXPORT_FILE_TO_CLOUD -> onSuccess : onError', t =
       providerError: null,
       currentProvider: 'taro',
       mapSaved: 'taro',
+      savedMapId: null,
       initialState: {},
       successInfo: {url: 'taro_and_blue'},
       modalId: null,
@@ -273,6 +278,7 @@ test('#providerStateReducer -> EXPORT_FILE_TO_CLOUD -> onSuccess : onError', t =
       providerError: null,
       currentProvider: 'taro',
       mapSaved: 'taro',
+      savedMapId: null,
       initialState: {},
       successInfo: {},
       modalId: null,
@@ -318,6 +324,7 @@ test('#providerStateReducer -> RESET_PROVIDER_STATUS', t => {
       successInfo: {},
       initialState: {},
       mapSaved: null,
+      savedMapId: null,
       visualizations: []
     },
     'Should resetProviderStatus'


### PR DESCRIPTION
- This PR fixes the map save functionality for the Foursquare provider when overwriting an existing map. 

- update uploadMap to properly fetch and update map data during an overwrite.
- add a new savedMapId state field in the provider state updaters
