### PR TITLE
fix(effects): fixes for effects

### DIFF
--- a/src/components/src/effects/effect-configurator.tsx
+++ b/src/components/src/effects/effect-configurator.tsx
@@ -139,6 +139,34 @@ const RegularSliderWrapper = styled.div.attrs({
   }
 `;
 
+const StyledCheckboxWrapper = styled.div.attrs({
+  className: 'effect-configurator__pp-section-checkbox'
+})`
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+`;
+
+const StyledCheckbox = styled.input`
+  margin-right: 6px;
+  cursor: pointer;
+  accent-color: ${props => props.theme.activeColor};
+`;
+
+const StyledCheckboxLabel = styled.label`
+  font-size: ${props => props.theme.inputFontSize};
+  color: ${props => props.theme.effectPanelTextSecondary1};
+  cursor: pointer;
+  white-space: nowrap;
+`;
+
+const StyledColorCheckboxRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+`;
+
 const COMMON_SLIDER_PROPS = {
   showInput: true,
   isRanged: false,
@@ -148,11 +176,11 @@ const COMMON_SLIDER_PROPS = {
 
 type EffectParameterDescriptionFlattened = {
   name: string;
-  type?: 'number' | 'array' | 'color';
+  type?: 'number' | 'array' | 'color' | 'checkbox';
   label?: string | false | (string | false)[];
   min: number;
   max: number;
-  defaultValue?: number | number[];
+  defaultValue?: number | number[] | boolean;
   index?: number;
 };
 
@@ -325,6 +353,17 @@ export default function EffectConfiguratorFactory(
           };
         }
 
+        if (desc.type === 'checkbox') {
+          return {
+            isCheckbox: true as const,
+            label: typeof desc.label === 'string' ? desc.label : desc.name,
+            paramName: desc.name,
+            checked: Boolean(parameters[desc.name]),
+            onChange: () =>
+              updateEffectConfig(null, id, {parameters: {[desc.name]: !parameters[desc.name]}})
+          };
+        }
+
         const paramName = desc.name;
 
         const rawUniform = uniforms[desc.name];
@@ -396,41 +435,98 @@ export default function EffectConfiguratorFactory(
 
     return (
       <StyledEffectConfigurator key={effect.id}>
-        {flatParameterDescriptions.map((desc, parameterIndex) => {
-          const control = controls[parameterIndex];
-          if (!control) {
-            return null;
-          }
+        {(() => {
+          const elements: React.ReactNode[] = [];
+          let i = 0;
+          while (i < flatParameterDescriptions.length) {
+            const control = controls[i];
+            if (!control) {
+              i++;
+              continue;
+            }
 
-          if ('isColor' in control) {
-            return (
-              <RegularOuterWrapper key={`${effect.id}-${parameterIndex}`}>
-                <CompactColorPicker
-                  label={typeof control.label === 'string' ? control.label : 'Color'}
-                  color={control.color}
-                  onSetColor={
-                    control.onSetColor ??
-                    (() => {
-                      /* noop */
-                    })
-                  }
-                  Icon={ArrowDownSmall}
-                />
+            if ('isColor' in control) {
+              const nextControl = i + 1 < controls.length ? controls[i + 1] : null;
+              if (nextControl && 'isCheckbox' in nextControl) {
+                elements.push(
+                  <StyledColorCheckboxRow key={`${effect.id}-${i}`}>
+                    <CompactColorPicker
+                      label={typeof control.label === 'string' ? control.label : 'Color'}
+                      color={control.color}
+                      onSetColor={
+                        control.onSetColor ??
+                        (() => {
+                          /* noop */
+                        })
+                      }
+                      Icon={ArrowDownSmall}
+                    />
+                    <StyledCheckboxWrapper onClick={nextControl.onChange}>
+                      <StyledCheckbox
+                        type="checkbox"
+                        checked={nextControl.checked}
+                        onChange={nextControl.onChange}
+                        onClick={e => e.stopPropagation()}
+                      />
+                      <StyledCheckboxLabel>{nextControl.label}</StyledCheckboxLabel>
+                    </StyledCheckboxWrapper>
+                  </StyledColorCheckboxRow>
+                );
+                i += 2;
+                continue;
+              }
+
+              elements.push(
+                <RegularOuterWrapper key={`${effect.id}-${i}`}>
+                  <CompactColorPicker
+                    label={typeof control.label === 'string' ? control.label : 'Color'}
+                    color={control.color}
+                    onSetColor={
+                      control.onSetColor ??
+                      (() => {
+                        /* noop */
+                      })
+                    }
+                    Icon={ArrowDownSmall}
+                  />
+                </RegularOuterWrapper>
+              );
+              i++;
+              continue;
+            }
+
+            if ('isCheckbox' in control) {
+              elements.push(
+                <RegularOuterWrapper key={`${effect.id}-${i}`}>
+                  <StyledCheckboxWrapper onClick={control.onChange}>
+                    <StyledCheckbox
+                      type="checkbox"
+                      checked={control.checked}
+                      onChange={control.onChange}
+                      onClick={e => e.stopPropagation()}
+                    />
+                    <StyledCheckboxLabel>{control.label}</StyledCheckboxLabel>
+                  </StyledCheckboxWrapper>
+                </RegularOuterWrapper>
+              );
+              i++;
+              continue;
+            }
+
+            elements.push(
+              <RegularOuterWrapper key={`${effect.id}-${i}`}>
+                {control.label ? (
+                  <RegularSectionTitleWrapper>{control.label}</RegularSectionTitleWrapper>
+                ) : null}
+                <RegularSliderWrapper>
+                  <RangeSlider key={i} {...COMMON_SLIDER_PROPS} {...control} />
+                </RegularSliderWrapper>
               </RegularOuterWrapper>
             );
+            i++;
           }
-
-          return (
-            <RegularOuterWrapper key={`${effect.id}-${parameterIndex}`}>
-              {control.label ? (
-                <RegularSectionTitleWrapper>{control.label}</RegularSectionTitleWrapper>
-              ) : null}
-              <RegularSliderWrapper>
-                <RangeSlider key={parameterIndex} {...COMMON_SLIDER_PROPS} {...control} />
-              </RegularSliderWrapper>
-            </RegularOuterWrapper>
-          );
-        })}
+          return elements;
+        })()}
       </StyledEffectConfigurator>
     );
   };

--- a/src/components/src/effects/effect-configurator.tsx
+++ b/src/components/src/effects/effect-configurator.tsx
@@ -461,11 +461,13 @@ export default function EffectConfiguratorFactory(
                       }
                       Icon={ArrowDownSmall}
                     />
-                    <StyledCheckboxWrapper onClick={nextControl.onChange}>
+                    <StyledCheckboxWrapper
+                      onClick={() => (nextControl as {onChange: () => void}).onChange()}
+                    >
                       <StyledCheckbox
                         type="checkbox"
                         checked={nextControl.checked}
-                        onChange={nextControl.onChange}
+                        onChange={() => (nextControl as {onChange: () => void}).onChange()}
                         onClick={e => e.stopPropagation()}
                       />
                       <StyledCheckboxLabel>{nextControl.label}</StyledCheckboxLabel>
@@ -498,11 +500,13 @@ export default function EffectConfiguratorFactory(
             if ('isCheckbox' in control) {
               elements.push(
                 <RegularOuterWrapper key={`${effect.id}-${i}`}>
-                  <StyledCheckboxWrapper onClick={control.onChange}>
+                  <StyledCheckboxWrapper
+                    onClick={() => (control as {onChange: () => void}).onChange()}
+                  >
                     <StyledCheckbox
                       type="checkbox"
                       checked={control.checked}
-                      onChange={control.onChange}
+                      onChange={() => (control as {onChange: () => void}).onChange()}
                       onClick={e => e.stopPropagation()}
                     />
                     <StyledCheckboxLabel>{control.label}</StyledCheckboxLabel>

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1623,8 +1623,22 @@ export const POSTPROCESSING_EFFECTS: {[key: string]: EffectDescription} = {
       {name: 'density', defaultValue: 0.6, min: 0, max: 1},
       {name: 'height', label: 'Elevation (m)', defaultValue: 50, min: -200, max: 3000},
       {name: 'thickness', label: 'Transition (m)', defaultValue: 50, min: 0, max: 1000},
-      {name: 'fogColor', type: 'color', label: 'Fog Color', min: 0, max: 255, defaultValue: [230, 235, 242]},
-      {name: 'pattern', type: 'checkbox', label: 'Show Pattern', defaultValue: false, min: 0, max: 1}
+      {
+        name: 'fogColor',
+        type: 'color',
+        label: 'Fog Color',
+        min: 0,
+        max: 255,
+        defaultValue: [230, 235, 242]
+      },
+      {
+        name: 'pattern',
+        type: 'checkbox',
+        label: 'Show Pattern',
+        defaultValue: false,
+        min: 0,
+        max: 1
+      }
     ]
   }
 };

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1621,9 +1621,10 @@ export const POSTPROCESSING_EFFECTS: {[key: string]: EffectDescription} = {
     name: 'Surface Fog',
     parameters: [
       {name: 'density', defaultValue: 0.6, min: 0, max: 1},
-      {name: 'height', label: 'Elevation (m)', defaultValue: 100, min: -200, max: 3000},
-      {name: 'thickness', label: 'Transition (m)', defaultValue: 200, min: 0, max: 1000},
-      {name: 'fogColor', type: 'color', min: 0, max: 255, defaultValue: [230, 235, 242]}
+      {name: 'height', label: 'Elevation (m)', defaultValue: 50, min: -200, max: 3000},
+      {name: 'thickness', label: 'Transition (m)', defaultValue: 50, min: 0, max: 1000},
+      {name: 'fogColor', type: 'color', label: 'Fog Color', min: 0, max: 255, defaultValue: [230, 235, 242]},
+      {name: 'pattern', type: 'checkbox', label: 'Show Pattern', defaultValue: false, min: 0, max: 1}
     ]
   }
 };

--- a/src/effects/src/shader-passes/distance-fog.ts
+++ b/src/effects/src/shader-passes/distance-fog.ts
@@ -19,6 +19,12 @@ uniform distanceFogUniforms {
   float nearPlane;
   float farPlane;
   vec3 fogColor;
+  vec4 invCol0;
+  vec4 invCol1;
+  vec4 invCol2;
+  vec4 invCol3;
+  float viewportWidth;
+  float viewportHeight;
 } distanceFog;
 `;
 
@@ -41,14 +47,48 @@ void main() {
 
   float n = distanceFog.nearPlane;
   float f = distanceFog.farPlane;
-  float eyeZ = n * f / (f - depth * (f - n));
-  float linearDepth = (eyeZ - n) / (f - n);
+
+  bool isBasemap = depth >= 0.999;
+  float linearDepth;
+
+  if (isBasemap) {
+    vec2 screenXY = vec2(
+      coordinate.x * distanceFog.viewportWidth,
+      (1.0 - coordinate.y) * distanceFog.viewportHeight
+    );
+    mat4 invMat = mat4(
+      distanceFog.invCol0,
+      distanceFog.invCol1,
+      distanceFog.invCol2,
+      distanceFog.invCol3
+    );
+    vec4 nearH = invMat * vec4(screenXY, -1.0, 1.0);
+    vec4 farH  = invMat * vec4(screenXY,  1.0, 1.0);
+    vec3 nearP = nearH.xyz / nearH.w;
+    vec3 farP  = farH.xyz / farH.w;
+    float denom = farP.z - nearP.z;
+    float t = abs(denom) > 1e-6 ? -nearP.z / denom : 0.0;
+    linearDepth = clamp(t, 0.0, 1.0);
+  } else {
+    float eyeZ = n * f / (f - depth * (f - n));
+    linearDepth = (eyeZ - n) / (f - n);
+  }
 
   vec3 fogColor = distanceFog.fogColor / 255.0;
   float end = distanceFog.fogStart + distanceFog.fogRange;
   float fogFactor = smoothstep(distanceFog.fogStart, end, linearDepth) * distanceFog.density;
 
-  fragColor = vec4(mix(color.rgb, fogColor, fogFactor), color.a);
+  if (fogFactor <= 0.001) {
+    fragColor = color;
+    return;
+  }
+
+  // Porter-Duff source-over for correct compositing over transparent basemap pixels.
+  vec3 baseRgb = color.a > 0.001 ? color.rgb / color.a : fogColor;
+  vec3 blended = mix(baseRgb, fogColor, fogFactor);
+  vec3 outRgb = blended * fogFactor + color.rgb * (1.0 - fogFactor);
+  float outAlpha = fogFactor + color.a * (1.0 - fogFactor);
+  fragColor = vec4(outRgb, outAlpha);
 }
 `;
 
@@ -73,7 +113,13 @@ const distanceFogModule = {
     fogRange: 'f32',
     nearPlane: 'f32',
     farPlane: 'f32',
-    fogColor: 'vec3<f32>'
+    fogColor: 'vec3<f32>',
+    invCol0: 'vec4<f32>',
+    invCol1: 'vec4<f32>',
+    invCol2: 'vec4<f32>',
+    invCol3: 'vec4<f32>',
+    viewportWidth: 'f32',
+    viewportHeight: 'f32'
   },
   defaultUniforms: {
     density: 0.5,
@@ -81,7 +127,13 @@ const distanceFogModule = {
     fogRange: 0.5,
     nearPlane: 0.1,
     farPlane: 1000,
-    fogColor: [217, 222, 230]
+    fogColor: [217, 222, 230],
+    invCol0: [1, 0, 0, 0],
+    invCol1: [0, 1, 0, 0],
+    invCol2: [0, 0, 1, 0],
+    invCol3: [0, 0, 0, 1],
+    viewportWidth: 1,
+    viewportHeight: 1
   },
   propTypes: {
     density: {value: 0.5, min: 0, max: 1},
@@ -89,7 +141,13 @@ const distanceFogModule = {
     fogRange: {value: 0.5, min: 0.01, max: 1},
     fogColor: {value: [217, 222, 230]},
     nearPlane: {value: 0.1, private: true},
-    farPlane: {value: 1000, private: true}
+    farPlane: {value: 1000, private: true},
+    invCol0: {value: [1, 0, 0, 0], private: true},
+    invCol1: {value: [0, 1, 0, 0], private: true},
+    invCol2: {value: [0, 0, 1, 0], private: true},
+    invCol3: {value: [0, 0, 0, 1], private: true},
+    viewportWidth: {value: 1, private: true},
+    viewportHeight: {value: 1, private: true}
   }
 } as const satisfies ShaderModule;
 
@@ -98,6 +156,8 @@ const distanceFogModule = {
  * camera-to-fragment distance. The raw depth buffer values are linearized
  * using the camera's near/far planes (extracted from the viewport projection
  * matrix) so that the fog gradient is perceptually uniform with distance.
+ * Basemap pixels (no depth) use ray-ground-plane intersection to compute
+ * their true linear depth so fog fades correctly with distance.
  */
 export class DeckDistanceFogEffect {
   id = 'distance-fog-effect';
@@ -147,16 +207,25 @@ export class DeckDistanceFogEffect {
 
     if (!this.model) return inputBuffer;
 
-    // Distance fog always runs first among post-processing effects
-    // (enforced by fixEffectOrder), so inputBuffer is always the scene
-    // render target with valid depth data.
     const depthAttachment = inputBuffer.depthStencilAttachment;
     if (!depthAttachment) return inputBuffer;
 
     let nearPlane = 0.1;
     let farPlane = 1000;
+    let invCol0 = [1, 0, 0, 0];
+    let invCol1 = [0, 1, 0, 0];
+    let invCol2 = [0, 0, 1, 0];
+    let invCol3 = [0, 0, 0, 1];
+    let viewportWidth = 1;
+    let viewportHeight = 1;
+
     if (params.viewports?.length > 0) {
-      const pm = params.viewports[0].projectionMatrix;
+      const viewport = params.viewports[0];
+
+      viewportWidth = viewport.width;
+      viewportHeight = viewport.height;
+
+      const pm = viewport.projectionMatrix;
       if (pm) {
         const n = pm[14] / (pm[10] - 1);
         const f = pm[14] / (pm[10] + 1);
@@ -164,6 +233,14 @@ export class DeckDistanceFogEffect {
           nearPlane = n;
           farPlane = f;
         }
+      }
+
+      const pum = viewport.pixelUnprojectionMatrix;
+      if (pum) {
+        invCol0 = [pum[0], pum[1], pum[2], pum[3]];
+        invCol1 = [pum[4], pum[5], pum[6], pum[7]];
+        invCol2 = [pum[8], pum[9], pum[10], pum[11]];
+        invCol3 = [pum[12], pum[13], pum[14], pum[15]];
       }
     }
 
@@ -181,7 +258,13 @@ export class DeckDistanceFogEffect {
         fogRange: this.props.fogRange,
         nearPlane,
         farPlane,
-        fogColor: this.props.fogColor
+        fogColor: this.props.fogColor,
+        invCol0,
+        invCol1,
+        invCol2,
+        invCol3,
+        viewportWidth,
+        viewportHeight
       }
     });
 

--- a/src/effects/src/shader-passes/surface-fog.ts
+++ b/src/effects/src/shader-passes/surface-fog.ts
@@ -11,6 +11,8 @@ export type SurfaceFogProps = {
   /** Vertical transition zone in meters above the ceiling. */
   thickness: number;
   fogColor: [number, number, number];
+  /** When true, render a static wave/water pattern instead of plain fog. */
+  pattern: boolean;
 };
 
 const SURFACE_FOG_UNIFORM_BLOCK = /* glsl */ `\
@@ -25,6 +27,8 @@ uniform surfaceFogUniforms {
   vec4 invCol3;
   float viewportWidth;
   float viewportHeight;
+  float unitsPerMeter;
+  float pattern;
 } surfaceFog;
 `;
 
@@ -41,25 +45,99 @@ in vec2 uv;
 
 out vec4 fragColor;
 
+// --- Gradient noise for pattern detail ---
+
+vec2 hashGrad(vec2 p) {
+  vec2 k = vec2(0.3183099, 0.3678794);
+  p = p * k + k.yx;
+  vec2 h = fract(p.x * p.y * (p.x + p.y) * vec2(127.1, 311.7));
+  return normalize(h * 2.0 - 1.0);
+}
+
+float noise2d(vec2 p) {
+  vec2 i = floor(p);
+  vec2 f = fract(p);
+  vec2 u = f * f * f * (f * (f * 6.0 - 15.0) + 10.0);
+  float n00 = dot(hashGrad(i), f);
+  float n10 = dot(hashGrad(i + vec2(1.0, 0.0)), f - vec2(1.0, 0.0));
+  float n01 = dot(hashGrad(i + vec2(0.0, 1.0)), f - vec2(0.0, 1.0));
+  float n11 = dot(hashGrad(i + vec2(1.0, 1.0)), f - vec2(1.0, 1.0));
+  return mix(mix(n00, n10, u.x), mix(n01, n11, u.x), u.y);
+}
+
+// 3-octave FBM with rotation to break axis-alignment.
+float fbm(vec2 p) {
+  float v = 0.0;
+  float a = 0.5;
+  mat2 rot = mat2(0.8, 0.6, -0.6, 0.8);
+  for (int i = 0; i < 3; i++) {
+    v += a * noise2d(p);
+    p = rot * p * 2.0;
+    a *= 0.5;
+  }
+  return v;
+}
+
+// Wave normal from layered sine trains + multi-octave noise.
+vec3 waveNormal(vec2 m) {
+  float normalScale = 6.0;
+  vec2 dh = vec2(0.0);
+  float p;
+
+  // Low-frequency pattern
+  p = dot(m, vec2( 0.014,  0.008)); dh += cos(p) * 0.50 * vec2( 0.014,  0.008);
+  p = dot(m, vec2(-0.009,  0.019)); dh += cos(p) * 0.40 * vec2(-0.009,  0.019);
+  p = dot(m, vec2( 0.022, -0.011)); dh += cos(p) * 0.30 * vec2( 0.022, -0.011);
+  p = dot(m, vec2(-0.005, -0.025)); dh += cos(p) * 0.25 * vec2(-0.005, -0.025);
+
+  // Mid-frequency pattern
+  p = dot(m, vec2( 0.041,  0.029)); dh += cos(p) * 0.18 * vec2( 0.041,  0.029);
+  p = dot(m, vec2(-0.033,  0.037)); dh += cos(p) * 0.15 * vec2(-0.033,  0.037);
+  p = dot(m, vec2( 0.057, -0.019)); dh += cos(p) * 0.10 * vec2( 0.057, -0.019);
+  p = dot(m, vec2(-0.018, -0.051)); dh += cos(p) * 0.08 * vec2(-0.018, -0.051);
+
+  // High-frequency pattern for fine detail when zoomed in
+  p = dot(m, vec2( 0.083,  0.061)); dh += cos(p) * 0.06 * vec2( 0.083,  0.061);
+  p = dot(m, vec2(-0.071,  0.089)); dh += cos(p) * 0.05 * vec2(-0.071,  0.089);
+  p = dot(m, vec2( 0.097, -0.067)); dh += cos(p) * 0.04 * vec2( 0.097, -0.067);
+  p = dot(m, vec2(-0.059, -0.103)); dh += cos(p) * 0.04 * vec2(-0.059, -0.103);
+  p = dot(m, vec2( 0.131,  0.047)); dh += cos(p) * 0.03 * vec2( 0.131,  0.047);
+  p = dot(m, vec2(-0.113,  0.127)); dh += cos(p) * 0.03 * vec2(-0.113,  0.127);
+
+  // Very high-frequency pattern for close-up detail
+  p = dot(m, vec2( 0.173, -0.139)); dh += cos(p) * 0.025 * vec2( 0.173, -0.139);
+  p = dot(m, vec2(-0.149,  0.181)); dh += cos(p) * 0.020 * vec2(-0.149,  0.181);
+  p = dot(m, vec2( 0.211,  0.157)); dh += cos(p) * 0.018 * vec2( 0.211,  0.157);
+  p = dot(m, vec2(-0.193, -0.167)); dh += cos(p) * 0.015 * vec2(-0.193, -0.167);
+
+  // Multi-octave noise via FBM for organic variation
+  float eps = 0.5;
+  float nc = fbm(m * 0.04);
+  float nx = fbm((m + vec2(eps, 0.0)) * 0.04);
+  float ny = fbm((m + vec2(0.0, eps)) * 0.04);
+  dh += vec2(nc - nx, nc - ny) * (0.4 / eps);
+
+  return normalize(vec3(-dh.x * normalScale, 1.0, -dh.y * normalScale));
+}
+
+const vec3 SUN_DIR   = normalize(vec3(0.3, 0.8, 0.5));
+const vec3 SUN_COLOR = vec3(1.0, 0.95, 0.8);
+
+void sunLight(vec3 normal, vec3 eyeDir, float shiny, float spec, float diff,
+              inout vec3 diffuseOut, inout vec3 specularOut) {
+  vec3 refl = normalize(reflect(-SUN_DIR, normal));
+  float d = max(0.0, dot(eyeDir, refl));
+  specularOut += pow(d, shiny) * SUN_COLOR * spec;
+  diffuseOut  += max(dot(SUN_DIR, normal), 0.0) * SUN_COLOR * diff;
+}
+
 void main() {
   vec4 color = texture(texSrc, coordinate);
   float depth = texture(texDepth, coordinate).r;
 
-  if (depth >= 0.999) {
-    fragColor = color;
-    return;
-  }
-
-  // pixelUnprojectionMatrix maps (pixelX, pixelY, clipZ) → common space.
-  // coordinate is 0..1 UV; convert to CSS pixel coords matching deck.gl convention
-  // (origin top-left, y-down).
-  // Depth buffer stores [0,1]; convert to clip-space Z [-1,1] (WebGL NDC).
-  // Must use viewport CSS dimensions (not texture device-pixel size) because
-  // pixelUnprojectionMatrix is built from CSS-pixel width/height.
-  vec3 pixelPos = vec3(
+  vec2 screenXY = vec2(
     coordinate.x * surfaceFog.viewportWidth,
-    (1.0 - coordinate.y) * surfaceFog.viewportHeight,
-    depth * 2.0 - 1.0
+    (1.0 - coordinate.y) * surfaceFog.viewportHeight
   );
 
   mat4 invMat = mat4(
@@ -69,19 +147,80 @@ void main() {
     surfaceFog.invCol3
   );
 
-  vec4 commonPos = invMat * vec4(pixelPos, 1.0);
-  commonPos /= commonPos.w;
+  bool isBasemap = depth >= 0.999;
+  bool usePattern = surfaceFog.pattern > 0.5;
 
-  // commonPos.z is elevation in common-space units.
-  // fogHeight and fogThickness are pre-converted to the same units on CPU.
-  // Below fogHeight: full fog.
-  // fogHeight → fogHeight + fogThickness: smooth transition.
-  // Above fogHeight + fogThickness: no fog.
-  float fogFactor = (1.0 - smoothstep(surfaceFog.fogHeight, surfaceFog.fogHeight + surfaceFog.fogThickness, commonPos.z))
-                    * surfaceFog.density;
+  float submersion;
+  float fogFactor;
+  vec2 worldMeters = vec2(0.0);
+
+  if (isBasemap) {
+    // Basemap sits at z=0 in common space.
+    float groundZ = 0.0;
+    submersion = 1.0 - smoothstep(surfaceFog.fogHeight,
+                                   surfaceFog.fogHeight + surfaceFog.fogThickness,
+                                   groundZ);
+    fogFactor = submersion * surfaceFog.density;
+    if (fogFactor <= 0.001) {
+      fragColor = color;
+      return;
+    }
+    vec4 nearH = invMat * vec4(screenXY, -1.0, 1.0);
+    vec4 farH  = invMat * vec4(screenXY,  1.0, 1.0);
+    vec3 nearP = nearH.xyz / nearH.w;
+    vec3 farP  = farH.xyz / farH.w;
+    float denom = farP.z - nearP.z;
+    float t = abs(denom) > 1e-6 ? -nearP.z / denom : 0.0;
+    vec2 groundXY = nearP.xy + t * (farP.xy - nearP.xy);
+    worldMeters = groundXY / surfaceFog.unitsPerMeter;
+  } else {
+    vec4 commonPos = invMat * vec4(screenXY, depth * 2.0 - 1.0, 1.0);
+    commonPos /= commonPos.w;
+    submersion = 1.0 - smoothstep(surfaceFog.fogHeight,
+                                   surfaceFog.fogHeight + surfaceFog.fogThickness,
+                                   commonPos.z);
+    fogFactor = submersion * surfaceFog.density;
+    if (usePattern) {
+      worldMeters = commonPos.xy / surfaceFog.unitsPerMeter;
+    }
+  }
+
+  if (fogFactor <= 0.001) {
+    fragColor = color;
+    return;
+  }
 
   vec3 fogColorNorm = surfaceFog.fogColor / 255.0;
-  fragColor = vec4(mix(color.rgb, fogColorNorm, clamp(fogFactor, 0.0, 1.0)), color.a);
+
+  if (!usePattern) {
+    // Plain fog — Porter-Duff source-over for basemap coverage.
+    float ff = clamp(fogFactor, 0.0, 1.0);
+    vec3 baseRgb = color.a > 0.001 ? color.rgb / color.a : fogColorNorm;
+    vec3 blended = mix(baseRgb, fogColorNorm, ff);
+    vec3 outRgb = blended * ff + color.rgb * (1.0 - ff);
+    float outAlpha = ff + color.a * (1.0 - ff);
+    fragColor = vec4(outRgb, outAlpha);
+    return;
+  }
+
+  // --- Pattern mode ---
+
+  vec3 N = waveNormal(worldMeters);
+  vec3 eyeDir = vec3(0.0, 1.0, 0.0);
+  vec3 diffuse  = vec3(0.0);
+  vec3 specular = vec3(0.0);
+  sunLight(N, eyeDir, 100.0, 2.0, 0.5, diffuse, specular);
+
+  vec3 baseRgb = color.a > 0.001 ? color.rgb / color.a : fogColorNorm;
+  vec3 tinted = mix(baseRgb, fogColorNorm, submersion);
+  vec3 waterSurface = clamp(tinted * (diffuse + vec3(0.1)) + specular, 0.0, 1.0);
+
+  // Porter-Duff source-over so the effect is visible on transparent basemap areas.
+  float wf = clamp(fogFactor, 0.0, 1.0);
+  vec3 outRgb = waterSurface * wf + color.rgb * (1.0 - wf);
+  float outAlpha = wf + color.a * (1.0 - wf);
+
+  fragColor = vec4(outRgb, outAlpha);
 }
 `;
 
@@ -110,7 +249,9 @@ const surfaceFogModule = {
     invCol2: 'vec4<f32>',
     invCol3: 'vec4<f32>',
     viewportWidth: 'f32',
-    viewportHeight: 'f32'
+    viewportHeight: 'f32',
+    unitsPerMeter: 'f32',
+    pattern: 'f32'
   },
   defaultUniforms: {
     density: 0.6,
@@ -122,13 +263,16 @@ const surfaceFogModule = {
     invCol2: [0, 0, 1, 0],
     invCol3: [0, 0, 0, 1],
     viewportWidth: 1,
-    viewportHeight: 1
+    viewportHeight: 1,
+    unitsPerMeter: 1,
+    pattern: 0
   },
   propTypes: {
     density: {value: 0.6, min: 0, max: 1},
-    height: {value: 100, min: 0, max: 3000},
-    thickness: {value: 200, min: 0, max: 1000},
+    height: {value: 50, min: -200, max: 3000},
+    thickness: {value: 50, min: 0, max: 1000},
     fogColor: {value: [230, 235, 242]},
+    pattern: {value: 0, min: 0, max: 1},
     fogHeight: {value: 0, private: true},
     fogThickness: {value: 0, private: true},
     invCol0: {value: [1, 0, 0, 0], private: true},
@@ -136,19 +280,18 @@ const surfaceFogModule = {
     invCol2: {value: [0, 0, 1, 0], private: true},
     invCol3: {value: [0, 0, 0, 1], private: true},
     viewportWidth: {value: 1, private: true},
-    viewportHeight: {value: 1, private: true}
+    viewportHeight: {value: 1, private: true},
+    unitsPerMeter: {value: 1, private: true}
   }
 } as const satisfies ShaderModule;
 
 /**
- * Surface Fog Effect — elevation-based ground-level fog.
+ * Surface Fog / Water Effect — elevation-based ground-level fog or ocean overlay.
  *
- * Uses deck.gl's pixelUnprojectionMatrix to reconstruct the common-space
- * position of each fragment from the depth buffer.  The Z component of
- * that position corresponds to the fragment's real-world elevation
- * (scaled by distanceScales.unitsPerMeter).  Fog is applied to all
- * fragments whose elevation is below the user-configured height (meters),
- * with a smooth transition zone controlled by thickness (meters).
+ * When `pattern` is false the effect behaves as a classic flat-colour fog layer.
+ * When `pattern` is true a static wave pattern (layered sine trains + FBM noise,
+ * lit with diffuse+specular sun shading) replaces the flat tint and the
+ * effect also renders over basemap areas via Porter-Duff compositing.
  */
 export class DeckSurfaceFogEffect {
   id = 'surface-fog-effect';
@@ -159,9 +302,10 @@ export class DeckSurfaceFogEffect {
   constructor(props: Partial<SurfaceFogProps> = {}) {
     this.props = {
       density: 0.6,
-      height: 100,
-      thickness: 200,
+      height: 50,
+      thickness: 50,
       fogColor: [230, 235, 242],
+      pattern: false,
       ...props
     };
   }
@@ -189,8 +333,9 @@ export class DeckSurfaceFogEffect {
     Object.assign(this.props, props);
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  preRender(): void {}
+  preRender(): void {
+    // no-op
+  }
 
   postRender(params: any): any {
     const {inputBuffer, swapBuffer, target} = params;
@@ -215,7 +360,6 @@ export class DeckSurfaceFogEffect {
       viewportWidth = viewport.width;
       viewportHeight = viewport.height;
 
-      // pixelUnprojectionMatrix maps (pixelX, pixelY, depth) → common space
       const pum = viewport.pixelUnprojectionMatrix;
       if (pum) {
         invCol0 = [pum[0], pum[1], pum[2], pum[3]];
@@ -233,7 +377,6 @@ export class DeckSurfaceFogEffect {
       }
     }
 
-    // Convert user-facing meters to common-space units for the shader
     const fogHeightCommon = this.props.height * unitsPerMeterZ;
     const fogThicknessCommon = this.props.thickness * unitsPerMeterZ;
 
@@ -255,7 +398,9 @@ export class DeckSurfaceFogEffect {
         invCol2,
         invCol3,
         viewportWidth,
-        viewportHeight
+        viewportHeight,
+        unitsPerMeter: unitsPerMeterZ,
+        pattern: this.props.pattern ? 1.0 : 0.0
       }
     });
 

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -2,10 +2,9 @@
 // Copyright contributors to the kepler.gl project
 
 import {Tile3DLayer as DeckTile3DLayer} from '@deck.gl/geo-layers';
-import {UpdateParameters} from '@deck.gl/core';
 import {Tiles3DLoader, CesiumIonLoader} from '@loaders.gl/3d-tiles';
 import {I3SLoader} from '@loaders.gl/i3s';
-import {Tileset3D, Tile3D, TILE_TYPE} from '@loaders.gl/tiles';
+import {Tileset3D, Tile3D} from '@loaders.gl/tiles';
 
 import Layer from '../base-layer';
 import Tile3DLayerIcon from './tile3d-layer-icon';
@@ -19,6 +18,10 @@ import {
 } from '@kepler.gl/constants';
 import {KeplerTable as KeplerDataset, Datasets as KeplerDatasets} from '@kepler.gl/table';
 import {VisConfigNumber, BindedLayerCallbacks} from '@kepler.gl/types';
+
+// Lazily created patched sublayer classes (see getSubLayerClass below).
+let _PatchedMeshLayer: any = null;
+let _PatchedScenegraphLayer: any = null;
 
 /**
  * Custom DeckTile3DLayer that catches exceptions in _loadTileset and
@@ -69,26 +72,56 @@ class KeplerTile3DLayer extends DeckTile3DLayer {
       });
   }
 
-  // deck.gl's ScenegraphLayer does not recreate its models when
-  // defaultShaderModules change (extensionsChanged flag).  This means
-  // adding/removing the Light & Shadow effect after tiles are loaded
-  // leaves ScenegraphLayer sublayers without the shadow shader module.
-  // SimpleMeshLayer (ArcGIS/I3S) already handles extensionsChanged
-  // correctly, so only invalidate SCENEGRAPH sublayers (Google 3D Tiles).
-  updateState(params: UpdateParameters<this>): void {
-    super.updateState(params);
-    if (params.changeFlags.extensionsChanged) {
-      const {layerMap} = this.state as any;
-      if (layerMap) {
-        for (const key of Object.keys(layerMap)) {
-          const entry = layerMap[key];
-          if (entry.tile?.type === TILE_TYPE.SCENEGRAPH) {
-            entry.layer = null;
-            entry.needsUpdate = true;
+  // deck.gl's ScenegraphLayer and MeshLayer do not correctly handle
+  // defaultShaderModule changes (extensionsChanged flag):
+  //
+  // ScenegraphLayer (Google/Cesium 3D tiles): models are created by
+  // luma.gl's GLTF pipeline with shader modules baked in.
+  // updateState only recreates models when the scenegraph *prop*
+  // changes, completely ignoring extensionsChanged. When the shadow
+  // module is added/removed, existing models keep their old shaders.
+  //
+  // MeshLayer (ArcGIS/I3S): getModel() creates the GPU model with PBR
+  // shader defines (HAS_BASECOLORMAP etc.) but does not set the
+  // corresponding texture bindings (pbr_baseColorSampler etc.).
+  // updateState only calls updatePbrMaterialUniforms when pbrMaterial
+  // *prop* changes, not when the model is recreated via
+  // extensionsChanged. luma.gl skips rendering ("Binding … not found").
+  //
+  // Fix: override getSubLayerClass to return patched sublayer classes.
+  // @ts-ignore protected override
+  protected getSubLayerClass(id: string, DefaultClass: any): any {
+    if (id === 'mesh') {
+      if (!_PatchedMeshLayer) {
+        _PatchedMeshLayer = class extends DefaultClass {
+          updateState(params) {
+            super.updateState(params);
+            if (params.changeFlags.extensionsChanged && this.state?.model) {
+              this.updatePbrMaterialUniforms(this.props.pbrMaterial);
+            }
           }
-        }
+        };
+        (_PatchedMeshLayer as any).layerName = DefaultClass.layerName || 'MeshLayer';
+        (_PatchedMeshLayer as any).defaultProps = DefaultClass.defaultProps;
       }
+      return _PatchedMeshLayer;
     }
+    if (id === 'scenegraph') {
+      if (!_PatchedScenegraphLayer) {
+        _PatchedScenegraphLayer = class extends DefaultClass {
+          updateState(params) {
+            super.updateState(params);
+            if (params.changeFlags.extensionsChanged && this.state?.scenegraph) {
+              this._updateScenegraph();
+            }
+          }
+        };
+        (_PatchedScenegraphLayer as any).layerName = DefaultClass.layerName || 'ScenegraphLayer';
+        (_PatchedScenegraphLayer as any).defaultProps = DefaultClass.defaultProps;
+      }
+      return _PatchedScenegraphLayer;
+    }
+    return super.getSubLayerClass(id, DefaultClass);
   }
 }
 (KeplerTile3DLayer as any).layerName = 'KeplerTile3DLayer';

--- a/src/types/effects.d.ts
+++ b/src/types/effects.d.ts
@@ -3,11 +3,11 @@
 
 type EffectParameterDescription = {
   name: string;
-  type?: 'number' | 'array' | 'color';
+  type?: 'number' | 'array' | 'color' | 'checkbox';
   label?: string | false | (string | false)[];
   min: number;
   max: number;
-  defaultValue?: number | number[];
+  defaultValue?: number | number[] | boolean;
 };
 
 export type EffectDescription = {

--- a/src/utils/src/effect-utils.ts
+++ b/src/utils/src/effect-utils.ts
@@ -245,6 +245,11 @@ export function validateEffectParameters(
       return;
     }
 
+    if (type === 'checkbox') {
+      result[name] = Boolean(property);
+      return;
+    }
+
     const value = Number.isFinite(property) ? clamp([min, max], property) : defaultValue ?? min;
 
     if (value !== undefined) {


### PR DESCRIPTION
- Fix fog effects on basemap pixels: Both Distance Fog and Surface Fog now correctly handle basemap fragments (depth >= 0.999) by using ray-ground-plane intersection via pixelUnprojectionMatrix instead of relying on the depth buffer, which has no valid depth for basemap tiles.
- Fix fog compositing over transparent areas: Replace simple mix() blending with Porter-Duff source-over compositing in both fog shaders so the effect renders correctly on transparent basemap pixels.
- Add "Show Pattern" mode to Surface Fog: A new pattern checkbox toggle enables a stylized water/ocean overlay mode that uses layered sine-wave normal mapping, 3-octave FBM noise, and diffuse+specular sun lighting instead of the plain flat-colour fog.
- Fix Tile3D sublayer shader module invalidation: deck.gl 9's ScenegraphLayer and MeshLayer do not properly react to defaultShaderModules changes (e.g. when adding/removing the Light & Shadow effect). Replaced the previous updateState-based invalidation with getSubLayerClass overrides that patch both sublayer types to re-apply their material/scenegraph state when extensionsChanged fires.
- Add checkbox control type to effect configurator: The effect UI now supports a checkbox parameter type, with smart layout that pairs color pickers with adjacent checkboxes on the same row.