### PR TITLE
[fix] fixes for raster tile layer

### DIFF
--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1594,18 +1594,19 @@ export enum GEOARROW_EXTENSIONS {
   WKB = 'geoarrow.wkb'
 }
 
+export const LOADERS_CDN_VERSION = '4.3.2';
 export const LOADERS_CDN_URL = 'https://unpkg.com/@loaders.gl';
 
 export const getLoaderOptions = () => {
   return {
     mvt: {
-      workerUrl: `${LOADERS_CDN_URL}/mvt/dist/mvt-worker.js`
+      workerUrl: `${LOADERS_CDN_URL}/mvt@${LOADERS_CDN_VERSION}/dist/mvt-worker.js`
     },
     'quantized-mesh': {
-      // workerUrl: `${LOADERS_CDN_URL}/terrain/dist/quantized-mesh-worker.js`
+      workerUrl: `${LOADERS_CDN_URL}/terrain@${LOADERS_CDN_VERSION}/dist/quantized-mesh-worker.js`
     },
     npy: {
-      // workerUrl: `${LOADERS_CDN_URL}/textures/dist/npy-worker.js`
+      workerUrl: `${LOADERS_CDN_URL}/textures@${LOADERS_CDN_VERSION}/dist/npy-worker.js`
     }
   };
 };

--- a/src/deckgl-layers/src/raster/raster-mesh-layer/raster-mesh-layer.ts
+++ b/src/deckgl-layers/src/raster/raster-mesh-layer/raster-mesh-layer.ts
@@ -8,7 +8,6 @@ import {Model, Geometry, isWebGL2} from '@luma.gl/core';
 import {ProgramManager} from '@luma.gl/engine';
 import {UniformsOptions} from '@luma.gl/webgl/src/classes/uniforms';
 
-import {shouldComposeModelMatrix} from './matrix';
 import fsWebGL1 from './raster-mesh-layer-webgl1.fs';
 import vsWebGL1 from './raster-mesh-layer-webgl1.vs';
 import fsWebGL2 from './raster-mesh-layer-webgl2.fs';
@@ -181,14 +180,12 @@ export default class RasterMeshLayer extends SimpleMeshLayer<any, RasterLayerAdd
       return;
     }
 
-    const {viewport} = this.context;
-    const {sizeScale, coordinateSystem, _instanced} = this.props;
+    const {sizeScale} = this.props;
 
     model
       .setUniforms(
         Object.assign({}, uniforms, {
           sizeScale,
-          composeModelMatrix: !_instanced || shouldComposeModelMatrix(viewport, coordinateSystem),
           flatShading: !this.state.hasNormals
         })
       )
@@ -221,7 +218,7 @@ export default class RasterMeshLayer extends SimpleMeshLayer<any, RasterLayerAdd
       Object.assign({}, this.getShaders(), {
         id: this.props.id,
         geometry: getGeometry(mesh),
-        isInstanced: true
+        isInstanced: false
       })
     );
 

