### PR TITLE
[fix] vector tile layer - use highlightedFeatureId for hover

### DIFF
--- a/src/layers/src/vector-tile/common-tile/tile-dataset.ts
+++ b/src/layers/src/vector-tile/common-tile/tile-dataset.ts
@@ -77,6 +77,13 @@ export default class TileDataset<T, I extends Iterable<any> = T extends Iterable
   }
 
   /**
+   * Return current tiles
+   */
+  getTiles(): readonly T[] {
+    return this.tiles;
+  }
+
+  /**
    * Get the min/max domain of a field
    */
   getExtent(field: KeplerField): [number, number] {

--- a/src/layers/src/vector-tile/vector-tile-layer.ts
+++ b/src/layers/src/vector-tile/vector-tile-layer.ts
@@ -73,7 +73,21 @@ export const DEFAULT_HIGHLIGHT_FILL_COLOR = [252, 242, 26, 150];
 export const DEFAULT_HIGHLIGHT_STROKE_COLOR = [252, 242, 26, 255];
 export const MAX_CACHE_SIZE_MOBILE = 1; // Minimize caching, visible tiles will always be loaded
 export const DEFAULT_STROKE_WIDTH = 1;
-
+export const UUID_CANDIDATES = [
+  'ufid',
+  'UFID',
+  'id',
+  'ID',
+  'fid',
+  'FID',
+  'objectid',
+  'OBJECTID',
+  'gid',
+  'GID',
+  'feature_id',
+  'FEATURE_ID',
+  '_id'
+];
 /**
  * Type for transformRequest returned parameters.
  */
@@ -538,6 +552,20 @@ export default class VectorTileLayer extends AbstractTileLayer<VectorTile, Featu
     if (data.tileSource) {
       const hoveredObject = this.hasHoveredObject(objectHovered);
 
+      // Try to infer a stable unique id property from the hovered feature so we can
+      // highlight the same feature across adjacent tiles. If none is found, rely on
+      // feature.id when available.
+      let uniqueIdProperty: string | undefined;
+      let highlightedFeatureId: string | number | undefined;
+      if (hoveredObject && hoveredObject.properties) {
+        uniqueIdProperty = UUID_CANDIDATES.find(
+          k => hoveredObject.properties && k in hoveredObject.properties
+        );
+        highlightedFeatureId = uniqueIdProperty
+          ? hoveredObject.properties[uniqueIdProperty]
+          : (hoveredObject as any).id;
+      }
+
       const layers = [
         new CustomMVTLayer({
           ...defaultLayerProps,
@@ -556,7 +584,8 @@ export default class VectorTileLayer extends AbstractTileLayer<VectorTile, Featu
           stroked: visConfig.stroked,
 
           // TODO: this is hard coded, design a UI to allow user assigned unique property id
-          // uniqueIdProperty: 'ufid',
+          uniqueIdProperty,
+          highlightedFeatureId,
           renderSubLayers: this.renderSubLayers,
           // when radiusUnits is meter
           getPointRadiusScaleByZoom: getPropertyByZoom(visConfig.radiusByZoom, visConfig.radius),
@@ -634,26 +663,7 @@ export default class VectorTileLayer extends AbstractTileLayer<VectorTile, Featu
           loadOptions: {
             mvt: getLoaderOptions().mvt
           }
-        }),
-        // hover layer
-        ...(hoveredObject
-          ? [
-              new GeoJsonLayer({
-                // @ts-expect-error props not typed?
-                ...objectHovered.sourceLayer?.props,
-                ...(this.getDefaultHoverLayerProps() as any),
-                visible: true,
-                wrapLongitude: false,
-                data: [hoveredObject],
-                getLineColor: DEFAULT_HIGHLIGHT_STROKE_COLOR,
-                getFillColor: DEFAULT_HIGHLIGHT_FILL_COLOR,
-                getLineWidth: visConfig.strokeWidth + 1,
-                lineWidthUnits: 'pixels',
-                stroked: true,
-                filled: true
-              })
-            ]
-          : [])
+        })
         // ...tileLayerBoundsLayer(defaultLayerProps.id, data),
       ];
 


### PR DESCRIPTION
For #3012 

- in vector tile layer rely on built in `highlightedFeatureId` for hovering
- add more props for unique id 
- smart outline calculation for features that are in multiple tiles

Before:
<img width="637" height="383" alt="Screenshot 2025-08-30 at 6 03 17 PM" src="https://github.com/user-attachments/assets/825bb2ce-4aea-43dd-a63a-861f587cf9e4" />

After:
<img width="548" height="367" alt="Screenshot 2025-08-30 at 11 13 42 PM" src="https://github.com/user-attachments/assets/db3a2804-a0ea-4a73-b825-b367b8f01942" />

