### PR TITLE
Fix PointLayer polygon filtering for GeoJSON column mode

### DIFF
--- a/src/layers/src/geojson-layer/geojson-position-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-position-utils.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {parseGeoJsonRawFeature} from './geojson-utils';
+
+/**
+ * Parse a raw geo field into Point/MultiPoint coordinates.
+ * Supports GeoJSON objects, WKT strings (via loaders.gl), and binary geometries.
+ */
+export function getGeojsonPointPositionFromRaw(
+  raw: unknown
+): number[] | number[][] | null {
+  const feature = parseGeoJsonRawFeature(raw);
+  const geometry = feature?.geometry as any;
+  if (!geometry) {
+    return null;
+  }
+
+  if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {
+    return geometry.coordinates;
+  }
+
+  if (geometry.type === 'GeometryCollection') {
+    const geometries = geometry.geometries || [];
+    const coords = geometries.reduce((accu, g) => {
+      if (g?.type === 'Point') {
+        accu.push(g.coordinates);
+      } else if (g?.type === 'MultiPoint') {
+        accu.push(...g.coordinates);
+      }
+      return accu;
+    }, []);
+
+    return coords.length ? coords : null;
+  }
+
+  return null;
+}

--- a/src/utils/src/filter-utils.spec.ts
+++ b/src/utils/src/filter-utils.spec.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+/** @jest-environment node */
+
+// loaders.gl expects fetch globals (Response, etc). Node < 18 / Jest may not provide them.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const nodeFetch = require('node-fetch');
+(global as any).fetch = (global as any).fetch || nodeFetch;
+(global as any).Response = (global as any).Response || nodeFetch.Response;
+(global as any).Headers = (global as any).Headers || nodeFetch.Headers;
+(global as any).Request = (global as any).Request || nodeFetch.Request;
+
+import {getPolygonFilterFunctor} from './filter-utils';
+import {getGeojsonPointPositionFromRaw} from '../../layers/src/geojson-layer/geojson-position-utils';
+
+describe('filterUtils - polygon filter', () => {
+  const squarePolygon = {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-1, -1],
+          [1, -1],
+          [1, 1],
+          [-1, 1],
+          [-1, -1]
+        ]
+      ]
+    }
+  };
+
+  test('WKT POINT string can be used for polygon filter', () => {
+    const layer = {
+      type: 'point',
+      getPositionAccessor: () => (d: {raw: unknown}) => getGeojsonPointPositionFromRaw(d.raw)
+    };
+
+    const filter = {value: squarePolygon};
+    const fn = getPolygonFilterFunctor(layer, filter, null);
+
+    expect(getGeojsonPointPositionFromRaw('POINT (0.5 0.5)')).toEqual([0.5, 0.5]);
+
+    expect(fn({raw: 'POINT (0.5 0.5)'})).toBe(true);
+    expect(fn({raw: 'POINT (10 10)'})).toBe(false);
+  });
+
+  test('MultiPoint keeps row if any point is inside polygon', () => {
+    const layer = {
+      type: 'point',
+      getPositionAccessor: () => (d: {pos: any}) => d.pos
+    };
+
+    const filter = {value: squarePolygon};
+    const fn = getPolygonFilterFunctor(layer, filter, null);
+
+    expect(
+      fn({
+        pos: [
+          [10, 10],
+          [0.2, 0.2]
+        ]
+      })
+    ).toBe(true);
+
+    expect(
+      fn({
+        pos: [
+          [10, 10],
+          [20, 20]
+        ]
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/src/filter-utils.ts
+++ b/src/utils/src/filter-utils.ts
@@ -384,7 +384,20 @@ export const getPolygonFilterFunctor = (layer, filter, dataContainer) => {
     case LAYER_TYPES.icon:
       return data => {
         const pos = getPosition(data);
-        return pos.every(Number.isFinite) && isInPolygon(pos, filter.value);
+
+        // PointLayer in geojson column mode can yield MultiPoint coordinates (number[][]).
+        if (!Array.isArray(pos)) {
+          return false;
+        }
+
+        const positions = Array.isArray(pos[0]) ? pos : [pos];
+        return positions.some(
+          p =>
+            Array.isArray(p) &&
+            p.length >= 2 &&
+            p.every(Number.isFinite) &&
+            isInPolygon(p, filter.value)
+        );
       };
     case LAYER_TYPES.arc:
     case LAYER_TYPES.line:


### PR DESCRIPTION
Problem: Polygon/rectangle filtering failed because getPositionAccessor returned raw WKT/GeoJSON values instead of numeric coordinates.
Fix: Accessor now returns parsed coordinates (or null), caches parsed results, and polygon filtering supports MultiPoint.