### PR TITLE
fix: name new point layer using label if provided

### DIFF
--- a/src/layers/src/point-layer/point-layer.ts
+++ b/src/layers/src/point-layer/point-layer.ts
@@ -328,7 +328,7 @@ export default class PointLayer extends Layer {
   }
 
   static findDefaultLayerProps(dataset: KeplerTable) {
-    const {fieldPairs = [], type} = dataset;
+    const {fieldPairs = [], type, label} = dataset;
 
     const props: FindDefaultLayerProps[] = [];
 
@@ -346,7 +346,10 @@ export default class PointLayer extends Layer {
         isVisible?: boolean;
         columns?: PointLayerColumnsConfig;
       } = {
-        label: pair.defaultName || 'Point'
+        label:
+          pair.defaultName ||
+          (typeof label === 'string' && label.replace(/\.[^/.]+$/, '')) ||
+          'Point'
       };
 
       // default layer color for begintrip and dropoff point


### PR DESCRIPTION
When creating a new point layer from a pair of {lat, lng} columns, the defaultName will be empty because of regex 
```js
const re = new RegExp(`(^|${specialCharacterSet})${suffixPair[0]}(${specialCharacterSet}|$)`);
```
and then falls back to name 'point':

<img width="376" height="154" alt="Screenshot 2026-02-03 at 10 46 28 AM" src="https://github.com/user-attachments/assets/9d833fce-a93b-48fa-a133-20ed129c7174" />

This leads to many point layers with same label 'point', which are difficult to distinguish.

This PR tries to use the `label` value (if provided) first in this case.