### PR TITLE
[fix] More than one copy of react-palm was loaded. This may cause problems.

### DIFF
--- a/examples/demo-app/esbuild.config.mjs
+++ b/examples/demo-app/esbuild.config.mjs
@@ -47,6 +47,7 @@ const getThirdPartyLibraryAliases = useKeplerNodeModules => {
     'react-redux': `${nodeModulesDir}/react-redux/lib`,
     'styled-components': `${nodeModulesDir}/styled-components`,
     'react-intl': `${nodeModulesDir}/react-intl`,
+    'react-palm': `${nodeModulesDir}/react-palm`,
     // kepler.gl and loaders.gl need to use same apache-arrow
     'apache-arrow': `${nodeModulesDir}/apache-arrow`
   };

--- a/examples/replace-component/esbuild.config.mjs
+++ b/examples/replace-component/esbuild.config.mjs
@@ -33,6 +33,7 @@ const RESOLVE_LOCAL_ALIASES = {
   'react-redux': `${NODE_MODULES_DIR}/react-redux/lib`,
   'styled-components': `${NODE_MODULES_DIR}/styled-components`,
   'react-intl': `${NODE_MODULES_DIR}/react-intl`,
+  'react-palm': `${NODE_MODULES_DIR}/react-palm`,
   // Suppress useless warnings from react-date-picker's dep
   'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`,
   // kepler.gl and loaders.gl need to use same apache-arrow

--- a/webpack/shared-webpack-configuration.js
+++ b/webpack/shared-webpack-configuration.js
@@ -14,6 +14,7 @@ const resolveAlias = {
   'react-redux': `${NODE_MODULES_DIR}/react-redux/lib`,
   'styled-components': `${NODE_MODULES_DIR}/styled-components`,
   'react-intl': `${NODE_MODULES_DIR}/react-intl`,
+  'react-palm': `${NODE_MODULES_DIR}/react-palm`,
   // Suppress useless warnings from react-date-picker's dep
   'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`,
   // kepler.gl and loaders.gl need to use same apache-arrow

--- a/website/esbuild.config.mjs
+++ b/website/esbuild.config.mjs
@@ -21,6 +21,7 @@ const RESOLVE_LOCAL_ALIASES = {
   'react-redux': `${NODE_MODULES_DIR}/react-redux/lib`,
   'styled-components': `${NODE_MODULES_DIR}/styled-components`,
   'react-intl': `${NODE_MODULES_DIR}/react-intl`,
+  'react-palm': `${NODE_MODULES_DIR}/react-palm`,
   'tiny-warning': `${SRC_DIR}/utils/src/noop.ts`,
   'apache-arrow': `${NODE_MODULES_DIR}/apache-arrow`,
 };


### PR DESCRIPTION
- fix for `More than one copy of react-palm was loaded. This may cause problems.` error message.