### PR TITLE
[fix] make onFilteredItemsChange optional

### DIFF
--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -34,6 +34,7 @@ import {
 import {
   DataContainerInterface,
   DomainQuantiles,
+  getApplicationConfig,
   getLatLngBounds,
   getSampleContainerData,
   hasColorMap,
@@ -156,8 +157,9 @@ const MAX_SAMPLE_SIZE = 5000;
 const defaultDomain: [number, number] = [0, 1];
 const dataFilterExtension = new DataFilterExtension({
   filterSize: MAX_GPU_FILTERS,
+  // `countItems` option. It enables the GPU to report the number of objects that pass the filter criteria via the `onFilteredItemsChange` callback.
   // @ts-expect-error not typed
-  countItems: true
+  countItems: getApplicationConfig().useOnFilteredItemsChange ?? false
 });
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/utils/src/application-config.ts
+++ b/src/utils/src/application-config.ts
@@ -39,6 +39,10 @@ export type KeplerApplicationConfig = {
   useArrowProgressiveLoading?: boolean;
   // Show built-in banner associated with the current version of Kepler.gl
   showReleaseBanner?: boolean;
+  // Use the onFilteredItemsChange callback for DataFilterExtension.
+  // Enabling this option may cause performance issues when dealing with a large number of layers or sublayers,
+  // especially if large Arrow files are split into relatively small batches (should be fixed in the future).
+  useOnFilteredItemsChange?: boolean;
 };
 
 const DEFAULT_APPLICATION_CONFIG: Required<KeplerApplicationConfig> = {
@@ -73,7 +77,8 @@ const DEFAULT_APPLICATION_CONFIG: Required<KeplerApplicationConfig> = {
   table: null,
 
   useArrowProgressiveLoading: true,
-  showReleaseBanner: true
+  showReleaseBanner: true,
+  useOnFilteredItemsChange: false
 };
 
 const applicationConfig: Required<KeplerApplicationConfig> = DEFAULT_APPLICATION_CONFIG;


### PR DESCRIPTION
- Make filtered item counting in the `DataFilterExtension` optional. It is disabled by default.
- `filteredItemCount` is not currently used in Kepler.gl.
- Reason: `onFilteredItemsChange` is called for each sublayer, and a large number of sublayers may be created for each batch of an Arrow table, potentially causing performance issues.
- Possible future solution: find a way to merge small arrow batches into a single binary data buffer.