### PR TITLE
fix: show OpenStreetMap attribution on demo site (#2462)

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -560,10 +560,10 @@ export default function MapContainerFactory(
       this._updateMapboxLayers();
 
       if (update && update.style) {
-        // No attributions are needed if the style doesn't reference Mapbox sources
+        // Show attributions if the style uses Mapbox or OpenStreetMap sources
         this.setState({
           showBaseMapAttribution:
-            isStyleUsingMapboxTiles(update.style) || !isStyleUsingOpenStreetMapTiles(update.style)
+            isStyleUsingMapboxTiles(update.style) || isStyleUsingOpenStreetMapTiles(update.style)
         });
       }
 

--- a/src/utils/src/map-style-utils/mapbox-utils.ts
+++ b/src/utils/src/map-style-utils/mapbox-utils.ts
@@ -32,8 +32,8 @@ export function isStyleUsingOpenStreetMapTiles(mapStyle: any) {
   const sources = mapStyle?.stylesheet?.sources || {};
   return Object.keys(sources).some(sourceId => {
     const {attribution} = sources[sourceId] || {};
-    if (typeof attribution?.attribution === 'string') {
-      return attribution.attribution.includes('openstreetmap.org');
+    if (typeof attribution === 'string') {
+      return attribution.includes('openstreetmap.org');
     }
     return false;
   });


### PR DESCRIPTION
Fixes #2462

This PR fixes the missing OpenStreetMap attribution on the demo site by:

1. Correcting the detection logic for OSM tiles in `isStyleUsingOpenStreetMapTiles` - the function was incorrectly accessing `attribution.attribution` instead of just `attribution`.

2. Fixing the attribution display logic in map-container to show attribution when OSM tiles are detected (removed the negation that was hiding attribution for OSM sources).

The demo now properly displays OpenStreetMap attribution when using map styles that rely on OSM data (like CARTO basemaps).