### PR TITLE
fix: use dataset label as CSV export filename

### DIFF
--- a/src/reducers/src/export-utils.ts
+++ b/src/reducers/src/export-utils.ts
@@ -26,7 +26,7 @@ export function exportData(state: StateType, options) {
   const {datasets} = visState;
   const {selectedDataset, dataType, filtered} = options;
   // get the selected data
-  const filename = appName ? appName : getApplicationConfig().defaultDataName;
+  const prefix = appName ? appName : getApplicationConfig().defaultDataName;
   const selectedDatasets = datasets[selectedDataset]
     ? [datasets[selectedDataset]]
     : Object.values(datasets);
@@ -34,6 +34,10 @@ export function exportData(state: StateType, options) {
     // error: selected dataset not found.
     return;
   }
+
+  // When exporting a single dataset, use its label as the filename directly.
+  // When exporting multiple datasets, prepend the app name to disambiguate.
+  const usePrefix = selectedDatasets.length > 1;
 
   selectedDatasets.forEach(selectedData => {
     const {dataContainer, fields, label, filteredIdxCPU = []} = selectedData as KeplerTable;
@@ -45,9 +49,9 @@ export function exportData(state: StateType, options) {
     switch (dataType) {
       case EXPORT_DATA_TYPE.CSV: {
         const csv = formatCsv(toExport, fields);
-
+        const fileName = usePrefix ? `${prefix}_${label}.csv` : `${label}.csv`;
         const fileBlob = new Blob([csv], {type: 'text/csv'});
-        downloadFile(fileBlob, `${filename}_${label}.csv`);
+        downloadFile(fileBlob, fileName);
         break;
       }
       // TODO: support more file types.


### PR DESCRIPTION
## Summary

When exporting a single dataset as CSV, the filename now uses the dataset label directly (e.g. `myData.csv`) instead of always prepending the app name prefix (e.g. `kepler.gl_myData.csv`).

When exporting multiple datasets at once, the app name prefix is still prepended to disambiguate files.

The `appName` prop and `defaultDataName` application config remain available for full customization.

## Changes

- `src/reducers/src/export-utils.ts`: Use dataset label as filename for single-dataset exports; only prepend app prefix for multi-dataset exports.

Closes #2561