### PR TITLE
fix(jupyter): Fix initial viewport sizing and React 18 migration

### DIFF
--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import React, {useEffect, useState, useRef} from 'react';
+import {useEffect, useState, useRef} from 'react';
 import styled from 'styled-components';
 const ReactHelmet = require('react-helmet');
 const Helmet = ReactHelmet ? ReactHelmet.Helmet : null;
@@ -58,15 +58,12 @@ function App() {
 
     const width = rootElm.current.offsetWidth;
     const height = rootElm.current.offsetHeight;
-    const dimensionToSet = {
-      ...(width && width !== windowDimension.width ? {width} : {}),
-      ...(height && height !== windowDimension.height ? {height} : {})
-    };
-
-    setDimension(dimensionToSet);
+    if (width && height) {
+      setDimension({width, height});
+    }
   };
 
-  // in Jupyter Lab,  parent component has transition when window resize.
+  // in Jupyter Lab, parent component has transition when window resize.
   // need to delay call to get the final parent width,
   const resizeDelay = () => window.setTimeout(handleResize, 500);
 

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
@@ -71,6 +71,8 @@ function App() {
   const resizeDelay = () => window.setTimeout(handleResize, 500);
 
   useEffect(() => {
+    // Call handleResize on mount to set initial dimensions
+    handleResize();
     window.addEventListener('resize', resizeDelay);
     return () => window.removeEventListener('resize', resizeDelay);
   }, []);

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/root.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/root.js
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import React, {useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Provider} from 'react-redux';
 import App from './app';
 import Window from 'global/window';
 import {addDataConfigToKeplerGl} from '../kepler.gl';
+
+// Store root instances to avoid creating multiple roots for the same element
+const rootInstances = new WeakMap();
 
 // Separate component to handle data loading after mount
 function DataLoader({store, onRenderComplete}) {
@@ -30,8 +33,13 @@ function DataLoader({store, onRenderComplete}) {
 }
 
 function renderRoot({id, store, ele, onRenderComplete}) {
-  // Use React 18 createRoot API
-  const root = createRoot(ele);
+  // Use React 18 createRoot API - reuse existing root if available
+  let root = rootInstances.get(ele);
+  if (!root) {
+    root = createRoot(ele);
+    rootInstances.set(ele, root);
+  }
+
   root.render(
     <Provider store={store}>
       <DataLoader store={store} onRenderComplete={onRenderComplete} />

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/root.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/root.js
@@ -2,7 +2,7 @@
 // Copyright contributors to the kepler.gl project
 
 import React from 'react';
-import ReactDOM from 'react-dom';
+import {createRoot} from 'react-dom/client';
 import {Provider} from 'react-redux';
 import App from './app';
 
@@ -13,7 +13,9 @@ function renderRoot({id, store, ele}) {
     </Provider>
   );
 
-  ReactDOM.render(<Root />, ele);
+  // Use React 18 createRoot API
+  const root = createRoot(ele);
+  root.render(<Root />);
 }
 
 export default renderRoot;

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/root.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/root.js
@@ -1,21 +1,43 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {createRoot} from 'react-dom/client';
 import {Provider} from 'react-redux';
 import App from './app';
+import Window from 'global/window';
+import {addDataConfigToKeplerGl} from '../kepler.gl';
 
-function renderRoot({id, store, ele}) {
-  const Root = () => (
+// Separate component to handle data loading after mount
+function DataLoader({store, onRenderComplete}) {
+  const hasLoadedData = useRef(false);
+
+  useEffect(() => {
+    // This runs AFTER component tree is mounted and Provider is fully subscribed
+    // Load data from Window.__keplerglDataConfig (HTML export mode)
+    if (!hasLoadedData.current && Window.__keplerglDataConfig) {
+      hasLoadedData.current = true;
+      const {data, config, options} = Window.__keplerglDataConfig;
+      addDataConfigToKeplerGl({data, config, options, store});
+    }
+    // Signal render complete for callback-based loading (Jupyter widget mode)
+    if (onRenderComplete) {
+      onRenderComplete();
+    }
+  }, [store, onRenderComplete]);
+
+  return null;
+}
+
+function renderRoot({id, store, ele, onRenderComplete}) {
+  // Use React 18 createRoot API
+  const root = createRoot(ele);
+  root.render(
     <Provider store={store}>
+      <DataLoader store={store} onRenderComplete={onRenderComplete} />
       <App />
     </Provider>
   );
-
-  // Use React 18 createRoot API
-  const root = createRoot(ele);
-  root.render(<Root />);
 }
 
 export default renderRoot;

--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/main.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/main.js
@@ -5,8 +5,6 @@
 import createAppStore from './store';
 import renderRoot from './components/root';
 import document from 'global/document';
-import Window from 'global/window';
-import {addDataConfigToKeplerGl} from './kepler.gl';
 
 const map = (function initKeplerGl() {
   const id = 'keplergl-0';
@@ -18,6 +16,8 @@ const map = (function initKeplerGl() {
 
   return {
     render: () => {
+      // Data loading is now handled inside renderRoot via useEffect
+      // This ensures Redux Provider subscriptions are active before dispatching
       renderRoot({id, store, ele: divElmt});
     },
     store
@@ -25,8 +25,3 @@ const map = (function initKeplerGl() {
 })();
 
 map.render();
-
-(function loadDataConfig(keplerGlMap) {
-  const {data, config, options} = Window.__keplerglDataConfig || {};
-  addDataConfigToKeplerGl({data, config, options, store: keplerGlMap.store});
-})(map);


### PR DESCRIPTION
## Summary

This PR fixes two related issues in the kepler.gl-jupyter HTML export:

1. **Initial viewport sizing** - Map doesn't fill the viewport on initial page load, requiring a browser resize to trigger correct sizing
2. **React 18 compatibility** - Migrates from deprecated `ReactDOM.render` to the modern `createRoot` API

### Changes

**app.js:**
- Call `handleResize()` on component mount in the `useEffect` hook to set correct initial dimensions

**root.js:**
- Migrate from `ReactDOM.render` to React 18's `createRoot` API
- Add `DataLoader` component to handle data loading after Redux Provider mounts
- This ensures Provider subscriptions are active before dispatching `addDataToMap` actions

**main.js:**
- Remove data loading logic (now handled by DataLoader component in React lifecycle)
- Simplify to only handle DOM setup and trigger render

### Root Cause

The original code had two issues:

1. `handleResize()` was only called on the resize event, never on initial mount, so the map container started with 0x0 dimensions until a resize occurred

2. React 18's `createRoot().render()` is asynchronous, unlike the synchronous `ReactDOM.render()`. This caused a race condition where data was dispatched to Redux before the Provider's subscriptions were active, resulting in no layers being displayed

### Testing

- Tested locally with HTML export - map now fills viewport immediately on load
- Data/config loads correctly with layers displayed
- No console errors

Fixes #3252