### PR TITLE
fix: hide Kepler editor tooltip “top-left jump” on invalid hover coords

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -858,19 +858,19 @@ export default function MapContainerFactory(
         getCursor?: ({isDragging}: {isDragging: boolean}) => string;
       } = {};
       if (primaryMap) {
-          // Omit hover updates when the pointer position is invalid, ie. over UI overlays or
-          // outside the map container. In those cases x/y may be < 0
-          extraDeckParams.getTooltip = info => {
-            const x = Number(info?.x);
-            const y = Number(info?.y);
-            if (Number.isNaN(x) || Number.isNaN(y) || x < 0 || y < 0) return null;
+        // Omit hover updates when the pointer position is invalid, ie. over UI overlays or
+        // outside the map container. In those cases x/y may be < 0
+        extraDeckParams.getTooltip = info => {
+          const x = Number(info?.x);
+          const y = Number(info?.y);
+          if (Number.isNaN(x) || Number.isNaN(y) || x < 0 || y < 0) return null;
 
-            return EditorLayerUtils.getTooltip(info, {
-              editorMenuActive,
-              editor,
-              theme
-            });
-          };
+          return EditorLayerUtils.getTooltip(info, {
+            editorMenuActive,
+            editor,
+            theme
+          });
+        };
 
         extraDeckParams.getCursor = ({isDragging}: {isDragging: boolean}) => {
           const editorCursor = EditorLayerUtils.getCursor({

--- a/test/browser-headless/component/map-container-test.js
+++ b/test/browser-headless/component/map-container-test.js
@@ -116,6 +116,13 @@ test('MapContainerFactory - _renderDeckOverlay', t => {
   const divWrapper = instance._renderDeckOverlay(...args);
   const DeckGl = divWrapper.props.children;
 
+  t.ok(typeof DeckGl.props.getTooltip === 'function', 'DeckGl should receive getTooltip prop');
+  t.equal(
+    DeckGl.props.getTooltip({x: -1, y: -1, pixel: [-1, -1]}),
+    null,
+    'getTooltip should return null for invalid hover coordinates'
+  );
+
   const clickEvents = [];
   const hoverEvents = [];
 


### PR DESCRIPTION
## Summary
Prevents the Kepler/Deck editor tooltip from snapping to the top-left corner when DeckGL reports invalid hover coordinates (e.g. -1/-1).

## What changed
Adds a small guard in packages/kepler.gl/src/components/src/map-container.tsx inside the DeckGL getTooltip callback to return null when info.x/info.y are clearly invalid.

## Tooltip issue example
This is most noticeable when the pointer moves over custom UI elements layered above the map (e.g. toolbars/controls/overlays) or when the cursor is effectively outside the map canvas/container. Deck can still emit hover updates, but the reported coordinates are invalid for map positioning.

![tool tip issue](https://github.com/user-attachments/assets/547e77d9-4141-45f0-a0fc-03add67eae21)

## Tooltip logs when hovering over a non-kepler component
![logs-resized](https://github.com/user-attachments/assets/fd0ed15d-77a5-4401-a75c-c8de127a3b64)
