### PR TITLE
fix: polygon filter for point layers with geojson column mode (#3278)

### DIFF
--- a/src/utils/src/filter-utils.ts
+++ b/src/utils/src/filter-utils.ts
@@ -382,6 +382,16 @@ export const getPolygonFilterFunctor = (layer, filter, dataContainer) => {
   switch (layer.type) {
     case LAYER_TYPES.point:
     case LAYER_TYPES.icon:
+      // For geojson column mode, coordinates are pre-parsed in dataToFeature
+      if (layer.dataToFeature && layer.config?.columnMode === 'geojson') {
+        return data => {
+          const pos = layer.dataToFeature[data.index];
+          // pos can be [lng, lat] for Point, or [[lng, lat], ...] for MultiPoint
+          if (!pos) return false;
+          const coords = Array.isArray(pos[0]) ? pos[0] : pos;
+          return coords.every(Number.isFinite) && isInPolygon(coords, filter.value);
+        };
+      }
       return data => {
         const pos = getPosition(data);
         return pos.every(Number.isFinite) && isInPolygon(pos, filter.value);


### PR DESCRIPTION
## Summary

Fixes #3278

When using point layers with geojson column mode (e.g., CSV with WKT point columns like `POINT (7.63 45.04)`), drawing a polygon/rectangle filter would crash with:
```
Uncaught TypeError: can't access property "every", pos is undefined
```

## Root Cause

The polygon filter pipeline passes data as `{index, dataContainer}` objects, but the geojson column mode's position accessor (`geojsonPosAccessor`) expects array-format data (row as array) and tries `d[geojson.fieldIdx]`, which returns `undefined` for objects.

## Fix

For point layers in geojson column mode, the polygon filter now uses the pre-parsed coordinates from `layer.dataToFeature` (which are computed during `updateLayerMeta`) instead of calling the raw position accessor. This avoids the format mismatch entirely and is more efficient since the coordinates are already parsed.

## Testing

1. Create a CSV with a WKT point column: `POINT (lng lat)`
2. Import into kepler.gl
3. Change layer type to Point, use geojson column mode
4. Draw a rectangle around points and apply as filter
5. Verify: points are correctly filtered without errors