### PR TITLE
feat: add compass and scale controls to map

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -4,7 +4,7 @@
 // libraries
 import React, {Component, createRef, useMemo} from 'react';
 import styled, {withTheme} from 'styled-components';
-import {Map, MapRef} from 'react-map-gl';
+import {Map, MapRef, NavigationControl, ScaleControl} from 'react-map-gl';
 import {PickInfo} from '@deck.gl/core/lib/deck';
 import DeckGL from '@deck.gl/react';
 import {createSelector, Selector} from 'reselect';
@@ -1119,7 +1119,10 @@ export default function MapContainerFactory(
             mapStyle={mapStyle.bottomMapStyle ?? EMPTY_MAPBOX_STYLE}
             {...bottomMapContainerProps}
             ref={this._setMapRef}
-          />
+          >
+            <NavigationControl position="bottom-right" showCompass visualizePitch />
+            <ScaleControl position="bottom-left" />
+          </MapComponent>
         )
       });
       if (!deck) {


### PR DESCRIPTION
## Summary

Adds NavigationControl (compass with pitch visualization) and ScaleControl from react-map-gl as native map controls on the map.

- **Compass** (bottom-right): Shows north orientation and allows pitch visualization. Clicking resets bearing/pitch to north.
- **Scale bar** (bottom-left): Shows a distance scale that updates with zoom level.

These are standard map controls available in react-map-gl/maplibre-gl that help users orient themselves and understand distances.

## Changes

- `src/components/src/map-container.tsx`: Import `NavigationControl` and `ScaleControl` from react-map-gl and add them as children of the bottom map component.

Closes #2562