### PR TITLE
[Feat] timeline zoom & precision controls in enlarged time filter

### DIFF
--- a/docs/user-guides/h-playback.md
+++ b/docs/user-guides/h-playback.md
@@ -15,5 +15,13 @@ Follow these steps to create a playback video of an event:
 
 ![custom y axis](https://d1a3f4spazzrp4.cloudfront.net/kepler.gl/documentation/h-playback-3.png "select filters")
 
+## Zoom & precision controls
+
+The enlarged timeline now lets you stay focused on the portion that matters:
+
+- Use the mouse wheel to resize the window under the cursor, and pinch (or hold <kbd>Ctrl</kbd> on Windows/Linux or <kbd>⌘</kbd> on macOS while scrolling) to zoom the full timeline.
+- A lightweight "Showing" bar appears whenever the full range is narrowed—click **Reset** to return to the original domain.
+- Hold <kbd>Ctrl</kbd> (Windows/Linux) or <kbd>⌘</kbd> (macOS) and press the arrow keys to pan left/right, with <kbd>Shift</kbd> for bigger steps.
+
 
 [Back to table of contents](README.md)

--- a/src/ai-assistant/src/config/models.ts
+++ b/src/ai-assistant/src/config/models.ts
@@ -2,12 +2,12 @@
 // Copyright contributors to the kepler.gl project
 
 export const PROVIDER_DEFAULT_BASE_URLS = {
-  "openai": "https://api.openai.com/v1",
-  "anthropic": "https://api.anthropic.com/v1",
-  "google": "https://generativelanguage.googleapis.com/v1beta",
-  "deepseek": "https://api.deepseek.com/v1",
-  "xai": "https://api.x.ai/v1",
-  "ollama": "http://localhost:11434/api"
+  openai: 'https://api.openai.com/v1',
+  anthropic: 'https://api.anthropic.com/v1',
+  google: 'https://generativelanguage.googleapis.com/v1beta',
+  deepseek: 'https://api.deepseek.com/v1',
+  xai: 'https://api.x.ai/v1',
+  ollama: 'http://localhost:11434/api'
 };
 
 export const PROVIDER_MODELS = {

--- a/src/components/src/common/data-table/index.tsx
+++ b/src/components/src/common/data-table/index.tsx
@@ -349,7 +349,7 @@ export const TableSection = ({
                 height={headerGridProps.height + browserScrollBarWidth}
                 width={headerGridWidth}
                 scrollLeft={scrollLeft}
-                onScroll={args => onScroll?.({...args, scrollTop:scrollTop ?? 0 })}
+                onScroll={args => onScroll?.({...args, scrollTop: scrollTop ?? 0})}
               />
             </div>
             <div

--- a/src/components/src/common/histogram-plot.tsx
+++ b/src/components/src/common/histogram-plot.tsx
@@ -58,23 +58,11 @@ Bar.displayName = 'Bar';
 
 const isBarInRange = (
   bar: {x0: number; x1: number},
-  index: number,
-  list: any[],
-  filterDomain: any[],
+  _index: number,
+  _list: any[],
+  _filterDomain: any[],
   filterValue: any[]
-) => {
-  // first
-  // if x0 <= domain[0] and current value[0] wasn't changed from the original domain
-  const x0Condition =
-    index === 0 ? bar.x0 <= filterDomain[0] && filterDomain[0] === filterValue[0] : false;
-  // Last
-  // if x1 >= domain[1] and current value[1] wasn't changed from the original domain
-  const x1Condition =
-    index === list.length - 1
-      ? bar.x1 >= filterDomain[1] && filterDomain[1] === filterValue[1]
-      : false;
-  return (x0Condition || bar.x0 >= filterValue[0]) && (x1Condition || bar.x1 <= filterValue[1]);
-};
+) => bar.x1 > filterValue[0] && bar.x0 < filterValue[1];
 
 export type HistogramMaskModeType = {
   NoMask: number;

--- a/src/components/src/common/time-range-slider.tsx
+++ b/src/components/src/common/time-range-slider.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import React, {useMemo} from 'react';
+import React, {useEffect, useMemo} from 'react';
 import throttle from 'lodash/throttle';
 import styled, {IStyledComponent} from 'styled-components';
 
@@ -121,6 +121,8 @@ export default function TimeRangeSliderFactory(
     } = props;
 
     const throttledOnchange = useMemo(() => throttle(onChange, 20), [onChange]);
+    useEffect(() => () => throttledOnchange.cancel(), [throttledOnchange]);
+
     const binsForInterval = useMemo(
       () => getTimeBinsForInterval(timeBins, plotType?.interval),
       [timeBins, plotType?.interval]

--- a/src/components/src/filters/time-widget.tsx
+++ b/src/components/src/filters/time-widget.tsx
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import React, {useCallback, useMemo} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled from 'styled-components';
-import {FILTER_VIEW_TYPES} from '@kepler.gl/constants';
-import {BottomWidgetInner} from '../common/styled-components';
+import {DEFAULT_TIME_FORMAT, FILTER_VIEW_TYPES} from '@kepler.gl/constants';
+import throttle from 'lodash/throttle';
+import {clamp, datetimeFormatter} from '@kepler.gl/utils';
+import {BottomWidgetInner, Button, PanelLabel} from '../common/styled-components';
 import TimeRangeSliderFactory from '../common/time-range-slider';
 import FloatingTimeDisplayFactory from '../common/animation-control/floating-time-display';
 import {timeRangeSliderFieldsSelector} from './time-range-filter';
@@ -14,6 +16,56 @@ import TimeWidgetTopFactory from './time-widget-top';
 const TimeBottomWidgetInner = styled(BottomWidgetInner)`
   padding: 6px 32px 24px 32px;
 `;
+
+const TimelineSection = styled.div`
+  position: relative;
+  margin-top: 22px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+`;
+
+const TimelineContainer = styled.div`
+  touch-action: none;
+`;
+
+const TimelineStatusBar = styled.div`
+  position: absolute;
+  top: -32px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 11px;
+  color: ${props => props.theme.subtextColor};
+`;
+
+const TimelineStatusRange = styled.span`
+  color: ${props => props.theme.textColorHl || props.theme.textColor};
+  font-weight: 500;
+  white-space: nowrap;
+`;
+
+function rangesEqual(a: [number, number] | null, b: [number, number] | null, eps = 1): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return Math.abs(a[0] - b[0]) <= eps && Math.abs(a[1] - b[1]) <= eps;
+}
+
+function clampRange(
+  [start, end]: [number, number],
+  [min, max]: [number, number]
+): [number, number] {
+  const clampedStart = clamp([min, max], start);
+  let clampedEnd = clamp([min, max], end);
+  if (clampedEnd <= clampedStart) {
+    clampedEnd = Math.min(max, clampedStart + 1);
+  }
+  return [clampedStart, clampedEnd];
+}
 
 TimeWidgetFactory.deps = [TimeRangeSliderFactory, FloatingTimeDisplayFactory, TimeWidgetTopFactory];
 
@@ -70,6 +122,315 @@ function TimeWidgetFactory(
       [filter, datasets, layers]
     );
 
+    const fullDomain = Array.isArray(timeRangeSlideProps.domain)
+      ? (timeRangeSlideProps.domain as [number, number])
+      : null;
+
+    const [timelineDomain, setTimelineDomain] = useState<[number, number] | null>(null);
+    const timelineContainerRef = useRef<HTMLDivElement | null>(null);
+
+    useEffect(() => {
+      if (!fullDomain) {
+        if (timelineDomain) {
+          setTimelineDomain(null);
+        }
+        return;
+      }
+      if (timelineDomain) {
+        const clamped = clampRange(timelineDomain, fullDomain);
+        if (!rangesEqual(clamped, timelineDomain)) {
+          setTimelineDomain(clamped);
+        }
+      }
+    }, [fullDomain, timelineDomain]);
+
+    const sliderDomain = timelineDomain ?? fullDomain ?? undefined;
+    const displayedTimelineDomain = sliderDomain ?? null;
+
+    const timelineZoomed = useMemo(() => {
+      if (!timelineDomain || !fullDomain) {
+        return false;
+      }
+      return !rangesEqual(timelineDomain, fullDomain);
+    }, [timelineDomain, fullDomain]);
+
+    const timeFormat =
+      timeRangeSlideProps.timeFormat ||
+      filter.timeFormat ||
+      filter.defaultTimeFormat ||
+      DEFAULT_TIME_FORMAT;
+    const formatTimestamp = useMemo(() => {
+      const formatter = datetimeFormatter(filter.timezone);
+      return (value: number) => formatter(timeFormat)(value);
+    }, [filter.timezone, timeFormat]);
+
+    const timelineRangeLabel = useMemo(() => {
+      if (!displayedTimelineDomain) {
+        return '';
+      }
+      return `${formatTimestamp(displayedTimelineDomain[0])} – ${formatTimestamp(
+        displayedTimelineDomain[1]
+      )}`;
+    }, [displayedTimelineDomain, formatTimestamp]);
+
+    const [filterStart, filterEnd] = filter.value;
+
+    const clampWindowToDomain = useCallback(
+      (windowStart: number, windowEnd: number, domainRange: [number, number]) => {
+        const [domainStart, domainEnd] = domainRange;
+        let nextStart = clamp(domainRange, windowStart);
+        let nextEnd = clamp(domainRange, windowEnd);
+        if (nextEnd <= nextStart) {
+          const width = Math.max(windowEnd - windowStart, 1);
+          const maxStart = Math.max(domainStart, domainEnd - width);
+          nextStart = clamp([domainStart, maxStart], windowStart);
+          nextEnd = nextStart + width;
+          if (nextEnd > domainEnd) {
+            nextEnd = domainEnd;
+            nextStart = Math.max(domainStart, nextEnd - width);
+          }
+        }
+        if (nextEnd <= nextStart) {
+          nextEnd = Math.min(domainEnd, nextStart + 1);
+        }
+        return [nextStart, nextEnd] as [number, number];
+      },
+      []
+    );
+
+    const handleWindowZoom = useCallback(
+      (factor: number, center: number) => {
+        const domainRange = timelineDomain ?? fullDomain;
+        if (!domainRange) {
+          return;
+        }
+        const domainWidth = Math.max(domainRange[1] - domainRange[0], 1);
+        const clampedCenter = clamp(domainRange, center);
+
+        const windowStart = filterStart;
+        const windowEnd = filterEnd;
+        const currentWidth = Math.max(windowEnd - windowStart, 1);
+        const newWidth = clamp([1, domainWidth], currentWidth / factor);
+        const ratio = clamp([0, 1], (clampedCenter - windowStart) / currentWidth);
+
+        const nextStart = clampedCenter - ratio * newWidth;
+        const nextEnd = clampedCenter + (1 - ratio) * newWidth;
+
+        const [clampedStart, clampedEnd] = clampWindowToDomain(nextStart, nextEnd, domainRange);
+        setFilterAnimationTime(index, 'value', [clampedStart, clampedEnd]);
+      },
+      [
+        clampWindowToDomain,
+        filterEnd,
+        filterStart,
+        fullDomain,
+        index,
+        setFilterAnimationTime,
+        timelineDomain
+      ]
+    );
+
+    const handleTimelineZoom = useCallback(
+      (factor: number, center: number) => {
+        if (!fullDomain) {
+          return;
+        }
+        const domainRange: [number, number] = timelineDomain ?? fullDomain;
+        const [domainStart, domainEnd] = fullDomain;
+        const fullWidth = domainEnd - domainStart;
+        if (!(fullWidth > 0)) {
+          return;
+        }
+        const baseWidth = Math.max(domainRange[1] - domainRange[0], 1);
+        const clampedCenter = clamp(domainRange, center);
+        const minWidth = Math.max(fullWidth / 20, 1);
+        const nextWidth = clamp([minWidth, fullWidth], baseWidth / factor);
+        const ratio = clamp(
+          [0, 1],
+          baseWidth > 0 ? (clampedCenter - domainRange[0]) / baseWidth : 0.5
+        );
+
+        let nextStart = clampedCenter - ratio * nextWidth;
+        let nextEnd = nextStart + nextWidth;
+
+        if (nextStart < domainStart) {
+          const shift = domainStart - nextStart;
+          nextStart = domainStart;
+          nextEnd += shift;
+        }
+        if (nextEnd > domainEnd) {
+          const shift = nextEnd - domainEnd;
+          nextEnd = domainEnd;
+          nextStart -= shift;
+        }
+        const nextRange: [number, number] = clampRange([nextStart, nextEnd], fullDomain);
+        setTimelineDomain(prev => (rangesEqual(prev, nextRange) ? prev : nextRange));
+
+        let windowStart = filterStart;
+        let windowEnd = filterEnd;
+        const rangeWidth = nextRange[1] - nextRange[0];
+        if (rangeWidth < windowEnd - windowStart) {
+          const windowWidth = Math.max(windowEnd - windowStart, 1);
+          const windowRatio = clamp([0, 1], (clampedCenter - windowStart) / windowWidth);
+          const adjustedStart = clampedCenter - windowRatio * rangeWidth;
+          const adjustedEnd = clampedCenter + (1 - windowRatio) * rangeWidth;
+          [windowStart, windowEnd] = clampWindowToDomain(adjustedStart, adjustedEnd, nextRange);
+        } else {
+          [windowStart, windowEnd] = clampWindowToDomain(windowStart, windowEnd, nextRange);
+        }
+        if (windowStart !== filterStart || windowEnd !== filterEnd) {
+          setFilterAnimationTime(index, 'value', [windowStart, windowEnd]);
+        }
+      },
+      [
+        clampWindowToDomain,
+        filterEnd,
+        filterStart,
+        fullDomain,
+        index,
+        setFilterAnimationTime,
+        timelineDomain
+      ]
+    );
+
+    const throttledWindowZoom = useMemo(
+      () => throttle(handleWindowZoom, 40, {leading: true, trailing: false}),
+      [handleWindowZoom]
+    );
+
+    const throttledTimelineZoom = useMemo(
+      () => throttle(handleTimelineZoom, 40, {leading: true, trailing: false}),
+      [handleTimelineZoom]
+    );
+
+    useEffect(() => () => throttledWindowZoom.cancel(), [throttledWindowZoom]);
+    useEffect(() => () => throttledTimelineZoom.cancel(), [throttledTimelineZoom]);
+
+    const handleWheel = useCallback(
+      (event: React.WheelEvent<HTMLDivElement>) => {
+        if (isMinified || !sliderDomain) {
+          return;
+        }
+        const nativeEvent = event.nativeEvent as WheelEvent;
+        const isPinch =
+          event.ctrlKey ||
+          nativeEvent.ctrlKey ||
+          nativeEvent.metaKey ||
+          Math.abs(nativeEvent.deltaZ || 0) > 0;
+        const zoomFn = isPinch ? throttledTimelineZoom : throttledWindowZoom;
+        if (!zoomFn) {
+          return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        if (event.deltaY === 0) {
+          return;
+        }
+
+        const baseStep = isPinch ? 0.02 : 0.08;
+        const factor = event.deltaY < 0 ? 1 + baseStep : 1 / (1 + baseStep);
+        const container = timelineContainerRef.current;
+        if (!container) {
+          return;
+        }
+        const sliderTrack = container.querySelector(
+          '.kg-range-slider__slider'
+        ) as HTMLElement | null;
+        const rect = sliderTrack?.getBoundingClientRect() ?? container.getBoundingClientRect();
+        if (!rect || rect.width === 0) {
+          return;
+        }
+        const ratio = clamp([0, 1], (event.clientX - rect.left) / rect.width);
+        const center = sliderDomain[0] + ratio * (sliderDomain[1] - sliderDomain[0]);
+        zoomFn(factor, center);
+      },
+      [isMinified, sliderDomain, throttledTimelineZoom, throttledWindowZoom]
+    );
+
+    useEffect(() => {
+      const node = timelineContainerRef.current;
+      if (!node) {
+        return undefined;
+      }
+      const preventBrowserZoom = (event: WheelEvent) => {
+        const isPinch = event.ctrlKey || event.metaKey || Math.abs(event.deltaZ || 0) > 0;
+        if (isPinch) {
+          event.preventDefault();
+        }
+      };
+      node.addEventListener('wheel', preventBrowserZoom, {passive: false});
+      return () => node.removeEventListener('wheel', preventBrowserZoom);
+    }, [timelineContainerRef]);
+
+    const panTimelineBy = useCallback(
+      (delta: number) => {
+        if (!fullDomain) {
+          return;
+        }
+        const [domainStart, domainEnd] = fullDomain;
+        const currentRange: [number, number] = timelineDomain ?? fullDomain;
+        let nextStart = currentRange[0] + delta;
+        let nextEnd = currentRange[1] + delta;
+        if (nextStart < domainStart) {
+          nextEnd += domainStart - nextStart;
+          nextStart = domainStart;
+        }
+        if (nextEnd > domainEnd) {
+          nextStart -= nextEnd - domainEnd;
+          nextEnd = domainEnd;
+        }
+        const nextRange: [number, number] = clampRange([nextStart, nextEnd], fullDomain);
+        setTimelineDomain(prev => (rangesEqual(prev, nextRange) ? prev : nextRange));
+
+        let windowStart = filterStart + delta;
+        let windowEnd = filterEnd + delta;
+        [windowStart, windowEnd] = clampWindowToDomain(windowStart, windowEnd, fullDomain);
+        if (windowStart !== filterStart || windowEnd !== filterEnd) {
+          setFilterAnimationTime(index, 'value', [windowStart, windowEnd]);
+        }
+      },
+      [
+        clampWindowToDomain,
+        filterEnd,
+        filterStart,
+        fullDomain,
+        index,
+        setFilterAnimationTime,
+        timelineDomain
+      ]
+    );
+
+    useEffect(() => {
+      const handler = (event: KeyboardEvent) => {
+        if (!(event.ctrlKey || event.metaKey)) {
+          return;
+        }
+        if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+          return;
+        }
+        const domainRange = timelineDomain ?? fullDomain;
+        if (!domainRange) {
+          return;
+        }
+        const span = domainRange[1] - domainRange[0];
+        if (!(span > 0)) {
+          return;
+        }
+        event.preventDefault();
+        const step = span * (event.shiftKey ? 0.2 : 0.1);
+        const delta = event.key === 'ArrowLeft' ? -step : step;
+        panTimelineBy(delta);
+      };
+      window.addEventListener('keydown', handler);
+      return () => window.removeEventListener('keydown', handler);
+    }, [fullDomain, panTimelineBy, timelineDomain]);
+
+    const handleResetTimeline = useCallback(() => {
+      setTimelineDomain(null);
+    }, []);
+
     return (
       <TimeBottomWidgetInner className="bottom-widget--inner">
         <TimeWidgetTop
@@ -82,22 +443,40 @@ function TimeWidgetFactory(
           onToggleMinify={onToggleMinify}
           isMinified={isMinified}
         />
-        {/* Once AnimationControl is able to display large timeline*/}
-        {/* we can replace TimeRangeSlider with AnimationControl*/}
-        <TimeRangeSlider
-          {...timeRangeSlideProps}
-          onChange={timeSliderOnChange}
-          toggleAnimation={_toggleAnimation}
-          updateAnimationSpeed={_updateAnimationSpeed}
-          setFilterAnimationWindow={_setFilterAnimationWindow}
-          hideTimeTitle={showTimeDisplay}
-          resetAnimation={resetAnimation}
-          isAnimatable={isAnimatable}
-          setFilterPlot={_setFilterPlot}
-          animationConfig={animationConfig}
-          isMinified={isMinified}
-          timeline={timeline}
-        />
+        <TimelineSection>
+          {timelineZoomed && timelineRangeLabel ? (
+            <TimelineStatusBar>
+              <PanelLabel>Showing</PanelLabel>
+              <TimelineStatusRange>{timelineRangeLabel}</TimelineStatusRange>
+              <Button
+                small
+                type="button"
+                onClick={handleResetTimeline}
+                aria-label="Reset timeline selection"
+                data-testid="time-widget-timeline-reset"
+              >
+                Reset
+              </Button>
+            </TimelineStatusBar>
+          ) : null}
+          <TimelineContainer ref={timelineContainerRef} onWheel={handleWheel}>
+            <TimeRangeSlider
+              {...timeRangeSlideProps}
+              domain={sliderDomain}
+              onChange={timeSliderOnChange}
+              toggleAnimation={_toggleAnimation}
+              updateAnimationSpeed={_updateAnimationSpeed}
+              setFilterAnimationWindow={_setFilterAnimationWindow}
+              hideTimeTitle={showTimeDisplay}
+              resetAnimation={resetAnimation}
+              isAnimatable={isAnimatable}
+              setFilterPlot={_setFilterPlot}
+              animationConfig={animationConfig}
+              isMinified={isMinified}
+              timeline={timeline}
+            />
+          </TimelineContainer>
+        </TimelineSection>
         {showTimeDisplay ? (
           <FloatingTimeDisplay
             currentTime={filter.value}


### PR DESCRIPTION
### Summary
This PR adds **cursor-centric zoom** and **precise navigation** to the enlarged time filter (bottom timeline):

- **Wheel** → zoom active window around cursor.  
- **Pinch** / hold <kbd>Ctrl</kbd> (<kbd>⌘</kbd> on Mac) + **wheel** → zoom entire timeline domain (shows a “**Showing … Reset**” banner with one-click reset).  
- **Keyboard pan** → <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>←</kbd>/<kbd>→</kbd> (hold <kbd>Shift</kbd> for larger steps).  
- Window and animation stay **clamped** to the full data domain; updates are **throttled** to minimize Redux churn.

---

### Related issues
Addresses timeline precision and usability gaps reported in  
**#743**, **#788**, **#1101**, **#2541**, and **#2991**.  
Closes **#743**, **#788**, #3231 .

---

### Why
Selecting **narrow time intervals** in the timeline has been difficult with only range handles.  
This feature improves precision and usability when exploring datasets with second-level or sub-minute events.

---

### User-facing changes
- New zoom/pan interactions in the **enlarged time filter** only (no change to the compact side-panel slider).  
- A small **“Showing … Reset”** banner appears whenever the visible domain is narrowed.

---

### Implementation notes
- **`time-widget.tsx`**  
  - Centralizes cursor-driven interactions.  
  - Adds local `timelineDomain` state separate from the main filter range.  
  - Implements wheel & pinch zoom, keyboard panning, domain/window clamping, and throttled updates (40 ms).  
  - Adds “Showing … Reset” status bar with reset button.
- **`time-range-slider.tsx`**  
  - Cancels throttled `onChange` on unmount to prevent lingering timers.
- **`histogram-plot.tsx`**  
  - Simplifies `isBarInRange`: bar is in range if it overlaps the active window (`bar.x1 > start && bar.x0 < end`), ensuring consistent highlights for zoomed domains.
- **Docs (`docs/user-guides/h-playback.md`)**  
  - Adds a new “Zoom & precision controls” section describing wheel/pinch zoom, reset banner, and keyboard panning.

---

### Performance & accessibility
- Wheel/pinch events are throttled and use `passive: false` only where necessary to prevent browser zoom.  
- Keyboard navigation (<kbd>Ctrl</kbd>/<kbd>⌘</kbd> + arrow keys, <kbd>Shift</kbd> for larger steps) improves accessibility.  
- All logic is isolated to the enlarged widget; no impact on saved configs or GPU filtering.

---

### Backwards compatibility
- No schema or API changes.  
- `timelineDomain` is purely UI state.  
- Saved maps load without modification.

---

### How to test
1. `yarn install && yarn bootstrap` (root), then `yarn start` or `yarn start:local` in `examples/demo-app`.  
2. Load a dataset with a timestamp column (e.g., second-level events).  
3. Add a **Time filter**, click **Enlarge** (bottom timeline).  
4. Try:
   - 🖱️ Wheel to zoom the **window**.  
   - 🤏 Pinch or hold <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + wheel to zoom the **timeline domain**.  
   - ⌨️ <kbd>Ctrl</kbd>/<kbd>⌘</kbd> + <kbd>←</kbd>/<kbd>→</kbd> to pan (hold <kbd>Shift</kbd> for larger steps).  
   - Click **Reset** to restore the full domain.
5. Verify histogram highlights and playback behavior remain consistent.

---

### Checklist
- [x] DCO sign-off on all commits (`git commit -s …`)  
- [x] Lint & tests pass (`yarn lint && yarn test`)  
- [x] Docs updated (`docs/user-guides/h-playback.md`)  
- [x] Manual QA with dense, second-level datasets  
- [x] No breaking changes


---

### Screenshots / GIFs

#### 1️⃣ Wheel zoom on active window  
Show how scrolling directly over the timeline zooms in/out on the visible playback window around the cursor position.
![kepler-scroll-gif](https://github.com/user-attachments/assets/b1308d64-bfa6-477c-b7b6-294977546a03)

#### 2️⃣ Pinch or Ctrl(⌘)+wheel zoom of full timeline  + Reset banner
Demonstrate pinch zoom or Ctrl(⌘)+scroll zooming the **entire domain**, and how the **“Showing … Reset”** banner appears.
Show the banner’s visibility state and how clicking **Reset** restores the full timeline domain.
![kepler-gif-zoom](https://github.com/user-attachments/assets/6c86e479-43a2-49b3-ae9c-cfac4da6975c)

#### 3️⃣ Keyboard panning  
Demonstrate holding **Ctrl(⌘)** and pressing **← / →** to pan, and adding **Shift** for larger steps.
![kepler-gif-arrow-panning](https://github.com/user-attachments/assets/f9dbeeba-d58f-40aa-8965-9665d109a8cc)

---

### Notes for reviewers
All changes are isolated to UI components and documentation.  
No schema or public API modifications.  
Focus review on timeline interaction behavior, clamping logic, and throttling performance.
