### PR TITLE
[feat] loading indicator improvements

### DIFF
--- a/src/components/src/loading-indicator.tsx
+++ b/src/components/src/loading-indicator.tsx
@@ -4,6 +4,8 @@
 import React, {PropsWithChildren} from 'react';
 import styled, {withTheme} from 'styled-components';
 
+import {getNumRasterTilesBeingLoaded} from '@kepler.gl/layers';
+
 type StyledContainerProps = {
   $isVisible?: boolean;
   $left: number;
@@ -33,9 +35,8 @@ type LoadingIndicatorProps = {
 /** Extra adjustment for the loading indicator when side panel is visible */
 const LEFT_POSITION_ADJUSTMENT = 3;
 
-const LoadingIndicator: React.FC<PropsWithChildren<LoadingIndicatorProps> & {theme: any}> = ({
+const LoadingIndicator: React.FC<LoadingIndicatorProps & {theme: any}> = ({
   isVisible,
-  children,
   activeSidePanel,
   sidePanelWidth,
   theme
@@ -44,9 +45,18 @@ const LoadingIndicator: React.FC<PropsWithChildren<LoadingIndicatorProps> & {the
     (activeSidePanel ? (sidePanelWidth || 0) + LEFT_POSITION_ADJUSTMENT : 0) +
     theme.sidePanel.margin.left;
 
+  // Helper message to track number of raster tiles that are being loaded
+  const numRasterTilesInProgress = getNumRasterTilesBeingLoaded();
+  const extraMessage =
+    numRasterTilesInProgress < 1
+      ? ''
+      : `${numRasterTilesInProgress} raster tile${
+          numRasterTilesInProgress === 1 ? ' is' : 's are'
+        } being loaded`;
+
   return (
     <StyledContainer $isVisible={isVisible} $left={left}>
-      {children}
+      {`Loading... ${extraMessage}`}
     </StyledContainer>
   );
 };

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -31,8 +31,7 @@ import {
   LayerBaseConfig,
   VisualChannelDomain,
   EditorLayerUtils,
-  AggregatedBin,
-  isRasterTilesBeingLoaded
+  AggregatedBin
 } from '@kepler.gl/layers';
 import {
   DatasetAttribution,
@@ -83,6 +82,7 @@ import {LOCALE_CODES} from '@kepler.gl/localization';
 import {MapView} from '@deck.gl/core';
 import {
   MapStyle,
+  areAnyDeckLayersLoading,
   computeDeckLayers,
   getLayerHoverProp,
   LayerHoverProp,
@@ -365,6 +365,8 @@ export default function MapContainerFactory(
 ): React.ComponentType<MapContainerProps> {
   class MapContainer extends Component<MapContainerProps> {
     displayName = 'MapContainer';
+
+    private anyActiveLayerLoading = false;
 
     static contextType = MapViewStateContext;
 
@@ -947,6 +949,12 @@ export default function MapContainerFactory(
               if (typeof deckRenderCallbacks?.onDeckAfterRender === 'function') {
                 deckRenderCallbacks.onDeckAfterRender(allDeckGlProps);
               }
+
+              const anyActiveLayerLoading = areAnyDeckLayersLoading(allDeckGlProps.layers);
+              if (anyActiveLayerLoading !== this.anyActiveLayerLoading) {
+                this._onSmthLoadingChanges();
+              }
+              this.anyActiveLayerLoading = anyActiveLayerLoading;
             }}
           >
             {children}
@@ -1001,6 +1009,10 @@ export default function MapContainerFactory(
     _onMouseMoveDebounced = debounce((event, viewport) => {
       this.props.visStateActions.onMouseMove(normalizeEvent(event, viewport));
     }, DEBOUNCE_MOUSE_MOVE_PROPAGATE);
+
+    _onSmthLoadingChanges = debounce(() => {
+      this.props.uiStateActions.setLoadingIndicator({change: 0});
+    }, 100);
 
     _toggleMapControl = panelId => {
       const {index, uiStateActions} = this.props;
@@ -1158,12 +1170,10 @@ export default function MapContainerFactory(
           {this._renderMapPopover()}
           {primary !== isSplit ? (
             <LoadingIndicator
-              isVisible={isLoadingIndicatorVisible || isRasterTilesBeingLoaded()}
+              isVisible={Boolean(isLoadingIndicatorVisible || this.anyActiveLayerLoading)}
               activeSidePanel={Boolean(activeSidePanel)}
               sidePanelWidth={sidePanelWidth}
-            >
-              Loading...
-            </LoadingIndicator>
+            />
           ) : null}
           {this.props.primary ? (
             <Attribution

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -100,6 +100,9 @@ import LoadingIndicator from './loading-indicator';
 const DEBOUNCE_VIEWPORT_PROPAGATE = 10;
 const DEBOUNCE_MOUSE_MOVE_PROPAGATE = 10;
 
+// How long should we wait between layer loading state changes before triggering a UI update
+const DEBOUNCE_LOADING_STATE_PROPAGATE = 100;
+
 const MAP_STYLE: {[key: string]: React.CSSProperties} = {
   container: {
     display: 'inline-block',
@@ -952,7 +955,7 @@ export default function MapContainerFactory(
 
               const anyActiveLayerLoading = areAnyDeckLayersLoading(allDeckGlProps.layers);
               if (anyActiveLayerLoading !== this.anyActiveLayerLoading) {
-                this._onSmthLoadingChanges();
+                this._onLayerLoadingStateChange();
                 this.anyActiveLayerLoading = anyActiveLayerLoading;
               }
             }}
@@ -1010,9 +1013,10 @@ export default function MapContainerFactory(
       this.props.visStateActions.onMouseMove(normalizeEvent(event, viewport));
     }, DEBOUNCE_MOUSE_MOVE_PROPAGATE);
 
-    _onSmthLoadingChanges = debounce(() => {
+    _onLayerLoadingStateChange = debounce(() => {
+      // trigger loading indicator update without any change
       this.props.uiStateActions.setLoadingIndicator({change: 0});
-    }, 100);
+    }, DEBOUNCE_LOADING_STATE_PROPAGATE);
 
     _toggleMapControl = panelId => {
       const {index, uiStateActions} = this.props;

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -1014,7 +1014,7 @@ export default function MapContainerFactory(
     }, DEBOUNCE_MOUSE_MOVE_PROPAGATE);
 
     _onLayerLoadingStateChange = debounce(() => {
-      // trigger loading indicator update without any change
+      // trigger loading indicator update without any change to update UI
       this.props.uiStateActions.setLoadingIndicator({change: 0});
     }, DEBOUNCE_LOADING_STATE_PROPAGATE);
 

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -953,8 +953,8 @@ export default function MapContainerFactory(
               const anyActiveLayerLoading = areAnyDeckLayersLoading(allDeckGlProps.layers);
               if (anyActiveLayerLoading !== this.anyActiveLayerLoading) {
                 this._onSmthLoadingChanges();
+                this.anyActiveLayerLoading = anyActiveLayerLoading;
               }
-              this.anyActiveLayerLoading = anyActiveLayerLoading;
             }}
           >
             {children}

--- a/src/layers/src/index.ts
+++ b/src/layers/src/index.ts
@@ -49,7 +49,7 @@ import {default as RasterTileLayer} from './raster-tile/raster-tile-layer';
 export {default as RasterTileIcon} from './raster-tile/raster-tile-icon';
 export {
   default as RasterTileLayer,
-  isTilesBeingLoaded as isRasterTilesBeingLoaded
+  getNumRasterTilesBeingLoaded
 } from './raster-tile/raster-tile-layer';
 export {
   CATEGORICAL_COLORMAP_ID,

--- a/src/layers/src/raster-tile/raster-tile-layer.ts
+++ b/src/layers/src/raster-tile/raster-tile-layer.ts
@@ -69,9 +69,9 @@ const devicePixelRatio: number = Math.min(
 // Global counter that represents the number of tiles currently being loaded across all the raster tile layers
 let tilesBeingLoaded = 0;
 
-// This is a temp solution, as we don't have proper logic to track loading of asycn layers atm in Kepler.gl
-export const isTilesBeingLoaded = () => {
-  return tilesBeingLoaded > 0;
+// This is a temp solution to track loading
+export const getNumRasterTilesBeingLoaded = () => {
+  return tilesBeingLoaded;
 };
 
 export const LOAD_ELEVATION_AFTER_ZOOM = 8.9;

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -484,3 +484,11 @@ export function getLayerHoverPropValue(
   if (data instanceof DataRow) return data.valueAt(fieldIndex);
   return data[fieldIndex];
 }
+
+/** Checks if any Deck layers are in the process of loading. */
+export function areAnyDeckLayersLoading(layers: DeckLayer[]): boolean {
+  return layers.some(
+    // layer.isLoaded changes frequently in Deck (even on hover) so we check additional properties
+    layer => layer.internalState && !layer.isLoaded
+  );
+}


### PR DESCRIPTION
- The loading indicator is now shown for the Vector Tile layer.
- After each deck.gl render, check the state of the layers to determine if any are still loading.
- Display the number of loaded raster tiles.

<img width="359" alt="Screenshot 2025-05-10 at 3 47 47 AM" src="https://github.com/user-attachments/assets/f2cb9d4e-ed79-46e7-844f-55651cc1698d" />
