### PR TITLE
[fix] Custom picker fix when called during initialization

### DIFF
--- a/src/components/src/side-panel/layer-panel/custom-picker.tsx
+++ b/src/components/src/side-panel/layer-panel/custom-picker.tsx
@@ -76,7 +76,7 @@ const defaultProps: CustomPickerProps = {
   }
 };
 
-// Note: When using SketchPicker, the parent component CustomPicker can be invoked as a function without props using ReactDOM.
+// Note: When using SketchPicker, the parent component CustomPicker can be invoked as a function without props by ReactDOM.
 const CustomPicker: React.FC<CustomPickerProps> = (props = defaultProps) => {
   const {color, onChange, theme} = props;
 

--- a/src/components/src/side-panel/layer-panel/custom-picker.tsx
+++ b/src/components/src/side-panel/layer-panel/custom-picker.tsx
@@ -65,7 +65,9 @@ type CustomPickerProps = {
   onChange: ColorChangeHandler;
 };
 
-const CustomPicker: React.FC<CustomPickerProps> = ({color, onChange, theme}: CustomPickerProps) => {
+const CustomPicker: React.FC<CustomPickerProps> = (props: CustomPickerProps) => {
+  // When using SketchPicker, the parent component CustomPicker can be invoked as a function without props using ReactDOM.
+  const {color, onChange, theme} = props || {};
   const pickerStyle = useMemo(
     () => ({
       picker: {

--- a/src/components/src/side-panel/layer-panel/custom-picker.tsx
+++ b/src/components/src/side-panel/layer-panel/custom-picker.tsx
@@ -6,6 +6,7 @@ import styled, {withTheme} from 'styled-components';
 import {SketchPicker, ColorChangeHandler} from 'react-color';
 
 import {HexColor} from '@kepler.gl/types';
+import {panelBackground} from '@kepler.gl/styles';
 
 import {BaseComponentProps} from '../../types';
 
@@ -65,8 +66,18 @@ type CustomPickerProps = {
   onChange: ColorChangeHandler;
 };
 
+const defaultProps: CustomPickerProps = {
+  color: '#f00',
+  theme: {
+    panelBackground
+  },
+  onChange: () => {
+    // no-op
+  }
+};
+
 // Note: When using SketchPicker, the parent component CustomPicker can be invoked as a function without props using ReactDOM.
-const CustomPicker: React.FC<CustomPickerProps> = (props = {} as CustomPickerProps) => {
+const CustomPicker: React.FC<CustomPickerProps> = (props = defaultProps) => {
   const {color, onChange, theme} = props;
 
   const pickerStyle = useMemo(

--- a/src/components/src/side-panel/layer-panel/custom-picker.tsx
+++ b/src/components/src/side-panel/layer-panel/custom-picker.tsx
@@ -65,9 +65,10 @@ type CustomPickerProps = {
   onChange: ColorChangeHandler;
 };
 
-const CustomPicker: React.FC<CustomPickerProps> = (props: CustomPickerProps) => {
-  // When using SketchPicker, the parent component CustomPicker can be invoked as a function without props using ReactDOM.
-  const {color, onChange, theme} = props || {};
+// Note: When using SketchPicker, the parent component CustomPicker can be invoked as a function without props using ReactDOM.
+const CustomPicker: React.FC<CustomPickerProps> = (props = {} as CustomPickerProps) => {
+  const {color, onChange, theme} = props;
+
   const pickerStyle = useMemo(
     () => ({
       picker: {


### PR DESCRIPTION
- When using SketchPicker, the parent component CustomPicker can potentially be invoked from ReactDOM as a function without any props.