### PR TITLE
feat: add support to DECIMAL duckdb column type

### DIFF
--- a/src/duckdb/src/table/duckdb-table-utils.ts
+++ b/src/duckdb/src/table/duckdb-table-utils.ts
@@ -140,9 +140,13 @@ export function castDuckDBTypesForKepler(
       return `ST_AsWKB(${quotedColumnName}) as ${quotedColumnName}`;
     } else if (
       options.bigIntToDouble &&
-      (type === 'BIGINT' || type === 'UBIGINT' || type === 'HUGEINT' || type === 'UHUGEINT')
+      (type === 'BIGINT' ||
+        type === 'UBIGINT' ||
+        type === 'HUGEINT' ||
+        type === 'UHUGEINT' ||
+        type.startsWith('DECIMAL'))
     ) {
-      // Cast 64-bit and larger integer types to DOUBLE to avoid BigInt in JS
+      // Cast 64-bit and larger integer types and DECIMAL to DOUBLE to avoid BigInt in JS
       return `CAST(${quotedColumnName} AS DOUBLE) as ${quotedColumnName}`;
     }
     return quotedColumnName;

--- a/test/node/utils/duckdb-utils-test.js
+++ b/test/node/utils/duckdb-utils-test.js
@@ -95,6 +95,24 @@ test('duckdb-utils -> castDuckDBTypesForKepler options', t => {
   t.end();
 });
 
+// Test castDuckDBTypesForKepler with DECIMAL types
+test('duckdb-utils -> castDuckDBTypesForKepler with DECIMAL', t => {
+  const tableName = 'test_table';
+  const columns = [
+    {name: 'id', type: 'INTEGER'},
+    {name: 'price', type: 'DECIMAL(18,2)'},
+    {name: 'amount', type: 'DECIMAL'},
+    {name: 'rate', type: 'DECIMAL(10,5)'}
+  ];
+
+  const result = castDuckDBTypesForKepler(tableName, columns);
+
+  const resultMock = `SELECT "id", CAST("price" AS DOUBLE) as "price", CAST("amount" AS DOUBLE) as "amount", CAST("rate" AS DOUBLE) as "rate" FROM "test_table"`;
+  t.equal(result, resultMock, 'should cast DECIMAL types to DOUBLE');
+
+  t.end();
+});
+
 // Test castDuckDBTypesForKepler
 test('duckdb-utils -> castDuckDBTypesForKepler with complex table name', t => {
   const tableName = '"memory"."main"."earthquakes"';


### PR DESCRIPTION
ISSUE: DECIMAL duckdb columns have been parsed as `string` type in kepler