### PR TITLE
fix: correct env variable instruction URLs (#2599)

### DIFF
--- a/webpack/shared-webpack-configuration.js
+++ b/webpack/shared-webpack-configuration.js
@@ -32,8 +32,8 @@ workspaces.forEach(workspace => {
 const ENV_VARIABLES_WITH_INSTRUCTIONS = {
   MapboxAccessToken: 'You can get the token at https://www.mapbox.com/help/how-access-tokens-work/',
   DropboxClientId: 'You can get the token at https://www.dropbox.com/developers',
-  CartoClientId: 'You can get the token at https://www.mapbox.com/help/how-access-tokens-work/',
-  MapboxExportToken: 'You can get the token at https://location.foursquare.com/developer',
+  CartoClientId: 'You can get the token at https://carto.com/help/working-with-data/carto-platform-api-keys',
+  MapboxExportToken: 'You can get the token at https://www.mapbox.com/help/how-access-tokens-work/',
   FoursquareClientId: 'You can get the token at https://location.foursquare.com/developer',
   FoursquareDomain: 'You can get the token at https://location.foursquare.com/developer',
   FoursquareAPIURL: 'You can get the token at https://location.foursquare.com/developer',


### PR DESCRIPTION
Fixes #2599

This PR corrects the instruction URLs for environment variables in the webpack configuration:

1. **CartoClientId** - Changed from Mapbox help URL to CARTO API keys documentation
2. **MapboxExportToken** - Changed from Foursquare developer URL to Mapbox help URL

These incorrect URLs were confusing developers trying to set up the required tokens.