--- a/src/layers/src/raster-tile/image.ts
+++ b/src/layers/src/raster-tile/image.ts
@@ -398,11 +398,11 @@ export async function loadTerrain(props: {
   index: {x: number; y: number; z: number};
   signal: AbortSignal;
   rasterTileServerUrls: string[];
-  boundsForGemetry?: [number, number, number, number];
+  boundsForGeometry?: [number, number, number, number];
 }): Promise<TerrainData> {
   const {
     index: {x, y, z},
-    boundsForGemetry,
+    boundsForGeometry,
     signal,
     rasterTileServerUrls
   } = props;
@@ -415,7 +415,7 @@ export async function loadTerrain(props: {
     fetch: {signal},
     'quantized-mesh': {
       ...loaderOptions['quantized-mesh'],
-      bounds: boundsForGemetry,
+      bounds: boundsForGeometry,
       skirtHeight: meshMaxError * 2
     }
   }) as Promise<TerrainData>;

--- a/src/layers/src/raster-tile/image.ts
+++ b/src/layers/src/raster-tile/image.ts
@@ -389,13 +389,20 @@ export function getCategoricalColormapDataUrl(
   return getImageDataURL(bitmap, CATEGORICAL_TEXTURE_WIDTH, 1);
 }
 
-export function loadTerrain(props: {
+/**
+ * Load terrain mesh from raster tile server
+ * @param props - properties to load terrain data
+ * @returns terrain mesh data
+ */
+export async function loadTerrain(props: {
   index: {x: number; y: number; z: number};
   signal: AbortSignal;
   rasterTileServerUrls: string[];
+  boundsForGemetry?: [number, number, number, number];
 }): Promise<TerrainData> {
   const {
     index: {x, y, z},
+    boundsForGemetry,
     signal,
     rasterTileServerUrls
   } = props;
@@ -408,6 +415,7 @@ export function loadTerrain(props: {
     fetch: {signal},
     'quantized-mesh': {
       ...loaderOptions['quantized-mesh'],
+      bounds: boundsForGemetry,
       skirtHeight: meshMaxError * 2
     }
   }) as Promise<TerrainData>;

--- a/src/layers/src/raster-tile/raster-tile-layer.ts
+++ b/src/layers/src/raster-tile/raster-tile-layer.ts
@@ -781,9 +781,11 @@ function renderSubLayersStac(props: RenderSubLayersProps): DeckLayer<any> | Deck
     props: {...props, minPixelValue, maxPixelValue}
   });
 
+  const idSuffix = props.hasShadowEffect ? 'shadow' : '';
+
   return terrain
     ? new RasterMeshLayer(props, {
-        id: `raster-3d-layer-${props.id}-${props.hasShadowEffect ? 'shadow' : ''}`,
+        id: `raster-3d-layer-${props.id}-${idSuffix}`,
         // Dummy data
         data: [1],
         mesh: terrain,
@@ -798,7 +800,7 @@ function renderSubLayersStac(props: RenderSubLayersProps): DeckLayer<any> | Deck
         // material: false
       })
     : new RasterLayer(props, {
-        id: `raster-2d-layer-${props.id}`,
+        id: `raster-2d-layer-${props.id}-${idSuffix}`,
         images,
         modules,
         moduleProps,

--- a/src/layers/src/raster-tile/raster-tile-layer.ts
+++ b/src/layers/src/raster-tile/raster-tile-layer.ts
@@ -629,7 +629,7 @@ export default class RasterTileLayer extends KeplerLayer {
         shouldLoadTerrain &&
         LOAD_ELEVATION_AFTER_ZOOM < zoom &&
         (await loadTerrain({
-          boundsForGemetry: [west, north, east, south],
+          boundsForGeometry: [west, north, east, south],
           index: props.index,
           signal: props.signal,
           rasterTileServerUrls: props.stac.rasterTileServerUrls || []
@@ -651,7 +651,7 @@ export default class RasterTileLayer extends KeplerLayer {
         }),
         shouldLoadTerrain && LOAD_ELEVATION_AFTER_ZOOM < zoom
           ? loadTerrain({
-              boundsForGemetry: [west, north, east, south],
+              boundsForGeometry: [west, north, east, south],
               index: props.index,
               signal: props.signal,
               rasterTileServerUrls: props.stac.rasterTileServerUrls || []
@@ -710,7 +710,7 @@ export default class RasterTileLayer extends KeplerLayer {
       const terrain =
         image && shouldLoadTerrain && LOAD_ELEVATION_AFTER_ZOOM < zoom
           ? await loadTerrain({
-              boundsForGemetry: [west, north, east, south],
+              boundsForGeometry: [west, north, east, south],
               index: props.index,
               signal: props.signal,
               rasterTileServerUrls: metadata.rasterTileServerUrls

--- a/src/layers/src/raster-tile/types.ts
+++ b/src/layers/src/raster-tile/types.ts
@@ -157,6 +157,7 @@ export type RenderSubLayersCustomProps = ColorRescaling &
     minCategoricalBandValue?: number;
     maxCategoricalBandValue?: number;
     hasCategoricalColorMap: boolean;
+    hasShadowEffect?: boolean;
   };
 
 export interface RenderSubLayersDefaultProps {

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -3,7 +3,7 @@
 
 import Console from 'global/console';
 
-import {GEOCODER_LAYER_ID} from '@kepler.gl/constants';
+import {GEOCODER_LAYER_ID, LIGHT_AND_SHADOW_EFFECT} from '@kepler.gl/constants';
 import {Layer as DeckLayer, LayerProps as DeckLayerProps} from '@deck.gl/core/typed';
 import {
   Field,
@@ -236,7 +236,8 @@ export function renderDeckGlLayer(props: any, layerCallbacks: {[key: string]: an
     mapState,
     interactionConfig,
     animationConfig,
-    mapLayers
+    mapLayers,
+    experimentalContext
   } = props;
   const dataset = datasets[layer.config.dataId];
   const {gpuFilter} = dataset || {};
@@ -253,7 +254,8 @@ export function renderDeckGlLayer(props: any, layerCallbacks: {[key: string]: an
     animationConfig,
     objectHovered,
     visible,
-    dataset
+    dataset,
+    experimentalContext
   });
 }
 
@@ -367,6 +369,7 @@ export function computeDeckLayers(
 ): Layer[] {
   const {
     datasets,
+    effects,
     layers,
     layerOrder,
     layerData,
@@ -381,6 +384,10 @@ export function computeDeckLayers(
     options || {};
 
   let dataLayers: any[] = [];
+
+  const hasShadowEffect = effects.some(effect => {
+    return effect.type === LIGHT_AND_SHADOW_EFFECT.type;
+  });
 
   if (layerData && layerData.length) {
     const mapLayers = getMapLayersFromSplitMaps(splitMaps, mapIndex || 0);
@@ -409,7 +416,10 @@ export function computeDeckLayers(
             mapState,
             interactionConfig,
             animationConfig,
-            mapLayers
+            mapLayers,
+            experimentalContext: {
+              hasShadowEffect
+            }
           },
           bindedLayerCallbacks
         );


### PR DESCRIPTION
- [x] pin versions of loader workers
- [x] fix for shadow effect completely breaking raster tile layer (existing raster layers with conflicting samplers required rebuilding).
- [x] fix for shadow effect not working on certain zoom levels due to internal projection mode switch in deck gl
- [x] load raster mesh layers in lon/lat coords instead of local coords with offsets

<img width="1564" alt="Screenshot 2025-05-12 at 10 17 42 PM" src="https://github.com/user-attachments/assets/766ab3e6-a4ee-4019-8347-7ba450660085" />
<img width="1560" alt="Screenshot 2025-05-12 at 10 17 54 PM" src="https://github.com/user-attachments/assets/26432d80-5b7a-45ae-ab1c-f519f5090266" />
