### PR TITLE
[fix] fit to bounds - fix initial basemap and deck projections mismatch

### DIFF
--- a/src/reducers/src/map-state-updaters.ts
+++ b/src/reducers/src/map-state-updaters.ts
@@ -422,7 +422,7 @@ function updateViewportBasedOnBounds(state: MapState, newMapState: MapState) {
     if (!booleanWithin(viewportBoundsPolygon, maxBoundsPolygon)) {
       const {latitude, longitude, zoom} = fitBounds({
         width: newMapState.width,
-        height: newMapState.width,
+        height: newMapState.height,
         bounds: [
           [newStateMaxBounds[0], newStateMaxBounds[1]],
           [newStateMaxBounds[2], newStateMaxBounds[3]]

--- a/src/utils/src/projection-utils.ts
+++ b/src/utils/src/projection-utils.ts
@@ -41,17 +41,26 @@ export function getCenterAndZoomFromBounds(bounds, {width, height}) {
   }
 
   // viewport(bounds, dimensions, minzoom, maxzoom, tileSize, allowFloat)
-  const {zoom} = geoViewport.viewport(
+  let {zoom} = geoViewport.viewport(
     bounds,
     [width, height],
     undefined,
     undefined,
-    MAPBOX_TILE_SIZE
+    MAPBOX_TILE_SIZE,
+    true
   );
   // center being calculated by geo-vieweport.viewport has a complex logic that
   // projects and then unprojects the coordinates to determine the center
   // Calculating a simple average instead as that is the expected behavior in most of cases
   const center = [(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2];
+
+  // NOTE: this logic is used in deck.gl normalizeViewportProps
+  // This is required in order to prevent projection matrix mismatch between basemap and layers
+  const minZoom = Math.log2(height / MAPBOX_TILE_SIZE);
+  if (zoom <= minZoom) {
+    zoom = minZoom;
+    center[1] = 0;
+  }
 
   return {zoom, center};
 }

--- a/test/browser/components/geocoder-panel-test.js
+++ b/test/browser/components/geocoder-panel-test.js
@@ -190,7 +190,7 @@ test('GeocoderPanel - render', t => {
 
   t.deepEqual(
     {latitude: newVP.latitude, longitude: newVP.longitude, zoom: newVP.zoom},
-    {latitude: 57.5, longitude: 1.5, zoom: 4},
+    {latitude: 57.5, longitude: 1.5, zoom: 4.307606395110668},
     'Should call updateMap action on onSelected w/ new viewport'
   );
 
@@ -201,7 +201,7 @@ test('GeocoderPanel - render', t => {
   const newVP2 = updateMap.args[1][0];
   t.deepEqual(
     {latitude: newVP2.latitude, longitude: newVP2.longitude, zoom: newVP2.zoom},
-    {latitude: 55, longitude: 1, zoom: 11},
+    {latitude: 55, longitude: 1, zoom: 11.655698543267773},
     'Should call updateMapaction on onSelected w/o bbox'
   );
 

--- a/test/browser/components/plot-container-test.js
+++ b/test/browser/components/plot-container-test.js
@@ -90,6 +90,6 @@ test('PlotContainer -> mount -> imageSize', t => {
     -45.57105275929253,
     'should set longitude when center: true'
   );
-  t.equal(map.props.mapState.zoom, 1, 'should set zoom when center: true');
+  t.equal(map.props.mapState.zoom, 1.8721094288367688, 'should set zoom when center: true');
   t.end();
 });

--- a/test/node/reducers/map-state-test.js
+++ b/test/node/reducers/map-state-test.js
@@ -346,7 +346,7 @@ test('#mapStateReducer -> FIT_BOUNDS', t => {
 
   const expected = {
     center: [5.7604079999999955, 45.189756500000016],
-    zoom: 10
+    zoom: 10.569800116329509
   };
 
   const stateWidthMapDimension = reducer(undefined, updateMap(mapUpdate, 0));


### PR DESCRIPTION
Before this fix, the initial zoom levels for the basemap and Deck layers could differ, requiring user input to synchronize the projections. This issue affected any layer whose bounds included latitude values closer the poles.

- getCenterAndZoomFromBounds - add extra zoom logic from normalizeViewportProps
- width was used instead of height

Example how dataset looked right after loading before the fix:
![bounds mis match](https://github.com/user-attachments/assets/0df5f114-80be-4a7b-9840-2cf19beae34d)

<img width="1127" height="1060" alt="Screenshot 2025-07-10 at 3 43 05 PM" src="https://github.com/user-attachments/assets/71c498c4-7a76-4099-bed2-2356efa14465" />

After the fix:
![Screenshot 2025-07-09 at 4 10 47 AM](https://github.com/user-attachments/assets/c614743f-8d7e-46f9-a80f-246fb5191236)

