### PR TITLE
[chore] keplergl-jupyter: reduce list of python build requirements

### DIFF
--- a/bindings/kepler.gl-jupyter/pyproject.toml
+++ b/bindings/kepler.gl-jupyter/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["geopandas~=0.14.3", "ipywidgets~=8.1.5", "notebook~=6.0.1", "jupyter_packaging~=0.12.3", "jupyter-contrib-nbextensions~=0.7.0", "jupyterlab~=4.1.6", "pyarrow~=16.0.0", "setuptools>=69.5.1", "wheel"]
+requires = ["jupyter_packaging~=0.12.3", "setuptools>=69.5.1"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
I noticed that installing this package installs a bunch of packages when pip creates the isolated build environment (which happens since keplergl-jupyter only provides a source distribution, so it will "build" a wheel when installing).

Right now also packages like geopandas and pyarrow get installed in that isolated build environment, while those are not needed for building the wheel (only as runtime dependency in the environment in which you are installing keplergl into).

I _think_ only `jupyter-packaging` (and its dependencies like setuptools) is needed for running `setup.py` (also following https://github.com/jupyter/jupyter-packaging?tab=readme-ov-file#as-a-build-requirement). 
The actual runtime dependencies which includes the packages like geopandas and pyarrow, are still listed in ` is still the setup.py  (`install_requires`), so this change should not impact the end result of `pip install keplergl-jupyter`