### PR TITLE
Table fix

### DIFF
--- a/src/components/src/common/data-table/index.tsx
+++ b/src/components/src/common/data-table/index.tsx
@@ -364,7 +364,7 @@ export const TableSection = ({
                 height={dataGridHeight - headerGridProps.height}
                 onScroll={onScroll}
                 scrollLeft={scrollLeft}
-               scrollTop={scrollTop}
+                scrollTop={scrollTop}
                 setGridRef={setGridRef}
               />
             </div>

--- a/src/components/src/common/data-table/index.tsx
+++ b/src/components/src/common/data-table/index.tsx
@@ -349,7 +349,7 @@ export const TableSection = ({
                 height={headerGridProps.height + browserScrollBarWidth}
                 width={headerGridWidth}
                 scrollLeft={scrollLeft}
-                onScroll={onScroll}
+                onScroll={args => onScroll?.({...args, scrollTop:scrollTop ?? 0 })}
               />
             </div>
             <div
@@ -364,7 +364,7 @@ export const TableSection = ({
                 height={dataGridHeight - headerGridProps.height}
                 onScroll={onScroll}
                 scrollLeft={scrollLeft}
-                scrollTop={scrollTop}
+               scrollTop={scrollTop}
                 setGridRef={setGridRef}
               />
             </div>


### PR DESCRIPTION
When the header grid fired scroll events (during horizontal scrolling), it was calling the shared onScroll function with its own scrollTop value (which is 0 for headers). This overwrote the ScrollSync's shared scrollTop state, causing the body grid to reset its vertical position.
[Screencast from 2025-09-05 00-13-43.webm](https://github.com/user-attachments/assets/46adb565-c6cd-4c10-98d9-8bb2199af23b)
