### PR TITLE
fix: interaction panel causes layout shift

### DIFF
--- a/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
+++ b/src/components/src/side-panel/interaction-panel/interaction-panel.tsx
@@ -35,6 +35,7 @@ interface InteractionPanelProps {
 
 const StyledInteractionPanel = styled.div`
   padding-bottom: 6px;
+  contain: layout paint;
 `;
 
 InteractionPanelFactory.deps = [TooltipConfigFactory, BrushConfigFactory];


### PR DESCRIPTION
For #3222

- layout containment: prevents child layout changes from affecting ancestors/siblings.
- paint containment: prevents paint operations from leaking outside the panel.
- Net effect: toggles that re-render Tooltip content no longer cause the map to shift, while the panel still behaves normally.