### PR TITLE
fix: copy geometry when geometry is of binary format

### DIFF
--- a/src/layers/src/geojson-layer/geojson-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.ts
@@ -69,7 +69,7 @@ export function parseGeoJsonRawFeature(rawFeature: unknown): Feature | null {
       // @ts-expect-error loaders.gl binary type to GeoJSON geometry
       const parsedGeo = binaryToGeometry(binaryGeo);
       const normalized = normalize(parsedGeo);
-      if (!normalized || !Array.isArray(normalized.features)) {
+      if (!normalized || !Array.isArray(normalized.features) || !normalized.features.length) {
         return null;
       }
       return {properties, ...normalized.features[0]};


### PR DESCRIPTION
- Implement missing part of Copy Geometry: get feature from a binary geojson

<img width="1128" height="638" alt="Screenshot 2025-11-04 at 2 59 35 AM" src="https://github.com/user-attachments/assets/c646e3fb-7d31-4583-9047-c1a653b68c37" />

<img width="1237" height="971" alt="Screenshot 2025-11-04 at 2 59 42 AM" src="https://github.com/user-attachments/assets/8eb74e9d-a5de-49d3-8cd5-9f9b738e5a06" />
