### PR TITLE
[Bug] Fix incorrect boolean parsing for yes/no string values

### DIFF
--- a/src/processors/src/data-processor.ts
+++ b/src/processors/src/data-processor.ts
@@ -51,7 +51,10 @@ function tryParseJsonString(str) {
 export const PARSE_FIELD_VALUE_FROM_STRING = {
   [ALL_FIELD_TYPES.boolean]: {
     valid: (d: unknown): boolean => typeof d === 'boolean',
-    parse: (d: unknown): boolean => d === 'true' || d === 'True' || d === 'TRUE' || d === '1'
+    parse: (d: unknown): boolean => {
+      const s = String(d).toLowerCase();
+      return s === 'true' || s === 'yes' || s === '1';
+    }
   },
   [ALL_FIELD_TYPES.integer]: {
     // @ts-ignore

--- a/test/node/utils/data-processor-test.js
+++ b/test/node/utils/data-processor-test.js
@@ -447,10 +447,45 @@ test('Processor -> parseCsvRowsByFieldType -> boolean', t => {
     type: ALL_FIELD_TYPES.boolean
   };
 
-  const rows = [[null], ['0'], ['1'], ['True'], ['False'], ['0'], ['1'], ['true']];
+  const rows = [
+    [null],
+    ['0'],
+    ['1'],
+    ['True'],
+    ['False'],
+    ['0'],
+    ['1'],
+    ['true'],
+    ['yes'],
+    ['Yes'],
+    ['YES'],
+    ['no'],
+    ['No'],
+    ['NO'],
+    ['TRUE'],
+    ['false'],
+    ['FALSE']
+  ];
 
-  // is parsing '' meaningful, why not false
-  const expected = [[null], [false], [true], [true], [false], [false], [true], [true]];
+  const expected = [
+    [null],
+    [false],
+    [true],
+    [true],
+    [false],
+    [false],
+    [true],
+    [true],
+    [true],
+    [true],
+    [true],
+    [false],
+    [false],
+    [false],
+    [true],
+    [false],
+    [false]
+  ];
 
   parseCsvRowsByFieldType(rows, -1, field, 0);
   t.same(rows, expected, 'should parsed boolean properly');


### PR DESCRIPTION
- Fix boolean field parsing when GeoJSON data contains yes/no string values
- type-analyzer correctly detects yes/no fields as boolean type, but kepler.gl PARSE_FIELD_VALUE_FROM_STRING only recognized true, True, TRUE, and 1 as truthy, causing all yes values to be parsed as false
- Use case-insensitive comparison via String(d).toLowerCase() to align with type-analyzer BOOLEAN_TRUE_VALUES (true, yes) and BOOLEAN_FALSE_VALUES (false, no)
- Expand test coverage for boolean parsing to include yes/no variants and additional case combinations

Closes #3346