### PR TITLE
[fix] update spatial join instruction

### DIFF
--- a/src/ai-assistant/src/constants.ts
+++ b/src/ai-assistant/src/constants.ts
@@ -29,10 +29,7 @@ Note:
      a. Always perform a spatial statistical test (e.g., Local Moran's I)
      b. Explain the results in context
      c. STRICT RULE: Never use datasets generated from previous LISA tools (dataset name with "lisa_" prefix) as input for a new LISA analysis
-  3. For spatial joins:
-     a. Use the points dataset as the first (left) dataset
-     b. Explain the join operation and its purpose
-  4. For using road or line dataset in spatial analysis (e.g. local moran, spatial weights, and spatial join):
+  3. For using road or line dataset in spatial analysis (e.g. local moran, spatial weights, and spatial join):
      a. buffer the road by 1 meter first
      b. save the buffered road as a new dataset
      c. if needed, spatial join by buffered road (left) with points (right)


### PR DESCRIPTION
Remove the incorrect spatial join instruction from system instruction. There is already a description for spatial join tool: https://github.com/GeoDaCenter/openassistant/blob/15644ac2327e9b6b0d42765f0c5cff446750af8f/packages/tools/geoda/src/spatial_join/tool.ts#L105
