### PR TITLE
fix: detect h3 column in arrow

### DIFF
--- a/src/processors/src/data-processor.ts
+++ b/src/processors/src/data-processor.ts
@@ -494,6 +494,10 @@ export function arrowSchemaToFields(
       type = keplerField.type;
       analyzerType = keplerField.analyzerType;
       format = keplerField.format;
+    } else if (fieldTypeSuggestion === 'VARCHAR' && keplerField.type === ALL_FIELD_TYPES.h3) {
+      // when kepler detected h3 column using getFieldsFromData(), set type to h3 and analyzerType to H3
+      type = ALL_FIELD_TYPES.h3;
+      analyzerType = keplerField.analyzerType;
     } else {
       // TODO should we use Kepler getFieldsFromData instead
       // of arrowDataTypeToFieldType for all fields?


### PR DESCRIPTION
Fix an issue that h3 column can not be detected when using arrow table.

in arrowSchemaToFields() function:

getFieldsFromData() was first used to detect H3 columns:
```ts
const keplerFields = getFieldsFromData(sample, headerRow);
```

If there is a H3 column, it will be recorded in keplerFields. However, when go through the `table.schema.fields`, the type and analyzeType are initialized as `string` and `AnalyzerDATA_TYPES.STRING` since the H3 column is VARCHAR.

So, there is a missing case for H3
```
    } else if (fieldTypeSuggestion === 'VARCHAR' && keplerField.type === ALL_FIELD_TYPES.h3) {
      // when kepler detected h3 column using getFieldsFromData(), set type to h3 and analyzerType to H3
      type = ALL_FIELD_TYPES.h3;
      analyzerType = keplerField.analyzerType;
    } else {
```

Otherwise, the `type` will be overwritten as 'string', and `analyzeType` will be `AnalyzerDATA_TYPES.STRING`
