### PR TITLE
fix: fix missing shadertools dependency

### DIFF
--- a/src/deckgl-layers/package.json
+++ b/src/deckgl-layers/package.json
@@ -41,6 +41,7 @@
     "@luma.gl/constants": "^9.2.6",
     "@luma.gl/core": "^9.2.6",
     "@luma.gl/engine": "^9.2.6",
+    "@luma.gl/shadertools": "^9.2.6",
     "@luma.gl/webgl": "^9.2.6",
     "@mapbox/geo-viewport": "^0.4.1",
     "@mapbox/vector-tile": "^1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5164,6 +5164,7 @@ __metadata:
     "@luma.gl/constants": "npm:^9.2.6"
     "@luma.gl/core": "npm:^9.2.6"
     "@luma.gl/engine": "npm:^9.2.6"
+    "@luma.gl/shadertools": "npm:^9.2.6"
     "@luma.gl/webgl": "npm:^9.2.6"
     "@mapbox/geo-viewport": "npm:^0.4.1"
     "@mapbox/vector-tile": "npm:^1.3.1"


### PR DESCRIPTION
fix missing shadertools dependency - 

VM1999 index.js:1 11:11:04.475 › [Preload] Script starting...
raster-layer-shaders.ts:4 Uncaught SyntaxError: The requested module '/@fs/Users/bdjulbic/IdeaProjects/mint/new/fsq-spatial-desktop/packages/electron-app/node_modules/.vite/deps/@luma__gl_shadertools.js?v=0923d359' does not provide an export named 'ShaderAssembler' (at raster-layer-shaders.ts:4:9)
VM1996 renderer_init:2 Electron Security Warning (Insecure Content-Security-Policy) This renderer process has either no Content Security
  Policy set or a policy with "unsafe-eval" enabled. This exposes users of
  this app to unnecessary security risks.