### PR TITLE
Implement WKT validation in data-type.ts

### DIFF
--- a/src/common-utils/src/data-type.ts
+++ b/src/common-utils/src/data-type.ts
@@ -15,7 +15,7 @@ const H3_ANALYZER_TYPE = 'H3';
 const WKT_PREFIX_RE =
   /^(?:SRID=\d+\s*;\s*)?(?:POINT|LINESTRING|POLYGON|MULTIPOINT|MULTILINESTRING|MULTIPOLYGON|GEOMETRYCOLLECTION)(?:\s+(?:Z|M|ZM))?\s*\(/i;
 
-function isWkt(value: unknown): boolean {
+export function isWkt(value: unknown): boolean {
   if (typeof value !== 'string') {
     return false;
   }


### PR DESCRIPTION
Add WKT validation function and regex for geometry types.

Issue:
When geometry is loaded as csv, Kepler map tooltip would show entire value. This PR add a heuristic check to determine if the value is a wkt geometry value

<img width="1248" height="1428" alt="image" src="https://github.com/user-attachments/assets/7364aa0d-3807-49b7-a57b-c78e74ba039c" />
