### PR TITLE
fix: replace deprecated pkg_resources with importlib.resources (#3158)

### DIFF
--- a/bindings/kepler.gl-jupyter/keplergl/keplergl.py
+++ b/bindings/kepler.gl-jupyter/keplergl/keplergl.py
@@ -10,7 +10,14 @@ import base64
 import sys
 import json
 import ipywidgets as widgets
-from pkg_resources import resource_string
+try:
+    # Python 3.9+
+    from importlib.resources import files
+    def resource_string(package, resource):
+        return files(package).joinpath(resource).read_bytes()
+except ImportError:
+    # Python < 3.9 fallback
+    from pkg_resources import resource_string
 from traitlets import Unicode, Dict, Int, validate, TraitError
 import pandas as pd
 import geopandas


### PR DESCRIPTION
Fixes #3158

This PR replaces the deprecated `pkg_resources` API with the modern `importlib.resources` API in the Jupyter binding.

**Changes:**
- Uses `importlib.resources.files()` for Python 3.9+
- Falls back to `pkg_resources` for older Python versions
- Eliminates the deprecation warning for users on Python 3.9+

The `pkg_resources` package is deprecated and will be removed in setuptools as early as 2025-11-30. This change ensures the codebase is future-proof while maintaining backward compatibility with older Python versions through a try/except fallback.