### PR TITLE
Update react-modal types version

### DIFF
--- a/src/components/package.json
+++ b/src/components/package.json
@@ -70,7 +70,7 @@
     "@types/react-dom": "^18.0.11",
     "@types/react-lifecycles-compat": "^3.0.1",
     "@types/react-map-gl": "^6.1.3",
-    "@types/react-modal": "^3.13.1",
+    "@types/react-modal": "^3.16.3",
     "@types/react-redux": "^7.1.23",
     "@types/react-virtualized": "^9.21.30",
     "@types/react-vis": "1.11.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4954,7 +4954,7 @@ __metadata:
     "@types/react-dom": "npm:^18.0.11"
     "@types/react-lifecycles-compat": "npm:^3.0.1"
     "@types/react-map-gl": "npm:^6.1.3"
-    "@types/react-modal": "npm:^3.13.1"
+    "@types/react-modal": "npm:^3.16.3"
     "@types/react-redux": "npm:^7.1.23"
     "@types/react-virtualized": "npm:^9.21.30"
     "@types/react-vis": "npm:1.11.7"
@@ -10383,7 +10383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-modal@npm:^3.13.1":
+"@types/react-modal@npm:^3.16.3":
   version: 3.16.3
   resolution: "@types/react-modal@npm:3.16.3"
   dependencies:


### PR DESCRIPTION
Update the types so that we are not getting this error: 

<img width="2559" height="1439" alt="Screenshot 2025-08-03 213837" src="https://github.com/user-attachments/assets/2760190a-1233-442e-ae9e-2eb3bffb3693" />
