### PR TITLE
fix: preserve line breaks in tooltip field values

### DIFF
--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -45,11 +45,16 @@ const StyledTable = styled.table`
       color: ${props => props.theme.negativeBtnActBgd};
     }
   }
-  & .row__value,
   & .row__name {
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: no-wrap;
+    white-space: nowrap;
+  }
+  & .row__value {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: pre-line;
+    max-width: 250px;
   }
 `;
 


### PR DESCRIPTION
Line breaks in GeoJSON property values (e.g. desc tags) are not displayed in tooltips. The StyledTable in layer-hover-info.tsx applies white-space: no-wrap to .row__value which prevents line break rendering. This PR changes it to pre-line and also fixes the invalid CSS value (no-wrap -> nowrap). Fixes #2369