### PR TITLE
fix: use average instead of sum as default y-axis aggregation for time series plot

### DIFF
--- a/src/utils/src/plot.ts
+++ b/src/utils/src/plot.ts
@@ -698,6 +698,6 @@ export function getDefaultPlotType(filter, datasets) {
     interval,
     defaultTimeFormat,
     type: PLOT_TYPES.histogram,
-    aggregation: AGGREGATION_TYPES.sum
+    aggregation: AGGREGATION_TYPES.average
   };
 }

--- a/test/fixtures/state-saved-v0.js
+++ b/test/fixtures/state-saved-v0.js
@@ -901,7 +901,7 @@ export const mergedFilters = [
       interval: '5-second',
       defaultTimeFormat: 'L  LTS',
       type: 'histogram',
-      aggregation: 'sum'
+      aggregation: 'average'
     },
     yAxis: null,
     domain: [1453770124000, 1453770810000],

--- a/test/fixtures/test-csv-data.js
+++ b/test/fixtures/test-csv-data.js
@@ -662,7 +662,7 @@ export const mergedTimeFilter = {
     interval: '1-hour',
     defaultTimeFormat: 'L  H A',
     type: 'histogram',
-    aggregation: 'sum'
+    aggregation: 'average'
   },
   yAxis: null,
   value: [1474606800000, 1474617600000],
@@ -712,7 +712,7 @@ export const mergedEpochFilter = {
     interval: '15-minute',
     defaultTimeFormat: 'L  LT',
     type: 'histogram',
-    aggregation: 'sum'
+    aggregation: 'average'
   },
   yAxis: null,
   value: [1472700000000, 1472760000000],
