### PR TITLE
fix: Yarn start fails

### DIFF
--- a/examples/demo-app/esbuild.config.mjs
+++ b/examples/demo-app/esbuild.config.mjs
@@ -94,7 +94,17 @@ const config = {
   outfile: 'dist/bundle.js',
   bundle: true,
   define: {
-    NODE_ENV
+    NODE_ENV,
+    // Define process.env variables for browser environment
+    'process.env.MapboxAccessToken': JSON.stringify(process.env.MapboxAccessToken || ''),
+    'process.env.DropboxClientId': JSON.stringify(process.env.DropboxClientId || ''),
+    'process.env.MapboxExportToken': JSON.stringify(process.env.MapboxExportToken || ''),
+    'process.env.CartoClientId': JSON.stringify(process.env.CartoClientId || ''),
+    'process.env.FoursquareClientId': JSON.stringify(process.env.FoursquareClientId || ''),
+    'process.env.FoursquareDomain': JSON.stringify(process.env.FoursquareDomain || ''),
+    'process.env.FoursquareAPIURL': JSON.stringify(process.env.FoursquareAPIURL || ''),
+    'process.env.FoursquareUserMapsURL': JSON.stringify(process.env.FoursquareUserMapsURL || ''),
+    'process.env.NODE_ENV': NODE_ENV
   },
   plugins: [
     dotenvRun({

--- a/src/components/package.json
+++ b/src/components/package.json
@@ -109,7 +109,7 @@
     "react-sortable-hoc": "^1.8.3",
     "react-time-picker": "^6.2.0",
     "react-tooltip": "^4.2.17",
-    "react-virtualized": "^9.22.5",
+    "react-virtualized": "9.22.6",
     "react-vis": "1.11.7",
     "redux": "^4.2.1",
     "reselect": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4993,7 +4993,7 @@ __metadata:
     react-sortable-hoc: "npm:^1.8.3"
     react-time-picker: "npm:^6.2.0"
     react-tooltip: "npm:^4.2.17"
-    react-virtualized: "npm:^9.22.5"
+    react-virtualized: "npm:9.22.6"
     react-vis: "npm:1.11.7"
     redux: "npm:^4.2.1"
     reselect: "npm:^4.1.0"
@@ -26418,9 +26418,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-virtualized@npm:^9.22.5":
-  version: 9.22.5
-  resolution: "react-virtualized@npm:9.22.5"
+"react-virtualized@npm:9.22.6":
+  version: 9.22.6
+  resolution: "react-virtualized@npm:9.22.6"
   dependencies:
     "@babel/runtime": "npm:^7.7.2"
     clsx: "npm:^1.0.4"
@@ -26429,9 +26429,9 @@ __metadata:
     prop-types: "npm:^15.7.2"
     react-lifecycles-compat: "npm:^3.0.4"
   peerDependencies:
-    react: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
-    react-dom: ^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0
-  checksum: 10c0/b0444b472f317dce61119c07426c5e9ebfe5125d049996678da922717715a1aa83df755aa36877f4b1718aa2e181d22f15ebb807ee356418c56f922f865628c1
+    react: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.3.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/0c4fbe86e0c121adcdb7a3f322601eee4661afe65e31ef767c6d876016b1e7043fdad7998b4fa0252eaf73ffb6c14effcf0f729d154cd15304a8b15ad42b7b06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes this error when trying to run the demo app in dev mode with `yarn start`:
```
✘ [ERROR] No matching export in "../../node_modules/react-virtualized/dist/es/WindowScroller/WindowScroller.js" for import "bpfrpt_proptype_WindowScroller"

    ../../node_modules/react-virtualized/dist/es/WindowScroller/utils/onScroll.js:74:9:
      74 │ import { bpfrpt_proptype_WindowScroller } from "../WindowScroller....
         ╵          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
and this:
```
default-settings.js:47 Uncaught ReferenceError: process is not defined
    at default-settings.js:47:17
    at main.js:30:21
(anonymous)	@	default-settings.js:47
(anonymous)	@	main.js:30
```