### PR TITLE
[Bug] on dataset change: this._rows[e] is undefined

### DIFF
--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -781,6 +781,44 @@ function validateExistingLayerWithData(dataset, layerClasses, layer, schema) {
     : null;
 }
 
+const validateAndReplaceFields = (state, layer, dataId) => {
+  const newSizeField = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.sizeField?.name
+  );
+  const newHeightField = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.heightField?.name
+  );
+
+  const newStrokeColorField = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.strokeColorField?.name
+  );
+
+  const newWeightField = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.weightField?.name
+  );
+
+  const newRadiusField = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.radiusField?.name
+  );
+
+  const newCoverageField = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.coverageField?.name
+  );
+
+  const newColorfield = state.datasets[dataId].fields.find(
+    field => field.name === layer.config.colorField?.name
+  );
+  return {
+    sizeField: newSizeField,
+    heightField: newHeightField,
+    strokeColorField: newStrokeColorField,
+    weightField: newWeightField,
+    radiusField: newRadiusField,
+    coverageField: newCoverageField,
+    colorField: newColorfield
+  };
+};
+
 /**
  * Update layer config dataId
  * @memberof visStateUpdaters
@@ -822,6 +860,11 @@ export function layerDataIdChangeUpdater(
     } else {
       newLayer = validated;
     }
+  } else {
+    const newFields = validateAndReplaceFields(state, newLayer, dataId);
+    newLayer = newLayer.updateLayerConfig({
+      ...newFields
+    });
   }
 
   newLayer = newLayer.updateLayerConfig({


### PR DESCRIPTION
Steps to reproduce:
1.Select two datasets where at least one column is common, but the number of rows differs.

2. In a layer, remove some columns.

3. Change the dataset for the layer.

4. Check the console for errors.

Root Cause:
Kepler.gl's colorField, sizeField, and similar properties continue referencing fields from the previously used dataset. Since the datasets have different row counts, these fields attempt to access indices beyond the length of the previous dataset, causing the error when index > firstDataset.rows.length.

[sameple_2.csv](https://github.com/user-attachments/files/19554531/sameple_2.csv)
[sample_1.csv](https://github.com/user-attachments/files/19554533/sample_1.csv)
[dataset_changed_undefined.webm](https://github.com/user-attachments/assets/a22b5676-b834-44a7-816b-28e84edd4dc0)
