### PR TITLE
feat: add layer visibility toggle to map legend (#3303)

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -28,6 +28,7 @@ import EditorFactory from './editor/editor';
 import {
   generateMapboxLayers,
   updateMapboxLayers,
+  Layer,
   LayerBaseConfig,
   VisualChannelDomain,
   EditorLayerUtils,
@@ -1050,6 +1051,11 @@ export default function MapContainerFactory(
       this.props.visStateActions.setLoadingIndicator({change: 0});
     }, DEBOUNCE_LOADING_STATE_PROPAGATE);
 
+    _handleToggleLayerVisibility = (layer: Layer) => {
+      const {visStateActions} = this.props;
+      visStateActions.layerConfigChange(layer, {isVisible: !layer.config.isVisible});
+    };
+
     _toggleMapControl = panelId => {
       const {index, uiStateActions} = this.props;
 
@@ -1160,6 +1166,7 @@ export default function MapContainerFactory(
             onSetLocale={uiStateActions.setLocale}
             onToggleEditorVisibility={visStateActions.toggleEditorVisibility}
             onLayerVisConfigChange={visStateActions.layerVisConfigChange}
+            onToggleLayerVisibility={this._handleToggleLayerVisibility}
             mapHeight={mapState.height}
             setMapControlSettings={uiStateActions.setMapControlSettings}
             activeSidePanel={activeSidePanel}

--- a/src/components/src/map/map-control.tsx
+++ b/src/components/src/map/map-control.tsx
@@ -62,6 +62,7 @@ export type MapControlProps = {
   onSetEditorMode: (mode: string) => void;
   onToggleEditorVisibility: () => void;
   onLayerVisConfigChange: (oldLayer: Layer, newVisConfig: Partial<LayerVisConfig>) => void;
+  onToggleLayerVisibility?: (layer: Layer) => void;
   top: number;
   onSetLocale: typeof UIStateActions.setLocale;
   availableLocales: string[];

--- a/src/components/src/map/map-legend-panel.tsx
+++ b/src/components/src/map/map-legend-panel.tsx
@@ -320,6 +320,7 @@ export type MapLegendPanelProps = {
   mapControls: MapControls;
   mapState?: MapState;
   onLayerVisConfigChange?: (oldLayer: Layer, newVisConfig: Partial<LayerVisConfig>) => void;
+  onToggleLayerVisibility?: (layer: Layer) => void;
   onToggleSplitMapViewport?: ActionHandler<typeof toggleSplitMapViewport>;
   isViewportUnsyncAllowed?: boolean;
   onClickControlBtn?: (e?: MouseEvent) => void;
@@ -352,6 +353,7 @@ const MapLegendPanelComponent = ({
   actionIcons = defaultActionIcons,
   mapState,
   onLayerVisConfigChange,
+  onToggleLayerVisibility,
   onToggleSplitMapViewport,
   onClickControlBtn,
   activeSidePanel,
@@ -406,6 +408,7 @@ const MapLegendPanelComponent = ({
         disableEdit={disableEdit}
         isExport={isExport}
         onLayerVisConfigChange={onLayerVisConfigChange}
+        onToggleLayerVisibility={onToggleLayerVisibility}
       />
     </MapControlPanel>
   ) : null;


### PR DESCRIPTION
## Summary
Closes #3303 — Adds layer visibility toggle buttons to the map legend.

## Problem
In read-only/exported maps, there was no way to toggle layer visibility since the side panel is not available. The legend showed layer names but no controls.

## Solution
Added an eye icon toggle (EyeSeen/EyeUnseen) next to each layer name in the legend header. Clicking it toggles the layer's `isVisible` config via `layerConfigChange`.

### Changes
- **`src/components/src/map/map-legend.tsx`**: 
  - Added `StyledLegendHeaderRow` and `StyledVisibilityToggle` styled components
  - Extended `LayerLegendHeaderFactory` to accept `onToggleLayerVisibility` prop
  - Added eye icon toggle with visual feedback (opacity changes for hidden layers)
  - Added `onToggleLayerVisibility` to `MapLegendProps` and threaded it through
- **`src/components/src/map/map-legend-panel.tsx`**: Added `onToggleLayerVisibility` prop passthrough
- **`src/components/src/map/map-control.tsx`**: Added `onToggleLayerVisibility` to `MapControlProps`
- **`src/components/src/map-container.tsx`**: Added `_handleToggleLayerVisibility` handler that calls `layerConfigChange`

## Behavior
- Eye icon appears next to each layer name in the legend
- Hidden layers show with reduced opacity and the EyeUnseen icon
- Toggle only appears when `onToggleLayerVisibility` is provided (backward compatible)