### PR TITLE
feat(processors): auto-detect delimiter for CSV/TSV/DSV files

### DIFF
--- a/src/reducers/src/vis-state-selectors.ts
+++ b/src/reducers/src/vis-state-selectors.ts
@@ -4,8 +4,8 @@
 import {createSelector} from 'reselect';
 
 // NOTE: default formats must match file-handler-test.js
-const DEFAULT_FILE_EXTENSIONS = ['csv', 'json', 'geojson', 'arrow', 'parquet'];
-const DEFAULT_FILE_FORMATS = ['CSV', 'Json', 'GeoJSON', 'Arrow', 'Parquet'];
+const DEFAULT_FILE_EXTENSIONS = ['csv', 'tsv', 'dsv', 'json', 'geojson', 'arrow', 'parquet'];
+const DEFAULT_FILE_FORMATS = ['CSV', 'TSV', 'DSV', 'Json', 'GeoJSON', 'Arrow', 'Parquet'];
 
 export const getFileFormatNames = createSelector(
   state => state.loaders,


### PR DESCRIPTION
## Summary

Add automatic delimiter detection to `processCsvData` so that files using tabs, semicolons, or pipe characters as delimiters are parsed correctly without requiring any user configuration.

## Problem

Kepler.gl only supports comma-separated CSV files (#202). Users with tab-separated (TSV), semicolon-separated (common in European locales), or pipe-separated files cannot load their data without first converting it.

## Solution

- Add a `detectDelimiter` function that examines the first line of the input and tests each supported delimiter (`,`, `\t`, `;`, `|`) to find which one produces the most columns
- Uses `d3-dsv`'s `dsvFormat` for proper parsing of quoted fields with any delimiter
- Falls back to comma if no delimiter produces multiple columns
- Add `.tsv` and `.dsv` to accepted file extensions

### Delimiter Detection Logic

1. Extract the first line of the raw data
2. For each candidate delimiter, parse the first line and count resulting columns
3. Pick the delimiter that produces the most columns (minimum 2)
4. Use the appropriate d3-dsv parser for that delimiter

This is a superset of PR #3313 (TSV support) and also handles semicolons and pipes.

Fixes #202
Related: #168