### PR TITLE
feat: extend bigInt casting to support UBIGINT, HUGEINT, UHUGEINT

### DIFF
--- a/src/duckdb/src/table/duckdb-table-utils.ts
+++ b/src/duckdb/src/table/duckdb-table-utils.ts
@@ -111,7 +111,11 @@ export function castDuckDBTypesForKepler(
     const quotedColumnName = quoteColumnName(name);
     if (type === 'GEOMETRY' && options.geometryToWKB) {
       return `ST_AsWKB(${quotedColumnName}) as ${quotedColumnName}`;
-    } else if (type === 'BIGINT' && options.bigIntToDouble) {
+    } else if (
+      options.bigIntToDouble &&
+      (type === 'BIGINT' || type === 'UBIGINT' || type === 'HUGEINT' || type === 'UHUGEINT')
+    ) {
+      // Cast 64-bit and larger integer types to DOUBLE to avoid BigInt in JS
       return `CAST(${quotedColumnName} AS DOUBLE) as ${quotedColumnName}`;
     }
     return quotedColumnName;


### PR DESCRIPTION
- Add support for casting UBIGINT, HUGEINT, and UHUGEINT to DOUBLE
- Prevents BigInt issues in JavaScript when dealing with large integer types

From the DuckDB documentation:

- HUGEINT is a signed 16-byte (128-bit) integer type. 
- UHUGEINT is an unsigned 16-byte (128-bit) integer type.
- UBIGINT is an unsigned 8-byte (64-bit) integer type.