### PR TITLE
[fix] icon layer - render default icon in case svgIconUrl loading fails

### DIFF
--- a/src/layers/src/icon-layer/icon-layer.ts
+++ b/src/layers/src/icon-layer/icon-layer.ts
@@ -209,10 +209,22 @@ export default class IconLayer extends Layer {
 
     if (Window.fetch && this.svgIconUrl) {
       Window.fetch(this.svgIconUrl, fetchConfig)
-        .then(response => response.json())
+        .then(response => {
+          if (!response.ok) {
+            throw new Error(`Failed to load svg-icons.json: ${response.status}`);
+          }
+          return response.json();
+        })
         .then((parsed: {svgIcons?: any[]} = {}) => {
           this.setSvgIcons(parsed.svgIcons);
+        })
+        .catch(() => {
+          // Fallback to empty geometry to allow default icon rendering
+          this.iconGeometry = {};
         });
+    } else {
+      // No fetch available; set empty geometry so layer can render default icons
+      this.iconGeometry = {};
     }
   }
 
@@ -389,42 +401,40 @@ export default class IconLayer extends Layer {
       cullFace: GL.FRONT
     };
 
-    return !this.iconGeometry
-      ? []
-      : [
-          new SvgIconLayer({
-            ...defaultLayerProps,
-            ...brushingProps,
-            ...layerProps,
-            ...data,
-            parameters,
-            getIconGeometry: id => this.iconGeometry?.[id],
+    return [
+      new SvgIconLayer({
+        ...defaultLayerProps,
+        ...brushingProps,
+        ...layerProps,
+        ...data,
+        parameters,
+        getIconGeometry: id => this.iconGeometry?.[id],
 
-            // update triggers
-            updateTriggers,
-            extensions
-          }),
+        // update triggers
+        updateTriggers,
+        extensions
+      }),
 
-          // hover layer
-          ...(hoveredObject
-            ? [
-                // @ts-expect-error SvgIconLayerProps needs getIcon Field
-                new SvgIconLayer({
-                  ...this.getDefaultHoverLayerProps(),
-                  ...layerProps,
-                  visible: defaultLayerProps.visible,
-                  data: [hoveredObject],
-                  parameters,
-                  getPosition: data.getPosition,
-                  getRadius: data.getRadius,
-                  getFillColor: this.config.highlightColor,
-                  getIconGeometry: id => this.iconGeometry?.[id]
-                })
-              ]
-            : []),
+      // hover layer
+      ...(hoveredObject
+        ? [
+            // @ts-expect-error SvgIconLayerProps needs getIcon Field
+            new SvgIconLayer({
+              ...this.getDefaultHoverLayerProps(),
+              ...layerProps,
+              visible: defaultLayerProps.visible,
+              data: [hoveredObject],
+              parameters,
+              getPosition: data.getPosition,
+              getRadius: data.getRadius,
+              getFillColor: this.config.highlightColor,
+              getIconGeometry: id => this.iconGeometry?.[id]
+            })
+          ]
+        : []),
 
-          // text label layer
-          ...labelLayers
-        ];
+      // text label layer
+      ...labelLayers
+    ];
   }
 }


### PR DESCRIPTION
Probably for #3062

- icon layer - render default icon in case `svgIconUrl` loading fails