### PR TITLE
fix: add security warning about Mapbox token in HTML exports

### DIFF
--- a/src/components/src/modals/export-map-modal/export-html-map.tsx
+++ b/src/components/src/modals/export-map-modal/export-html-map.tsx
@@ -105,6 +105,9 @@ function ExportHtmlMapFactory(): React.ComponentType<ExportHtmlMapProps> {
             <StyledWarning>
               <FormattedMessage id={'modal.exportMap.html.tokenMisuseWarning'} />
             </StyledWarning>
+            <StyledWarning>
+              <FormattedMessage id={'modal.exportMap.html.tokenSecurityWarning'} />
+            </StyledWarning>
             <FormattedMessage id={'modal.exportMap.html.tokenDisclaimer'} />
             <ExportMapLink href={EXPORT_HTML_MAP_DOC}>
               <FormattedMessage id={'modal.exportMap.html.tokenUpdate'} />

--- a/src/localization/src/translations/en.ts
+++ b/src/localization/src/translations/en.ts
@@ -388,6 +388,8 @@ export default {
         tokenPlaceholder: 'Paste your Mapbox access token',
         tokenMisuseWarning:
           '* If you do not provide your own token, the map may fail to display at any time when we replace ours to avoid misuse. ',
+        tokenSecurityWarning:
+          '* Warning: your Mapbox token will be embedded in the exported HTML file. Anyone with access to this file can see and use your token. Use a scoped token with URL restrictions when possible. ',
         tokenDisclaimer: 'You can change the Mapbox token later using the following instructions: ',
         tokenUpdate: 'How to update an existing map token.',
         modeTitle: 'Map Mode',

--- a/src/utils/src/export-map-html.ts
+++ b/src/utils/src/export-map-html.ts
@@ -63,6 +63,12 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
         </style>
 
         <!--MapBox token-->
+        <!--
+          SECURITY NOTE: Your Mapbox access token is embedded below in plain text.
+          Anyone with access to this HTML file can see and use this token.
+          Consider using a scoped token with URL restrictions to limit misuse.
+          See: https://docs.mapbox.com/accounts/guides/tokens/#url-restrictions
+        -->
         <script>
           /**
            * Provide your MapBox Token


### PR DESCRIPTION
## Summary

Adds security warnings to inform users that their Mapbox access token will be embedded in plain text in exported HTML files. Anyone with access to the exported file can see and use the token.

## Changes

- `src/components/src/modals/export-map-modal/export-html-map.tsx`: Add security warning in the export modal UI
- `src/utils/src/export-map-html.ts`: Add HTML comment in exported files about token exposure with link to Mapbox URL restriction docs
- `src/localization/src/translations/en.ts`: Add `tokenSecurityWarning` translation string

## Context

As discussed in the issue, Mapbox tokens embedded in HTML exports can be misused. While a complete solution would involve architectural changes (e.g., proxy tokens, switching to token-free basemaps), this PR provides immediate user awareness so they can take precautions like using scoped tokens with URL restrictions.

Relates to #3139