### PR TITLE
[feat] add support for boolean filter in vector tiles

### DIFF
--- a/src/components/src/modal-container.tsx
+++ b/src/components/src/modal-container.tsx
@@ -189,8 +189,12 @@ export default function ModalContainerFactory(
             ...processedMetadata,
             ...tileset.metadata
           },
-          // vector tile layer only supports gpu filtering for now
-          supportedFilterTypes: [ALL_FIELD_TYPES.real, ALL_FIELD_TYPES.integer],
+          // Vector tile layer supports GPU filtering for numeric and boolean fields
+          supportedFilterTypes: [
+            ALL_FIELD_TYPES.real,
+            ALL_FIELD_TYPES.integer,
+            ALL_FIELD_TYPES.boolean
+          ],
           disableDataOperation: true
         },
         {

--- a/src/table/src/tileset/vector-tile-utils.ts
+++ b/src/table/src/tileset/vector-tile-utils.ts
@@ -31,7 +31,6 @@ import {clamp, formatNumberByStep, getNumericStepSize, timeToUnixMilli} from '@k
 import {
   FilterProps,
   NumericFieldFilterProps,
-  BooleanFieldFilterProps,
   StringFieldFilterProps,
   default as KeplerDataset
 } from '../kepler-table';
@@ -530,11 +529,15 @@ export function getFilterProps(
     }
 
     case ALL_FIELD_TYPES.boolean: {
-      const filterProps: BooleanFieldFilterProps = {
-        domain: [true, false],
-        value: true,
-        type: FILTER_TYPES.select,
-        gpu: true
+      // Represent boolean as numeric range [0,1] to enable GPU filtering for vector tiles
+      const domain: [number, number] = [0, 1];
+      const filterProps: NumericFieldFilterProps = {
+        domain,
+        value: domain,
+        type: FILTER_TYPES.range,
+        typeOptions: [FILTER_TYPES.range],
+        gpu: true,
+        step: 1
       };
       return filterProps;
     }


### PR DESCRIPTION
- add support for boolean filter in vector tiles
- we don't perform cpu-side filtering for tiles, so transform boolean range to 0-1 range for direct GPU support