### PR TITLE
fix: replace broken vis.academy tutorial link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 
 [Kepler.gl][web] is a data-agnostic, high-performance web-based application for visual exploration of large-scale geolocation data sets. Built on top of [MapLibre GL](https://maplibre.org/) and [deck.gl](https://deck.gl/), kepler.gl can render millions of points representing thousands of trips and perform spatial aggregations on the fly.
 
-Kepler.gl is also a React component that uses [Redux](https://redux.js.org/) to manage its state and data flow. It can be embedded into other React-Redux applications and is highly customizable. For information on how to embed kepler.gl in your app take a look at this step-by-step [tutorial](https://github.com/uber-archive/vis-academy/blob/master/src/docs/kepler.gl/0-setup.md) on vis.academy.
+Kepler.gl is also a React component that uses [Redux](https://redux.js.org/) to manage its state and data flow. It can be embedded into other React-Redux applications and is highly customizable. For information on how to embed kepler.gl in your app take a look at the [documentation](https://docs.kepler.gl/).
 
 ## Links
 
@@ -43,7 +43,7 @@ Kepler.gl is also a React component that uses [Redux](https://redux.js.org/) to 
 - [Get Started][get-started]
 - [App User Guide][user-guide]
 - [Jupyter Widget User Guide][user-guide-jupyter]
-- [Tutorial][vis-academy]
+- [Documentation][docs]
 - [Stack Overflow][stack]
 - [Contribution Guidelines][contributing]
 - [Api Reference][api-reference]
@@ -528,7 +528,7 @@ Read more about [addDataToMap](./docs/api-reference/actions/actions.md#adddatato
 [roadmap]: https://github.com/keplergl/kepler.gl/wiki/Kepler.gl-2019-Roadmap
 [stack]: https://stackoverflow.com/questions/tagged/kepler.gl
 [web]: http://www.kepler.gl/
-[vis-academy]: http://vis.academy/#/kepler.gl/
+[docs]: https://docs.kepler.gl/
 [user-guide]: docs/user-guides/README.md
 [user-guide-jupyter]: docs/keplergl-jupyter/README.md
 [api-reference]: docs/api-reference/README.md


### PR DESCRIPTION
## Summary

The vis.academy tutorial link (`http://vis.academy/#/kepler.gl/`) in README.md is broken — the vis-academy repo has been archived and the site is no longer available.

## Changes

- Replace the inline tutorial link with a link to the current documentation at https://docs.kepler.gl/
- Update the reference-style link at the bottom of the README
- Update the links section from "Tutorial" to "Documentation"

Fixes #2734