### PR TITLE
Fix #3225: [Bug] Kepler.gl 3.2.0 + Next.js 15.5.6 -  KeplerMap fails to

### DIFF
--- a/src/processors/src/file-handler.ts
+++ b/src/processors/src/file-handler.ts
@@ -5,7 +5,6 @@ import {parseInBatches} from '@loaders.gl/core';
 import {JSONLoader, _JSONPath} from '@loaders.gl/json';
 import {CSVLoader} from '@loaders.gl/csv';
 import {GeoArrowLoader} from '@loaders.gl/arrow';
-import {ParquetWasmLoader} from '@loaders.gl/parquet';
 import {Loader} from '@loaders.gl/loader-utils';
 import {
   isPlainObject,
@@ -183,6 +182,7 @@ export async function readFileInBatches({
   loaders: Loader[];
   loadOptions: any;
 }): Promise<AsyncGenerator> {
+  const {ParquetWasmLoader} = await import('@loaders.gl/parquet');
   loaders = [JSONLoader, CSVLoader, GeoArrowLoader, ParquetWasmLoader, ...loaders];
   loadOptions = {
     csv: CSV_LOADER_OPTIONS,


### PR DESCRIPTION
Fixes #3225

## Summary
This PR addresses: [Bug] Kepler.gl 3.2.0 + Next.js 15.5.6 -  KeplerMap fails to load

## Changes
```
src/processors/src/file-handler.ts | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*