### PR TITLE
[fix] fix for image export with effects

### DIFF
--- a/src/components/src/modals/export-image-modal.tsx
+++ b/src/components/src/modals/export-image-modal.tsx
@@ -51,7 +51,6 @@ export interface ExportImageModalProps {
 }
 
 const ExportImageModalFactory = () => {
-  /** @type {typeof import('./export-image-modal').ExportImageModal} */
   const ExportImageModal: React.FC<ExportImageModalProps> = ({
     mapW,
     mapH,

--- a/src/effects/src/effect.ts
+++ b/src/effects/src/effect.ts
@@ -50,6 +50,11 @@ export class Effect implements EffectInterface {
     // implemented in subclasses
   }
 
+  clone(): Effect {
+    const props = this.getDefaultProps(this);
+    return new (this.constructor as new (props: EffectPropsPartial) => this)(props);
+  }
+
   getDefaultProps(props: EffectPropsPartial = {}): EffectProps {
     return {
       id: props.id || `e_${generateHashId(6)}`,

--- a/src/types/effects.d.ts
+++ b/src/types/effects.d.ts
@@ -46,4 +46,5 @@ export interface Effect {
   setProps(props: Partial<EffectProps>): void;
   isValidToSave(): boolean;
   getParameterDescriptions(): EffectParameterDescription[];
+  clone(): Effect;
 }


### PR DESCRIPTION
For #3034 

- fix for image export with active effects

- [x] An exported image with shadows and post-processing:
![kepler gl (8)](https://github.com/user-attachments/assets/aaf35a8e-2276-4a7a-bd72-90d6aa8a16c7)
