### PR TITLE
[fix] Legend positioning fixes

### DIFF
--- a/src/components/src/hooks/use-legend-position.ts
+++ b/src/components/src/hooks/use-legend-position.ts
@@ -42,6 +42,7 @@ const DEFAULT_POSITION: MapLegendControlSettings['position'] = {
   anchorY: 'bottom'
 };
 const MIN_CONTENT_HEIGHT = 100;
+const MAP_CONTROL_HEADER_FULL_HEIGHT = 34;
 
 export type UseCalcLegendPositionProps = {
   legendContentRef: React.MutableRefObject<HTMLElement | null>;
@@ -70,7 +71,7 @@ export function useCalcLegendPosition({
     );
     const rightOffset = Math.max(MARGIN.right, mapRootBounds.right - legendRect.right);
 
-    const topOffset = Math.max(MARGIN.top, legendRect.top);
+    const topOffset = Math.max(MARGIN.top, legendRect.top - mapRootBounds.top);
     const bottomOffset = Math.max(MARGIN.bottom, mapRootBounds.bottom - legendRect.bottom);
 
     return {
@@ -124,9 +125,10 @@ export default function useLegendPosition({
       const root = legendContentRef.current?.closest('.kepler-gl');
       const legendContent = legendContentRef.current;
       if (root instanceof HTMLElement && legendContent) {
+        const mapRootBounds = root.getBoundingClientRect();
         const legendRect = legendContent.getBoundingClientRect();
         const nextHeight = Math.min(
-          root.offsetHeight - legendRect.top - 100,
+          mapRootBounds.bottom - (legendRect.top + MAP_CONTROL_HEADER_FULL_HEIGHT + MARGIN.bottom),
           Math.max(MIN_CONTENT_HEIGHT, startHeightRef.current + deltaY)
         );
         onChangeSettings({contentHeight: nextHeight});


### PR DESCRIPTION
- Fixed legend positioning when the KeplerMap is not located at the top (i.e., top ≠ 0).
- Fixed legend flickering or jumping during legend resizing when the legend is positioned at the bottom.

