### PR TITLE
fix(geojson-layer): initialize strokeColor for LineString features (#2305)

### DIFF
--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -634,6 +634,13 @@ export default class GeoJsonLayer extends Layer {
     } else if (featureTypes && featureTypes.point) {
       // set fill to true if detect point
       return this.updateLayerVisConfig({filled: true, stroked: false});
+    } else if (featureTypes && featureTypes.line) {
+      // for line features, set strokeColor so the color picker reflects the actual rendered color
+      return this.updateLayerVisConfig({
+        stroked: true,
+        filled: false,
+        strokeColor: colorMaker.next().value
+      });
     }
 
     return this;


### PR DESCRIPTION
## Summary

Fixes stroke color initialization for GeoJSON layers containing only LineString/MultiLineString features.

## Problem

When loading GeoJSON data with only line features (LineString/MultiLineString), the `setInitialLayerConfig` method did not set an initial `strokeColor` in the visConfig. The default `strokeColor` was `null`, so:

1. The line rendered using the layer's base `color` (e.g., purple)
2. The stroke color picker in the layer panel showed a different color or the default
3. Changing the stroke color in the panel might not immediately reflect because the rendered color was coming from the `config.color` fallback rather than `visConfig.strokeColor`

This contrasts with polygon features, which properly received a `strokeColor` during initialization.

## Fix

Added a branch in `setInitialLayerConfig` for `featureTypes.line` that explicitly sets `strokeColor`, `stroked: true`, and `filled: false`, matching the auto-styling behavior already present for polygon features.

### Before
```
Polygon → strokeColor: ✅ (set from colorMaker)
Point   → strokeColor: ❌ (stroked: false, not needed)
Line    → strokeColor: ❌ (null, falls back to config.color)
```

### After
```
Polygon → strokeColor: ✅ (set from colorMaker)
Point   → strokeColor: ❌ (stroked: false, not needed)
Line    → strokeColor: ✅ (set from colorMaker)
```

Closes #2305