### PR TITLE
Fix #3122: [Bug] Time series animation mini plot line graph is taking s

### DIFF
--- a/src/utils/src/plot.ts
+++ b/src/utils/src/plot.ts
@@ -698,6 +698,6 @@ export function getDefaultPlotType(filter, datasets) {
     interval,
     defaultTimeFormat,
     type: PLOT_TYPES.histogram,
-    aggregation: AGGREGATION_TYPES.sum
+    aggregation: AGGREGATION_TYPES.average
   };
 }


### PR DESCRIPTION
Fixes #3122

## Summary
This PR addresses: [Bug] Time series animation mini plot line graph is taking sum of all values for a selected y-field

## Changes
```
src/utils/src/plot.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*