### PR TITLE
fix(components): add RTLTextPlugin prop to disable remote script loading (#2477)

### DIFF
--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -193,7 +193,10 @@ export const mapFieldsSelector = (props: KeplerGLProps, index = 0) => ({
   bottomMapContainerProps: props.bottomMapContainerProps,
 
   // transformRequest for Mapbox basemaps
-  transformRequest: props.transformRequest
+  transformRequest: props.transformRequest,
+
+  // RTL text plugin
+  RTLTextPlugin: props.RTLTextPlugin
 });
 
 export function getVisibleDatasets(datasets) {
@@ -413,6 +416,10 @@ type KeplerGLBasicProps = {
   bottomMapContainerProps?: object;
 
   transformRequest?: (url: string) => {url: string};
+
+  /** Set to false to disable loading the mapbox-gl RTL text plugin from a remote URL.
+   *  Useful in strict Content Security Policy (CSP) environments. */
+  RTLTextPlugin?: string | false;
 };
 
 type KeplerGLProps = KeplerGlState & KeplerGlActions & KeplerGLBasicProps;

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -346,6 +346,10 @@ export interface MapContainerProps {
   bottomMapContainerProps: any;
   transformRequest?: (url: string, resourceType?: string) => {url: string};
 
+  /** Set to false to disable loading the RTL text plugin from a remote URL.
+   *  Useful in strict CSP environments. Defaults to undefined (react-map-gl default behaviour). */
+  RTLTextPlugin?: string | false;
+
   datasetAttributions?: DatasetAttribution[];
 
   generateMapboxLayers?: typeof generateMapboxLayers;
@@ -1103,7 +1107,8 @@ export default function MapContainerFactory(
         mapLib: baseMapLibraryConfig.getMapLib(),
         transformRequest:
           this.props.transformRequest ||
-          transformRequest(currentStyle?.accessToken || mapboxApiAccessToken)
+          transformRequest(currentStyle?.accessToken || mapboxApiAccessToken),
+        ...(this.props.RTLTextPlugin !== undefined ? {RTLTextPlugin: this.props.RTLTextPlugin} : {})
       };
 
       const hasGeocoderLayer = Boolean(layers.find(l => l.id === GEOCODER_LAYER_ID));


### PR DESCRIPTION
## Summary

Adds an `RTLTextPlugin` prop to the `KeplerGl` and `MapContainer` components, allowing users to disable the automatic loading of the [mapbox-gl-rtl-text](https://github.com/mapbox/mapbox-gl-rtl-text) plugin from a remote URL.

## Problem

`react-map-gl` loads the RTL text plugin from `https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-rtl-text/v0.2.3/mapbox-gl-rtl-text.js` by default. This violates strict Content Security Policy (CSP) environments where loading external scripts is prohibited.

See also: [visgl/react-map-gl#2310](https://github.com/visgl/react-map-gl/issues/2310)

## Solution

Thread the `RTLTextPlugin` prop from `KeplerGl` → `MapContainer` → `react-map-gl`'s `Map` component. Users can now:

```jsx
// Disable RTL text plugin loading entirely
<KeplerGl RTLTextPlugin={false} ... />

// Or point to a self-hosted version
<KeplerGl RTLTextPlugin="/static/mapbox-gl-rtl-text.js" ... />
```

When the prop is not provided, the default `react-map-gl` behavior is preserved (loads from Mapbox CDN).

## Changes

- `src/components/src/kepler-gl.tsx`: Add `RTLTextPlugin` to `KeplerGLBasicProps` and pass it to `MapContainer`
- `src/components/src/map-container.tsx`: Add `RTLTextPlugin` to `MapContainerProps` and include it in `mapProps`

Closes #2477