### PR TITLE
[fix] schema panel displays temp table

### DIFF
--- a/src/duckdb/src/components/schema-panel.tsx
+++ b/src/duckdb/src/components/schema-panel.tsx
@@ -142,7 +142,7 @@ export const SchemaPanel = ({
 
     setColumnSchemas(result);
     setTableSchema(tableSchema);
-    c.close();
+    await c.close();
 
     // schemaUpdateTrigger indicates possible change in DuckDB
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/duckdb/src/components/sql-panel.tsx
+++ b/src/duckdb/src/components/sql-panel.tsx
@@ -187,9 +187,6 @@ export const SqlPanel: React.FC<SqlPanelProps> = ({initialSql = ''}) => {
       const db = await getDuckDB();
       const connection = await db.connect();
 
-      // Indicate that there may be a possible change in DuckDB.
-      setSchemaUpdateTrigger(Date.now());
-
       // TODO find a cheap way to get DuckDb types with a single query to a remote resource - temp table? cte?
       const tempTableName = 'temp_keplergl_table';
 
@@ -230,12 +227,15 @@ export const SqlPanel: React.FC<SqlPanelProps> = ({initialSql = ''}) => {
         setError(null);
       }
 
-      connection.close();
+      await connection.close();
     } catch (e) {
       setError(e as Error);
     } finally {
       setIsRunning(false);
     }
+
+    // Indicate that there may be a possible change in DuckDB.
+    setSchemaUpdateTrigger(Date.now());
   }, [sql]);
 
   const onChange = useCallback(

--- a/src/duckdb/src/table/duckdb-table-utils.ts
+++ b/src/duckdb/src/table/duckdb-table-utils.ts
@@ -491,7 +491,7 @@ Possible reasons:
     }
   }
 
-  c.close();
+  await c.close();
 
   return error;
 }
@@ -506,7 +506,7 @@ export function sanitizeDuckDBTableName(fileName: string): string {
   let name = fileName.replace(/[^a-zA-Z0-9_]/g, '_');
   // Ensure it doesn't start with a digit
   if (/^\d/.test(name)) {
-    name = 't_' + name;
+    name = `t_${name}`;
   }
   return name || 'default_table';
 }


### PR DESCRIPTION
- trigger schema panel update after all queries are executed
- properly wait for `connection.close()`