### PR TITLE
fix: geocoder coordinate search results not showing (#2245)

### DIFF
--- a/src/components/src/geocoder/geocoder.tsx
+++ b/src/components/src/geocoder/geocoder.tsx
@@ -164,7 +164,11 @@ const GeoCoder: React.FC<GeocoderProps & IntlProps> = ({
       setInputValue(queryString);
       const resultCoordinates = testForCoordinates(queryString);
       if (resultCoordinates[0]) {
+        if (debounceTimeout) {
+          clearTimeout(debounceTimeout);
+        }
         const [_isValid, longitude, latitude] = resultCoordinates;
+        setShowResults(true);
         setResults([{center: [longitude, latitude], place_name: queryString}]);
       } else {
         if (debounceTimeout) {


### PR DESCRIPTION
## Summary

Fixes #2245

When entering coordinates directly in the geocoder search box (e.g., `3.5260, 98.6736`), the marker might not appear because:

1. **Pending geocoder API call could overwrite results**: If the user types a partial string that triggers the debounced mapbox geocoder, then modifies it to valid coordinates, the pending API call could overwrite the coordinate results when it resolves.

2. **Results dropdown might not be visible**: The `showResults` state was not explicitly set to `true` in the coordinate path, relying on the focus handler which might not have fired.

## Changes

In the coordinate detection branch of the `onChange` handler in `geocoder.tsx`:
- Clear any pending geocoder debounce timeout to prevent stale API results
- Explicitly set `showResults` to `true` to ensure the dropdown is visible

## Testing

1. Enable geocoder in kepler.gl
2. Enter coordinates like `3.5260, 98.6736`
3. Verify the result appears in the dropdown
4. Press Enter or click the result
5. Verify the marker appears on the map at the correct location