### PR TITLE
fix(components): disable preserveDrawingBuffer by default for better performance

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -1097,7 +1097,7 @@ export default function MapContainerFactory(
       const internalViewState = this.context?.getInternalViewState(index);
       const mapProps = {
         ...internalViewState,
-        preserveDrawingBuffer: true,
+        preserveDrawingBuffer: this.props.isExport ?? false,
         mapboxAccessToken: currentStyle?.accessToken || mapboxApiAccessToken,
         // baseApiUrl: mapboxApiUrl,
         mapLib: baseMapLibraryConfig.getMapLib(),


### PR DESCRIPTION
## Summary

Disables `preserveDrawingBuffer` on the base map by default, only enabling it during image export (`isExport: true`). This improves rendering performance as `preserveDrawingBuffer: true` forces the browser to keep a copy of the drawing buffer after each frame, which is a [known WebGL performance penalty](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#preservedrawingbuffer).

### Changes

**src/components/src/map-container.tsx:**
- Changed `preserveDrawingBuffer: true` → `preserveDrawingBuffer: this.props.isExport ?? false`
- The `isExport` prop is already set to `true` by `plot-container.tsx` during image export, so export functionality is preserved
- Users can still override via `bottomMapContainerProps` if needed

### Root Cause

`preserveDrawingBuffer` was hardcoded to `true` for all map instances, even though it's only needed when calling `canvas.toDataURL()` for image export. This caused unnecessary performance overhead during normal map interaction.

### Testing

- Normal map rendering: `preserveDrawingBuffer` is now `false` (better performance)
- Image export: `preserveDrawingBuffer` remains `true` (via `isExport` prop)
- Override path: users can pass `bottomMapContainerProps={{ preserveDrawingBuffer: true }}` if needed

Addresses #3237