### PR TITLE
fix(components): render tooltip comparison delta in separate column (#1641)

### DIFF
--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -65,11 +65,12 @@ interface RowProps {
   value: string;
   deltaValue?: string | null;
   url?: string;
+  isComparing?: boolean;
 }
 
 const TOOLTIP_VALUE_MAX_LENGTH = 256;
 
-const Row: React.FC<RowProps> = ({name, value, deltaValue, url}) => {
+const Row: React.FC<RowProps> = ({name, value, deltaValue, url, isComparing}) => {
   // Set 'url' to 'value' if it looks like a url
   if (!url && value && typeof value === 'string' && value.match(/^http/)) {
     url = value;
@@ -92,20 +93,22 @@ const Row: React.FC<RowProps> = ({name, value, deltaValue, url}) => {
             {displayValue}
           </a>
         ) : (
-          <>
-            <span>{displayValue}</span>
-            {notNullorUndefined(deltaValue) ? (
-              <span
-                className={`row__delta-value ${
-                  deltaValue?.toString().charAt(0) === '+' ? 'positive' : 'negative'
-                }`}
-              >
-                {deltaValue}
-              </span>
-            ) : null}
-          </>
+          <span>{displayValue}</span>
         )}
       </td>
+      {isComparing ? (
+        <td
+          className={`row__delta-value ${
+            notNullorUndefined(deltaValue)
+              ? deltaValue?.toString().charAt(0) === '+'
+                ? 'positive'
+                : 'negative'
+              : ''
+          }`}
+        >
+          {deltaValue ?? ''}
+        </td>
+      ) : null}
     </tr>
   );
 };
@@ -183,6 +186,7 @@ const EntryInfoRow: React.FC<EntryInfoRowProps> = ({
       name={field.displayName || field.name}
       value={displayValue}
       deltaValue={displayDeltaValue}
+      isComparing={Boolean(primaryData)}
     />
   );
 };

--- a/src/components/src/map/map-popover.tsx
+++ b/src/components/src/map/map-popover.tsx
@@ -76,6 +76,9 @@ const StyledMapPopover = styled.div`
   .map-popover__layer-info > table {
     grid-template-columns: auto auto;
   }
+  .map-popover__layer-info > table:has(td.row__delta-value) {
+    grid-template-columns: auto auto auto;
+  }
 
   tbody,
   tr {


### PR DESCRIPTION
## Summary

Fixes the tooltip layout in comparison mode where delta values caused misaligned columns.

## Problem

When comparison mode is enabled in the tooltip settings, the delta value (difference between hovered and pinned feature) was rendered as an inline `<span>` inside the value `<td>`. Since the CSS grid for `.map-popover__layer-info > table` only defined 2 columns (`auto auto`), the delta values broke the layout, causing scattered and misaligned columns.

## Fix

1. **`layer-hover-info.tsx`**: Moved the delta value from an inline `<span>` to a separate `<td>` element. Added an `isComparing` prop to `Row` so that all rows consistently render a third column when comparison mode is active, keeping the grid aligned.

2. **`map-popover.tsx`**: Added a CSS rule using the `:has()` selector to switch to a 3-column grid when any delta value cell is present:
   ```css
   .map-popover__layer-info > table:has(td.row__delta-value) {
     grid-template-columns: auto auto auto;
   }
   ```

### Before
| Name | Value + Delta (crammed) |
|------|------------------------|

### After  
| Name | Value | Delta |
|------|-------|-------|

Closes #1641