@@ -751,7 +751,7 @@ export const expectedSyncedTsFilter = {
     interval: '15-second',
     defaultTimeFormat: 'L  LTS',
     type: 'histogram',
-    aggregation: 'sum',
+    aggregation: 'average',
     colorsByDataId: {
       'test-csv-data-1': '#FF0000',
       'test-csv-data-2': '#00FF00'

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -2938,7 +2938,7 @@ test('#visStateReducer -> setFilter.fixedDomain & DynamicDomain & gpu & cpu', as
     plotType: {
       type: 'histogram',
       interval: '15-second',
-      aggregation: 'sum',
+      aggregation: 'average',
       defaultTimeFormat: 'L  LTS'
     },
     yAxis: null,
@@ -3384,14 +3384,14 @@ test('#visStateReducer -> SET_FILTER_PLOT.yAxis', t => {
       interval: '15-second',
       defaultTimeFormat: 'L  LTS',
       type: 'lineChart',
-      aggregation: 'sum'
+      aggregation: 'average'
     },
     yAxis: yAxisField,
     lineChart: {
-      yDomain: [0, 12124],
+      yDomain: [1, 12124],
       xDomain: [1474070985000, 1474072215000],
       interval: '15-second',
-      aggregation: 'sum',
+      aggregation: 'average',
       series: {
         lines: [
           [
@@ -3402,29 +3402,40 @@ test('#visStateReducer -> SET_FILTER_PLOT.yAxis', t => {
             {x: 1474071240000, y: 5, delta: 'last', pct: 0.25},
             {x: 1474071300000, y: 12124, delta: 'last', pct: 2423.8},
             {x: 1474071360000, y: 222, delta: 'last', pct: -0.9816892114813592},
-            {x: 1474071420000, y: 345, delta: 'last', pct: 0.5540540540540541},
-            {x: 1474071480000, y: 0, delta: 'last', pct: -1},
-            {x: 1474071540000, y: 0, delta: 'last', pct: null},
-            {x: 1474071555000, y: 0, delta: 'last', pct: null},
-            {x: 1474071600000, y: 0, delta: 'last', pct: null},
-            {x: 1474071675000, y: 0, delta: 'last', pct: null},
-            {x: 1474071735000, y: 0, delta: 'last', pct: null},
-            {x: 1474071795000, y: 0, delta: 'last', pct: null},
-            {x: 1474071855000, y: 1, delta: 'last', pct: null},
-            {x: 1474071915000, y: 0, delta: 'last', pct: -1},
+            {x: 1474071420000, y: 345, delta: 'last', pct: 0.5540540540540541}
+          ],
+          [
+            {x: 1474071855000, y: 1, delta: 'last', pct: null}
+          ],
+          [
             {x: 1474071975000, y: 43, delta: 'last', pct: null},
             {x: 1474072050000, y: 4, delta: 'last', pct: -0.9069767441860465},
-            {x: 1474072110000, y: 5, delta: 'last', pct: 0.25},
-            {x: 1474072170000, y: 0, delta: 'last', pct: -1},
-            {x: 1474072200000, y: 13, delta: 'last', pct: null}
+            {x: 1474072110000, y: 5, delta: 'last', pct: 0.25}
+          ],
+          [
+            {x: 1474072200000, y: 6.5, delta: 'last', pct: null}
           ]
         ],
-        markers: []
+        markers: [
+          {x: 1474070985000, y: 1, delta: 'last', pct: null},
+          {x: 1474071045000, y: 2, delta: 'last', pct: 1},
+          {x: 1474071105000, y: 3, delta: 'last', pct: 0.5},
+          {x: 1474071165000, y: 4, delta: 'last', pct: 0.3333333333333333},
+          {x: 1474071240000, y: 5, delta: 'last', pct: 0.25},
+          {x: 1474071300000, y: 12124, delta: 'last', pct: 2423.8},
+          {x: 1474071360000, y: 222, delta: 'last', pct: -0.9816892114813592},
+          {x: 1474071420000, y: 345, delta: 'last', pct: 0.5540540540540541},
+          {x: 1474071855000, y: 1, delta: 'last', pct: null},
+          {x: 1474071975000, y: 43, delta: 'last', pct: null},
+          {x: 1474072050000, y: 4, delta: 'last', pct: -0.9069767441860465},
+          {x: 1474072110000, y: 5, delta: 'last', pct: 0.25},
+          {x: 1474072200000, y: 6.5, delta: 'last', pct: null}
+        ]
       },
       yAxis: 'uid',
-      title: 'Total of uid',
+      title: 'Average of uid',
       fieldType: 'integer',
-      allTime: {title: 'All Time Average', value: 580.5454545454545},
+      allTime: {title: 'All Time Average', value: 981.9615384615385},
       bins
     },
     speed: 1,

--- a/test/node/schemas/vis-state-schema-test.js
+++ b/test/node/schemas/vis-state-schema-test.js
@@ -107,7 +107,7 @@ test('#visStateSchema -> v1 -> save load filters', t => {
         interval: '1-hour',
         defaultTimeFormat: 'L  H A',
         type: 'histogram',
-        aggregation: 'sum'
+        aggregation: 'average'
       },
       yAxis: null,
       animationWindow: 'free',

--- a/test/node/utils/filter-utils-test.js
+++ b/test/node/utils/filter-utils-test.js
@@ -567,7 +567,7 @@ test('filterUtils -> mergeFilterWithTimeline', t => {
       interval: '1-minute',
       defaultTimeFormat: 'L  LT',
       type: 'histogram',
-      aggregation: 'sum'
+      aggregation: 'average'
     },
     yAxis: null,
     gpu: true,

--- a/test/node/utils/timeline-test.js
+++ b/test/node/utils/timeline-test.js
@@ -22,7 +22,7 @@ test('#timeline -> getTimelineFromFilter', t => {
       interval: '5-minute',
       defaultTimeFormat: 'L  LT',
       type: 'histogram',
-      aggregation: 'sum'
+      aggregation: 'average'
     },
     yAxis: null,
     gpu: true,


### PR DESCRIPTION
The initial plot type for time filter animations defaults to AGGREGATION_TYPES.sum, causing misleading y-axis values. For example, the earthquakes demo shows magnitudes of 2000/4000/6000 instead of actual values, because all magnitudes in each time bucket are summed rather than averaged. All other aggregation defaults in the codebase use average — this was an inconsistency. One-line fix in plot.ts. Fixes #3122