### PR TITLE
[fix] fix tooltip crashing for trip layer

### DIFF
--- a/src/table/src/kepler-table.ts
+++ b/src/table/src/kepler-table.ts
@@ -108,13 +108,14 @@ export function maybeToDate(
   fieldIdx: number,
   format: string,
   dc: DataContainerInterface,
-  d: {index: number}
+  // An object with row index or a materialized row array (for materialized hover info from trip layer)
+  d: {index: number} | any[]
 ) {
   if (isTime) {
-    return timeToUnixMilli(dc.valueAt(d.index, fieldIdx), format);
+    return timeToUnixMilli(Array.isArray(d) ? d[fieldIdx] : dc.valueAt(d.index, fieldIdx), format);
   }
 
-  return dc.valueAt(d.index, fieldIdx);
+  return Array.isArray(d) ? d[fieldIdx] : dc.valueAt(d.index, fieldIdx);
 }
 
 class KeplerTable<F extends Field = Field> {


### PR DESCRIPTION
For #3094 

- Fixed tooltip crash for the Trip Layer.

- The Trip Layer calculates intermediate data between two data points and sends a materialized row as an array to data accessors, which by default expect an index and a data container.