### PR TITLE
fix: remove Google Analytics tracking from HTML exports

### DIFF
--- a/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
+++ b/bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js
@@ -116,8 +116,7 @@ function App() {
                 }
                 `}
           </style>
-          <script async src="https://www.googletagmanager.com/gtag/js?id=UA-64694404-19" />
-          <script>{`window.dataLayer=window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'UA-64694404-19', {page_path: '/keplergl-jupyter-widget'});`}</script>
+          {/* Analytics removed to respect user privacy */}
         </Helmet>
       ) : null}
       <KeplerGl

--- a/bindings/kepler.gl-jupyter/js/template/keplergl-html.ejs
+++ b/bindings/kepler.gl-jupyter/js/template/keplergl-html.ejs
@@ -91,25 +91,6 @@
 <script src="<%= htmlWebpackPlugin.options.devServer %>/webpack-dev-server.js" type="text/javascript"></script>
 <% } %>
 
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-64694404-19', {
-    'storage': 'none',
-    'clientId': localStorage.getItem('ga:clientId')
-  });
-  ga(function(tracker) {
-      localStorage.setItem('ga:clientId', tracker.get('clientId'));
-  });
-  ga('set', 'checkProtocolTask', null); // Disable file protocol checking.
-  ga('set', 'checkStorageTask', null); // Disable cookie storage checking.
-  ga('set', 'historyImportTask', null); // Disable history checking (requires reading from cookies).
-  ga('set', 'page', 'keplergl-jupyter-html');
-
-  ga('send', 'pageview');
-</script>
+<!-- Analytics removed to respect user privacy in exported maps -->
 </body>
 </html>

--- a/src/utils/src/export-map-html.ts
+++ b/src/utils/src/export-map-html.ts
@@ -71,25 +71,7 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
           const WARNING_MESSAGE = 'Please Provide a Mapbox Token in order to use Kepler.gl. Edit this file and fill out MAPBOX_TOKEN with your access key';
         </script>
 
-        <!-- GA: Delete this as you wish, However to pat ourselves on the back, we only track anonymous pageview to understand how many people are using kepler.gl. -->
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-          ga('create', 'UA-64694404-19', {
-            'storage': 'none',
-            'clientId': localStorage.getItem('ga:clientId')
-          });
-          ga(function(tracker) {
-              localStorage.setItem('ga:clientId', tracker.get('clientId'));
-          });
-          ga('set', 'checkProtocolTask', null); // Disable file protocol checking.
-          ga('set', 'checkStorageTask', null); // Disable cookie storage checking.
-          ga('set', 'historyImportTask', null); // Disable history checking (requires reading from cookies).
-          ga('set', 'page', 'keplergl-html');
-          ga('send', 'pageview');
-        </script>
+        <!-- Analytics removed to respect user privacy in exported maps -->
       </head>
       <body>
         <!-- We will put our React component inside this div. -->


### PR DESCRIPTION
## Summary

Removes embedded Google Analytics tracking scripts from all HTML export templates. These scripts were tracking users of exported maps without their consent, which raises privacy concerns — particularly in regions with strict data privacy regulations like GDPR in Europe.

## Changes

- `src/utils/src/export-map-html.ts`: Remove GA script from standalone HTML export
- `bindings/kepler.gl-jupyter/js/template/keplergl-html.ejs`: Remove GA script from Jupyter HTML export template
- `bindings/kepler.gl-jupyter/js/lib/keplergl/components/app.js`: Remove GA gtag from Jupyter widget component

## Context

As noted in the issue, the GA tracking contradicts kepler.gl's own [Data Security statement](https://github.com/keplergl/kepler.gl/issues/730) which states the library does not collect information. The tracking also used `localStorage` which can cause `SecurityError` in restricted environments (related to #1488).

Closes #2036