### PR TITLE
fix(ai-assistant): clear LLM history on restart chat

### DIFF
--- a/src/ai-assistant/src/components/ai-assistant-component.tsx
+++ b/src/ai-assistant/src/components/ai-assistant-component.tsx
@@ -75,9 +75,7 @@ export function AiAssistantComponent() {
   const {temporaryPrompt, restartChat: libraryRestartChat} = useAssistant({...assistantProps, instructions});
   
   const restartChatRef = useRef(libraryRestartChat);
-  useEffect(() => {
-    restartChatRef.current = libraryRestartChat;
-  }, [libraryRestartChat]);
+  restartChatRef.current = libraryRestartChat;
 
   const generateIdeas = async () => {
     try {


### PR DESCRIPTION
```markdown
## Description
Fixes the restart chat functionality to properly clear LLM message history by calling the library's built-in `restartChat` function and forcing component remount.

## Problem
When "Restart Chat" is clicked, the UI resets but LLM providers still receive old messages, wasting tokens and increasing costs.

## Solution
- Call `restartChat()` from `@openassistant/core` to clear library state
- Force `AiAssistant` component remount using React key prop
- Ensures both library and component state are reset

## Changes
- Added `restartChat` from useAssistant hook
- Store in ref to access latest version
- Call `restartChat()` in onRestartAssistant handler
- Added `restartKey` state to force component remount
- Applied `key={restartKey}` to AiAssistant component

## Testing
- [x] Tested locally
- [x] Verified network logs show no old messages after restart
- [x] Works with all LLM providers (OpenAI, Google Gemini)
- [x] No breaking changes

Fixes #3261

## Checklist
- [x] Code follows project style guidelines
- [x] Comments explain the fix
- [x] Commit includes DCO sign-off
- [x] No breaking changes
```