### PR TITLE
fix: colors not working in trip layer of TABLE mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ build/
 umd/
 */**/dist/
 
+__pycache__/
+.pytest_cache/
+.ipynb_checkpoints/
+bindings/python/keplergl/static/
 typedoc/
 
 examples/**/yarn.lock

--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -515,10 +515,13 @@ export default class GeoJsonLayer extends Layer {
     let dataAccessor;
     if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
       filterValueAccessor = (dc, d, fieldIndex) => dc.valueAt(d.properties.index, fieldIndex);
+      // For GEOJSON mode, properties.index is the row index in the data container
       dataAccessor = () => d => ({index: d.properties.index});
     } else {
       filterValueAccessor = getTableModeValueAccessor;
-      dataAccessor = () => d => ({index: d.properties.index});
+      // For TABLE mode, properties.index is the feature index (not row index).
+      // Use the first row from properties.values to get field values for color/size.
+      dataAccessor = () => d => d.properties.values[0];
     }
 
     const indexAccessor = f => f.properties.index;

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -362,15 +362,20 @@ export default class TripLayer extends Layer {
     const {data} = this.updateData(datasets, oldLayerData);
 
     let valueAccessor;
+    let dataAccessor;
     if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
       valueAccessor = (dc: DataContainerInterface, f, fieldIndex: number) => {
         return dc.valueAt(f.properties.index, fieldIndex);
       };
+      // For GEOJSON mode, properties.index is the row index in the data container
+      dataAccessor = () => d => ({index: d.properties.index});
     } else {
       valueAccessor = getTableModeValueAccessor;
+      // For TABLE mode, properties.index is the feature index (not row index).
+      // Use the first row from properties.values to get field values for color/size.
+      dataAccessor = () => d => d.properties.values[0];
     }
     const indexAccessor = f => f.properties.index;
-    const dataAccessor = () => d => ({index: d.properties.index});
     const accessors = this.getAttributeAccessors({dataAccessor, dataContainer});
     const getFilterValue = gpuFilter.filterValueAccessor(dataContainer)(
       indexAccessor,


### PR DESCRIPTION
In TABLE mode (when using columns like id/lat/lng/timestamp instead of GeoJSON), the trip layer groups rows by ID to create features. Each feature has:

- properties.index - the feature index (0, 1, 2, ...), NOT a row index
- properties.values - an array of all materialized rows belonging to this trip

The bug is in formatLayerData:
```ts
const dataAccessor = () => d => ({index: d.properties.index});
```
This returns {index: featureIndex}, but when valueAccessor({index: featureIndex}) is called, it looks up row featureIndex in the data container, which is the wrong row.

For TABLE mode, the dataAccessor should return the first row from properties.values:

```ts
if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
  dataAccessor = () => d => ({index: d.properties.index});
} else {
  // TABLE mode: use the first row from properties.values
  dataAccessor = () => d => d.properties.values[0];
}
```