### PR TITLE
fix: updates to attribution logic for tiled layers

### DIFF
--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -162,39 +162,43 @@ export const mapStateSelector = createSelector(
   }
 );
 
-export const mapFieldsSelector = (props: KeplerGLProps, index = 0) => ({
-  getMapboxRef: props.getMapboxRef,
-  mapboxApiAccessToken: props.mapboxApiAccessToken,
-  mapboxApiUrl: props.mapboxApiUrl ? props.mapboxApiUrl : DEFAULT_KEPLER_GL_PROPS.mapboxApiUrl,
-  mapState: mapStateSelector(props, index),
-  datasetAttributions: attributionSelector(props).sources,
-  mapStyle: props.mapStyle,
-  onDeckInitialized: props.onDeckInitialized,
-  onViewStateChange: props.onViewStateChange,
-  onMouseMove: props.onMouseMove,
-  deckGlProps: props.deckGlProps,
-  uiStateActions: props.uiStateActions,
-  visStateActions: props.visStateActions,
-  mapStateActions: props.mapStateActions,
+export const mapFieldsSelector = (props: KeplerGLProps, index = 0) => {
+  const attribution = attributionSelector(props);
+  return {
+    getMapboxRef: props.getMapboxRef,
+    mapboxApiAccessToken: props.mapboxApiAccessToken,
+    mapboxApiUrl: props.mapboxApiUrl ? props.mapboxApiUrl : DEFAULT_KEPLER_GL_PROPS.mapboxApiUrl,
+    mapState: mapStateSelector(props, index),
+    datasetAttributions: attribution.sources,
+    attributionLogos: attribution.logos,
+    mapStyle: props.mapStyle,
+    onDeckInitialized: props.onDeckInitialized,
+    onViewStateChange: props.onViewStateChange,
+    onMouseMove: props.onMouseMove,
+    deckGlProps: props.deckGlProps,
+    uiStateActions: props.uiStateActions,
+    visStateActions: props.visStateActions,
+    mapStateActions: props.mapStateActions,
 
-  // visState
-  visState: props.visState,
+    // visState
+    visState: props.visState,
 
-  // uiState
-  activeSidePanel: props.uiState.activeSidePanel,
-  mapControls: props.uiState.mapControls,
-  readOnly: props.uiState.readOnly,
-  locale: props.uiState.locale,
-  isLoadingIndicatorVisible: Number(props.visState.loadingIndicatorValue) > 0,
-  sidePanelWidth: props.sidePanelWidth ? props.sidePanelWidth : DEFAULT_KEPLER_GL_PROPS.width,
+    // uiState
+    activeSidePanel: props.uiState.activeSidePanel,
+    mapControls: props.uiState.mapControls,
+    readOnly: props.uiState.readOnly,
+    locale: props.uiState.locale,
+    isLoadingIndicatorVisible: Number(props.visState.loadingIndicatorValue) > 0,
+    sidePanelWidth: props.sidePanelWidth ? props.sidePanelWidth : DEFAULT_KEPLER_GL_PROPS.width,
 
-  // mapStyle
-  topMapContainerProps: props.topMapContainerProps,
-  bottomMapContainerProps: props.bottomMapContainerProps,
+    // mapStyle
+    topMapContainerProps: props.topMapContainerProps,
+    bottomMapContainerProps: props.bottomMapContainerProps,
 
-  // transformRequest for Mapbox basemaps
-  transformRequest: props.transformRequest
-});
+    // transformRequest for Mapbox basemaps
+    transformRequest: props.transformRequest
+  };
+};
 
 export function getVisibleDatasets(datasets) {
   // We don't want Geocoder dataset to be present in SidePanel dataset list
@@ -343,19 +347,50 @@ export const datasetAttributionSelector = createSelector(
 );
 
 /**
- * Deduplicated dataset and layer text attributions and logos.
- * Returns text attributions and logos to display.
+ * Collect unique layer-level attributions from visible layers.
+ * Not memoized because layer.meta is mutated in-place during render
+ * (outside Redux), so the layers array reference doesn't change.
  */
-export const attributionSelector = createSelector(
-  [datasetAttributionSelector],
-  datasetAttributions => {
-    // TODO collect attributions from layers, and merge with dataset attributions here
-    const uniqueTextAttributions = datasetAttributions;
-    const logos: AttributionWithStyle[] = [];
-
-    return {sources: uniqueTextAttributions, logos};
+export function layerAttributionSelector(state: any): AttributionWithStyle[] {
+  const layers: any[] = state.visState.layers;
+  const attributions: AttributionWithStyle[] = [];
+  if (!layers) return attributions;
+  for (const layer of layers) {
+    if (layer.config?.isVisible && layer.meta?.attribution) {
+      const attr = layer.meta.attribution;
+      if (attr.title && !attributions.find(a => a.title === attr.title && a.url === attr.url)) {
+        attributions.push(attr);
+      }
+    }
   }
-);
+  return attributions;
+}
+
+export function attributionSelector(props: any): {
+  sources: DatasetAttribution[];
+  logos: AttributionWithStyle[];
+} {
+  const datasetAttributions = datasetAttributionSelector(props);
+  const layerAttributions = layerAttributionSelector(props);
+
+  const uniqueTextAttributions: DatasetAttribution[] = [...datasetAttributions];
+  const logos: AttributionWithStyle[] = [];
+
+  layerAttributions.forEach(layerAttribution => {
+    if (
+      !uniqueTextAttributions.find(
+        a => a.title === layerAttribution.title && a.url === layerAttribution.url
+      )
+    ) {
+      uniqueTextAttributions.push({title: layerAttribution.title, url: layerAttribution.url});
+    }
+    if (layerAttribution.logoUrl && !logos.find(a => a.logoUrl === layerAttribution.logoUrl)) {
+      logos.push(layerAttribution);
+    }
+  });
+
+  return {sources: uniqueTextAttributions, logos};
+}
 
 export const notificationPanelSelector = (props: KeplerGLProps) => ({
   removeNotification: props.uiStateActions.removeNotification,

--- a/src/components/src/kepler-gl.tsx
+++ b/src/components/src/kepler-gl.tsx
@@ -348,49 +348,67 @@ export const datasetAttributionSelector = createSelector(
 
 /**
  * Collect unique layer-level attributions from visible layers.
- * Not memoized because layer.meta is mutated in-place during render
- * (outside Redux), so the layers array reference doesn't change.
+ * Builds a serialized cache key from attribution values so createSelector
+ * can detect in-place mutations to layer.meta.
  */
-export function layerAttributionSelector(state: any): AttributionWithStyle[] {
-  const layers: any[] = state.visState.layers;
-  const attributions: AttributionWithStyle[] = [];
-  if (!layers) return attributions;
+const layerAttributionKeySelector = (state: any): string => {
+  const layers: any[] = state.visState?.layers;
+  if (!layers) return '';
+  let key = '';
   for (const layer of layers) {
     if (layer.config?.isVisible && layer.meta?.attribution) {
-      const attr = layer.meta.attribution;
-      if (attr.title && !attributions.find(a => a.title === attr.title && a.url === attr.url)) {
-        attributions.push(attr);
-      }
+      const a = layer.meta.attribution;
+      key += `${a.title}\0${a.url}\0${a.logoUrl ?? ''}\0`;
     }
   }
-  return attributions;
-}
+  return key;
+};
 
-export function attributionSelector(props: any): {
-  sources: DatasetAttribution[];
-  logos: AttributionWithStyle[];
-} {
-  const datasetAttributions = datasetAttributionSelector(props);
-  const layerAttributions = layerAttributionSelector(props);
-
-  const uniqueTextAttributions: DatasetAttribution[] = [...datasetAttributions];
-  const logos: AttributionWithStyle[] = [];
-
-  layerAttributions.forEach(layerAttribution => {
-    if (
-      !uniqueTextAttributions.find(
-        a => a.title === layerAttribution.title && a.url === layerAttribution.url
-      )
-    ) {
-      uniqueTextAttributions.push({title: layerAttribution.title, url: layerAttribution.url});
+export const layerAttributionSelector = createSelector(
+  [(state: any) => state.visState?.layers, layerAttributionKeySelector],
+  (layers: any[]): AttributionWithStyle[] => {
+    const attributions: AttributionWithStyle[] = [];
+    if (!layers) return attributions;
+    for (const layer of layers) {
+      if (layer.config?.isVisible && layer.meta?.attribution) {
+        const attr = layer.meta.attribution;
+        if (attr.title && !attributions.find(a => a.title === attr.title && a.url === attr.url)) {
+          attributions.push(attr);
+        }
+      }
     }
-    if (layerAttribution.logoUrl && !logos.find(a => a.logoUrl === layerAttribution.logoUrl)) {
-      logos.push(layerAttribution);
-    }
-  });
+    return attributions;
+  }
+);
 
-  return {sources: uniqueTextAttributions, logos};
-}
+export const attributionSelector = createSelector(
+  [datasetAttributionSelector, layerAttributionSelector],
+  (
+    datasetAttributions: DatasetAttribution[],
+    layerAttributions: AttributionWithStyle[]
+  ): {
+    sources: DatasetAttribution[];
+    logos: AttributionWithStyle[];
+  } => {
+    const uniqueTextAttributions: DatasetAttribution[] = [...datasetAttributions];
+    const logos: AttributionWithStyle[] = [];
+
+    layerAttributions.forEach(layerAttribution => {
+      if (
+        !uniqueTextAttributions.find(
+          a => a.title === layerAttribution.title && a.url === layerAttribution.url
+        )
+      ) {
+        uniqueTextAttributions.push({title: layerAttribution.title, url: layerAttribution.url});
+      }
+      if (layerAttribution.logoUrl && !logos.find(a => a.logoUrl === layerAttribution.logoUrl)) {
+        logos.push(layerAttribution);
+      }
+    });
+
+    return {sources: uniqueTextAttributions, logos};
+  }
+);
 
 export const notificationPanelSelector = (props: KeplerGLProps) => ({
   removeNotification: props.uiStateActions.removeNotification,

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -315,8 +315,8 @@ const StyledAttributionLogoContainer = styled.div`
   pointer-events: auto;
 `;
 
-const StyledLogoLink = styled.a<{enabled: boolean}>`
-  cursor: ${props => (props.enabled ? 'pointer' : 'default')};
+const StyledLogoLink = styled.a<{$enabled: boolean}>`
+  cursor: ${props => (props.$enabled ? 'pointer' : 'default')};
   display: flex;
   align-items: flex-end;
 `;
@@ -333,10 +333,9 @@ export const AttributionLogos: React.FC<AttributionLogosProps> = ({logos}) => {
         <StyledLogoLink
           key={logo.logoUrl || idx}
           href={logo.url || undefined}
-          target="_blank"
-          rel="noopener noreferrer"
-          enabled={Boolean(logo.url)}
-          style={{bottom: logo.bottom ?? 0}}
+          {...(logo.url ? {target: '_blank', rel: 'noopener noreferrer'} : {})}
+          $enabled={Boolean(logo.url)}
+          style={logo.bottom ? {marginBottom: logo.bottom} : undefined}
         >
           <img src={logo.logoUrl} style={{height: logo.height || 12}} alt={logo.title} />
         </StyledLogoLink>

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -35,6 +35,7 @@ import {
   AggregatedBin
 } from '@kepler.gl/layers';
 import {
+  AttributionWithStyle,
   DatasetAttribution,
   MapState,
   MapControls,
@@ -303,6 +304,47 @@ export const Attribution: React.FC<AttributionProps> = ({
   return memoizedComponents;
 };
 
+const StyledAttributionLogoContainer = styled.div`
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  z-index: 1;
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  pointer-events: auto;
+`;
+
+const StyledLogoLink = styled.a<{enabled: boolean}>`
+  cursor: ${props => (props.enabled ? 'pointer' : 'default')};
+  display: flex;
+  align-items: flex-end;
+`;
+
+type AttributionLogosProps = {
+  logos: AttributionWithStyle[];
+};
+
+export const AttributionLogos: React.FC<AttributionLogosProps> = ({logos}) => {
+  if (!logos?.length) return null;
+  return (
+    <StyledAttributionLogoContainer>
+      {logos.map((logo, idx) => (
+        <StyledLogoLink
+          key={logo.logoUrl || idx}
+          href={logo.url || undefined}
+          target="_blank"
+          rel="noopener noreferrer"
+          enabled={Boolean(logo.url)}
+          style={{bottom: logo.bottom ?? 0}}
+        >
+          <img src={logo.logoUrl} style={{height: logo.height || 12}} alt={logo.title} />
+        </StyledLogoLink>
+      ))}
+    </StyledAttributionLogoContainer>
+  );
+};
+
 MapContainerFactory.deps = [MapPopoverFactory, MapControlFactory, EditorFactory];
 
 type MapboxStyle = string | object | undefined;
@@ -348,6 +390,7 @@ export interface MapContainerProps {
   transformRequest?: (url: string, resourceType?: string) => {url: string};
 
   datasetAttributions?: DatasetAttribution[];
+  attributionLogos?: AttributionWithStyle[];
 
   generateMapboxLayers?: typeof generateMapboxLayers;
   generateDeckGLLayers?: typeof computeDeckLayers;
@@ -1098,6 +1141,7 @@ export default function MapContainerFactory(
         topMapContainerProps,
         theme,
         datasetAttributions = [],
+        attributionLogos = [],
         containerId = 0,
         isLoadingIndicatorVisible,
         activeSidePanel,
@@ -1241,6 +1285,9 @@ export default function MapContainerFactory(
               datasetAttributions={datasetAttributions}
               baseMapLibraryConfig={baseMapLibraryConfig}
             />
+          ) : null}
+          {this.props.primary ? (
+            <AttributionLogos logos={attributionLogos} />
           ) : null}
         </>
       );

--- a/src/components/src/modals/tilesets-modals/load-data-footer.tsx
+++ b/src/components/src/modals/tilesets-modals/load-data-footer.tsx
@@ -32,7 +32,7 @@ const LoadDataFooterContainer = styled.div.attrs({
   display: flex;
   justify-content: space-between;
   padding: 21px 21px 0px 72px;
-  margin: 24px -72px 0;
+  margin: 0 -72px 0;
   align-items: center;
 `;
 

--- a/src/components/src/modals/tilesets-modals/load-tileset.tsx
+++ b/src/components/src/modals/tilesets-modals/load-tileset.tsx
@@ -156,8 +156,6 @@ function LoadTilesetTabFactory() {
       <LoadTilesetTabContainer>
         <Container>
           <div>
-            <StyledHeaderMessage>Tileset Type</StyledHeaderMessage>
-
             <TilesetTypeContainer className="tileset-type">
               {tileTypes.map((tileType, index) => (
                 <TilesetIcon

--- a/src/components/src/modals/tilesets-modals/load-tileset.tsx
+++ b/src/components/src/modals/tilesets-modals/load-tileset.tsx
@@ -72,11 +72,6 @@ const MetaInnerContainer = styled.div<MetaInnerContainerProps>`
   max-width: 600px;
 `;
 
-const StyledHeaderMessage = styled.div`
-  color: ${props => props.theme.textColorLT};
-  font-size: 14px;
-`;
-
 type LoadTilesetTabProps = {
   meta: {[key: string]: any};
   isAddingDatasets: boolean;

--- a/src/components/src/modals/tilesets-modals/tileset-raster-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-raster-form.tsx
@@ -389,35 +389,39 @@ const RasterTileForm: React.FC<RasterTileFormProps> = ({setResponse}) => {
           </TilesetInputDescription>
         </div>
       )}
-      <div>
-        <TilesetInputDescription>For example, try a public raster tileset:</TilesetInputDescription>
-        <ExampleUrlsContainer>
-          <ExampleTabs>
-            {RASTER_TILE_EXAMPLES.map((ex, i) => (
-              <ExampleTab
-                key={`${ex.label}-${ex.name}`}
-                active={exampleTab === i}
-                onClick={() => {
-                  setExampleTab(i);
-                  onExampleClick(ex.url, ex.name);
-                }}
-              >
-                {ex.name}
-              </ExampleTab>
-            ))}
-          </ExampleTabs>
-          <ExampleUrl
-            onClick={() =>
-              onExampleClick(
-                RASTER_TILE_EXAMPLES[exampleTab].url,
-                RASTER_TILE_EXAMPLES[exampleTab].name
-              )
-            }
-          >
-            {RASTER_TILE_EXAMPLES[exampleTab].url}
-          </ExampleUrl>
-        </ExampleUrlsContainer>
-      </div>
+      {getApplicationConfig().showInlineTilesetExamples && (
+        <div>
+          <TilesetInputDescription>
+            For example, try a public raster tileset:
+          </TilesetInputDescription>
+          <ExampleUrlsContainer>
+            <ExampleTabs>
+              {RASTER_TILE_EXAMPLES.map((ex, i) => (
+                <ExampleTab
+                  key={`${ex.label}-${ex.name}`}
+                  active={exampleTab === i}
+                  onClick={() => {
+                    setExampleTab(i);
+                    onExampleClick(ex.url, ex.name);
+                  }}
+                >
+                  {ex.name}
+                </ExampleTab>
+              ))}
+            </ExampleTabs>
+            <ExampleUrl
+              onClick={() =>
+                onExampleClick(
+                  RASTER_TILE_EXAMPLES[exampleTab].url,
+                  RASTER_TILE_EXAMPLES[exampleTab].name
+                )
+              }
+            >
+              {RASTER_TILE_EXAMPLES[exampleTab].url}
+            </ExampleUrl>
+          </ExampleUrlsContainer>
+        </div>
+      )}
     </TilesetInputContainer>
   );
 };

--- a/src/components/src/modals/tilesets-modals/tileset-tile3d-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-tile3d-form.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import {validateUrl} from '@kepler.gl/common-utils';
 import {DatasetType, TILE3D_PROVIDERS, Tile3DDatasetMetadata} from '@kepler.gl/constants';
+import {getApplicationConfig} from '@kepler.gl/utils';
 
 import {MetaResponse, DatasetCreationAttributes} from './common';
 import {InputLight} from '../../common';
@@ -365,32 +366,34 @@ const TilesetTile3DForm: React.FC<Tile3DFormProps> = ({setResponse}) => {
           onChange={onAccessTokenChange}
         />
       </div>
-      <div>
-        <TilesetInputDescription>For example, try a public 3D tileset:</TilesetInputDescription>
-        <ExampleUrlsContainer>
-          <ExampleTabs>
-            {TILE3D_EXAMPLES.map((ex, i) => (
-              <ExampleTab
-                key={ex.label}
-                active={exampleTab === i}
-                onClick={() => {
-                  setExampleTab(i);
-                  onExampleClick(ex.url, ex.name);
-                }}
-              >
-                {ex.label}
-              </ExampleTab>
-            ))}
-          </ExampleTabs>
-          <ExampleUrl
-            onClick={() =>
-              onExampleClick(TILE3D_EXAMPLES[exampleTab].url, TILE3D_EXAMPLES[exampleTab].name)
-            }
-          >
-            {TILE3D_EXAMPLES[exampleTab].url}
-          </ExampleUrl>
-        </ExampleUrlsContainer>
-      </div>
+      {getApplicationConfig().showInlineTilesetExamples && (
+        <div>
+          <TilesetInputDescription>For example, try a public 3D tileset:</TilesetInputDescription>
+          <ExampleUrlsContainer>
+            <ExampleTabs>
+              {TILE3D_EXAMPLES.map((ex, i) => (
+                <ExampleTab
+                  key={ex.label}
+                  active={exampleTab === i}
+                  onClick={() => {
+                    setExampleTab(i);
+                    onExampleClick(ex.url, ex.name);
+                  }}
+                >
+                  {ex.label}
+                </ExampleTab>
+              ))}
+            </ExampleTabs>
+            <ExampleUrl
+              onClick={() =>
+                onExampleClick(TILE3D_EXAMPLES[exampleTab].url, TILE3D_EXAMPLES[exampleTab].name)
+              }
+            >
+              {TILE3D_EXAMPLES[exampleTab].url}
+            </ExampleUrl>
+          </ExampleUrlsContainer>
+        </div>
+      )}
     </TilesetInputContainer>
   );
 };

--- a/src/components/src/modals/tilesets-modals/tileset-vector-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-vector-form.tsx
@@ -16,6 +16,7 @@ import {TileJSON} from '@loaders.gl/mvt';
 import {PMTilesMetadata} from '@loaders.gl/pmtiles';
 import {getMetaUrl, parseVectorMetadata, VectorTileMetadata} from '@kepler.gl/table';
 import {Merge} from '@kepler.gl/types';
+import {getApplicationConfig} from '@kepler.gl/utils';
 
 import {default as useFetchVectorTileMetadata} from '../../hooks/use-fetch-vector-tile-metadata';
 import {DatasetCreationAttributes, MetaResponse} from './common';
@@ -23,7 +24,7 @@ import {InputLight} from '../../common';
 
 const TilesetInputContainer = styled.div`
   display: grid;
-  grid-template-rows: repeat(3, 1fr);
+  grid-template-rows: repeat(4, auto);
   row-gap: 18px;
   font-size: 12px;
 `;
@@ -33,6 +34,59 @@ const TilesetInputDescription = styled.div`
   color: ${props => props.theme.AZURE200};
   font-size: 11px;
 `;
+
+const ExampleUrlsContainer = styled.div`
+  text-align: left;
+  color: ${props => props.theme.AZURE200};
+  font-size: 11px;
+`;
+
+const ExampleTabs = styled.div`
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+`;
+
+const ExampleTab = styled.div<{active: boolean}>`
+  padding: 3px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  white-space: nowrap;
+  background: ${props => (props.active ? props.theme.AZURE400 : 'transparent')};
+  color: ${props => (props.active ? props.theme.WHITE : props.theme.AZURE200)};
+  border: 1px solid ${props => props.theme.AZURE400};
+  &:hover {
+    background: ${props => (props.active ? props.theme.AZURE400 : props.theme.AZURE500)};
+  }
+`;
+
+const ExampleUrl = styled.div`
+  word-break: break-all;
+  cursor: pointer;
+  color: ${props => props.theme.AZURE200};
+  font-size: 11px;
+`;
+
+const VECTOR_TILE_EXAMPLES = [
+  {
+    label: 'MVT',
+    name: 'USA Population',
+    url: 'https://4sq-studio-public.s3.us-west-2.amazonaws.com/vector-tile/cb_v2/{z}/{x}/{y}.pbf'
+  },
+  {
+    label: 'PMTiles',
+    name: 'FSQ Places',
+    url: 'https://fsq-os-places-us-east-1.s3.us-east-1.amazonaws.com/release/vector-tiles/latest/fsq-os-places.pmtiles'
+  },
+  {
+    label: 'PMTiles',
+    name: 'Railways',
+    url: 'https://4sq-studio-public.s3.us-west-2.amazonaws.com/pmtiles-test/161727fe-7952-4e57-aa05-850b3086b0b2.pmtiles'
+  }
+];
 
 export type VectorTilesetFormData = {
   name: string;
@@ -73,6 +127,7 @@ const TilesetVectorForm: React.FC<TilesetVectorFormProps> = ({setResponse}) => {
   const [tileUrl, setTileUrl] = useState<string>('');
   const [metadataUrl, setMetadataUrl] = useState<string | null>('');
   const [initialFetchError, setInitialFetchError] = useState<Error | null>(null);
+  const [exampleTab, setExampleTab] = useState(0);
 
   const onTileNameChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -119,6 +174,14 @@ const TilesetVectorForm: React.FC<TilesetVectorFormProps> = ({setResponse}) => {
     },
     [setTileUrl, tileName, setMetadataUrl, metadataUrl]
   );
+
+  const onExampleClick = useCallback((url: string, name: string) => {
+    const usePMTiles = isPMTilesUrl(url);
+    setTileUrl(url);
+    setTileName(name);
+    setInitialFetchError(null);
+    setMetadataUrl(usePMTiles ? url : getMetaUrl(url));
+  }, []);
 
   const process = useMemo(() => {
     return (value: PMTilesMetadata | TileJSON) =>
@@ -227,6 +290,39 @@ const TilesetVectorForm: React.FC<TilesetVectorFormProps> = ({setResponse}) => {
           Optional, but recommended. Supports json, txt
         </TilesetInputDescription>
       </div>
+      {getApplicationConfig().showInlineTilesetExamples && (
+        <div>
+          <TilesetInputDescription>
+            For example, try a public vector tileset:
+          </TilesetInputDescription>
+          <ExampleUrlsContainer>
+            <ExampleTabs>
+              {VECTOR_TILE_EXAMPLES.map((ex, i) => (
+                <ExampleTab
+                  key={`${ex.label}-${ex.name}`}
+                  active={exampleTab === i}
+                  onClick={() => {
+                    setExampleTab(i);
+                    onExampleClick(ex.url, ex.name);
+                  }}
+                >
+                  {ex.name}
+                </ExampleTab>
+              ))}
+            </ExampleTabs>
+            <ExampleUrl
+              onClick={() =>
+                onExampleClick(
+                  VECTOR_TILE_EXAMPLES[exampleTab].url,
+                  VECTOR_TILE_EXAMPLES[exampleTab].name
+                )
+              }
+            >
+              {VECTOR_TILE_EXAMPLES[exampleTab].url}
+            </ExampleUrl>
+          </ExampleUrlsContainer>
+        </div>
+      )}
     </TilesetInputContainer>
   );
 };

--- a/src/components/src/modals/tilesets-modals/tileset-wms-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-wms-form.tsx
@@ -8,6 +8,7 @@ import {WMSCapabilities} from '@loaders.gl/wms';
 import {validateUrl} from '@kepler.gl/common-utils';
 import {DatasetType, REMOTE_TILE, RemoteTileFormat, WMSDatasetMetadata} from '@kepler.gl/constants';
 import {getWMSCapabilities, wmsCapabilitiesToDatasetMetadata} from '@kepler.gl/table';
+import {getApplicationConfig} from '@kepler.gl/utils';
 
 import {MetaResponse} from './common';
 import {InputLight} from '../../common';
@@ -208,32 +209,34 @@ const TilesetWMSForm: React.FC<WMSTileFormProps> = ({setResponse}) => {
         />
         <TilesetInputDescription>Provide a valid WMS service URL.</TilesetInputDescription>
       </div>
-      <div>
-        <TilesetInputDescription>For example, try a public WMS URL:</TilesetInputDescription>
-        <ExampleUrlsContainer>
-          <ExampleTabs>
-            {WMS_EXAMPLES.map((ex, i) => (
-              <ExampleTab
-                key={ex.label}
-                active={exampleTab === i}
-                onClick={() => {
-                  setExampleTab(i);
-                  onExampleClick(ex.url, ex.name);
-                }}
-              >
-                {ex.label}
-              </ExampleTab>
-            ))}
-          </ExampleTabs>
-          <ExampleUrl
-            onClick={() =>
-              onExampleClick(WMS_EXAMPLES[exampleTab].url, WMS_EXAMPLES[exampleTab].name)
-            }
-          >
-            {WMS_EXAMPLES[exampleTab].url}
-          </ExampleUrl>
-        </ExampleUrlsContainer>
-      </div>
+      {getApplicationConfig().showInlineTilesetExamples && (
+        <div>
+          <TilesetInputDescription>For example, try a public WMS URL:</TilesetInputDescription>
+          <ExampleUrlsContainer>
+            <ExampleTabs>
+              {WMS_EXAMPLES.map((ex, i) => (
+                <ExampleTab
+                  key={ex.label}
+                  active={exampleTab === i}
+                  onClick={() => {
+                    setExampleTab(i);
+                    onExampleClick(ex.url, ex.name);
+                  }}
+                >
+                  {ex.label}
+                </ExampleTab>
+              ))}
+            </ExampleTabs>
+            <ExampleUrl
+              onClick={() =>
+                onExampleClick(WMS_EXAMPLES[exampleTab].url, WMS_EXAMPLES[exampleTab].name)
+              }
+            >
+              {WMS_EXAMPLES[exampleTab].url}
+            </ExampleUrl>
+          </ExampleUrlsContainer>
+        </div>
+      )}
     </TilesetInputContainer>
   );
 };

--- a/src/components/src/modals/tilesets-modals/tileset-wms-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-wms-form.tsx
@@ -169,7 +169,7 @@ const TilesetWMSForm: React.FC<WMSTileFormProps> = ({setResponse}) => {
           tilesetDataUrl: wmsUrl,
           tilesetMetadataUrl: `${wmsUrl}?service=WMS&request=GetCapabilities`,
           layers: wmsData?.layers || [],
-          wmsVersion: wmsData?.version || '1.3.0'
+          version: wmsData?.version || '1.3.0'
         }
       };
       setResponse({

--- a/src/constants/src/dataset.ts
+++ b/src/constants/src/dataset.ts
@@ -75,25 +75,46 @@ export type WMSDatasetMetadata = {
   tilesetMetadataUrl: string;
   version: string;
   layers: {name: string; title: string; boundingBox: number[] | null}[];
+  label?: string;
+  attribution?: string;
+};
+
+export type Tile3DProviderAttribution = {
+  title: string;
+  url: string;
+  logoUrl?: string;
+  height?: number;
+  bottom?: number;
 };
 
 export type Tile3DProvider = {
   name: string;
   urlKey: string;
+  attribution?: Tile3DProviderAttribution;
 };
 
 export const TILE3D_PROVIDERS: Record<string, Tile3DProvider> = {
   google: {
     name: 'Google 3D Tiles',
-    urlKey: 'google'
+    urlKey: 'google',
+    attribution: {
+      title: 'Built with Google Maps.',
+      url: '',
+      logoUrl:
+        'https://studio-public-data.foursquare.com/statics/images/google-watermark-white.png',
+      height: 17,
+      bottom: 0
+    }
   },
   cesium: {
     name: 'Cesium ion',
-    urlKey: 'ion.cesium'
+    urlKey: 'ion.cesium',
+    attribution: {title: 'Cesium.', url: 'https://cesium.com/', height: 19, bottom: 0}
   },
   arcgis: {
     name: 'ArcGIS',
-    urlKey: 'arcgis'
+    urlKey: 'arcgis',
+    attribution: {title: 'Powered by Esri.', url: 'https://arcgis.com/', height: 16}
   }
 };
 

--- a/src/layers/src/raster-tile/raster-tile-layer.ts
+++ b/src/layers/src/raster-tile/raster-tile-layer.ts
@@ -68,6 +68,38 @@ import {
 import {FindDefaultLayerPropsReturnValue} from '../layer-utils';
 import {default as KeplerLayer, LayerBaseConfigPartial} from '../base-layer';
 
+/**
+ * Extract attribution from STAC metadata providers array.
+ * STAC Items carry providers in properties.providers, Collections at top-level.
+ * Falls back to collection name or title when providers are absent.
+ * Returns null when no meaningful attribution can be determined.
+ */
+function extractSTACAttribution(
+  stac: CompleteSTACObject
+): {title: string; url: string} | null {
+  const providers =
+    (stac as any).providers || (stac as any).properties?.providers;
+  if (Array.isArray(providers) && providers.length > 0) {
+    const producer = providers.find(p => p.roles?.includes('producer'));
+    const host = providers.find(p => p.roles?.includes('host'));
+    const provider = producer || host || providers[0];
+    if (provider?.name) {
+      return {title: provider.name, url: provider.url || ''};
+    }
+  }
+
+  const title =
+    (stac as any).title ||
+    (stac as any).properties?.title ||
+    (stac as any).collection;
+  if (title && typeof title === 'string') {
+    const selfLink = ((stac as any).links || []).find(l => l.rel === 'self');
+    return {title, url: selfLink?.href || ''};
+  }
+
+  return null;
+}
+
 // Adjust tileSize to devicePixelRatio, but not higher than 2 to reduce requests to server
 const devicePixelRatio: number = Math.min(
   2,
@@ -286,9 +318,15 @@ export default class RasterTileLayer extends KeplerLayer {
 
     const stac = dataset.metadata;
     if (stac.pmtilesType === PMTilesType.RASTER) {
-      return this.updateMeta({
-        bounds: stac.bounds
-      });
+      const meta: Record<string, any> = {bounds: stac.bounds};
+      const firstAttribution =
+        Array.isArray(stac.attributions) && stac.attributions.length > 0
+          ? stac.attributions[0]
+          : null;
+      if (typeof firstAttribution === 'string' && firstAttribution) {
+        meta.attribution = {title: firstAttribution, url: ''};
+      }
+      return this.updateMeta(meta);
     }
 
     const bounds = getSTACBounds(stac);
@@ -299,6 +337,11 @@ export default class RasterTileLayer extends KeplerLayer {
       if (stac.type === 'Feature') {
         this.updateMeta({bounds});
       }
+    }
+
+    const attribution = extractSTACAttribution(stac);
+    if (attribution) {
+      this.updateMeta({attribution});
     }
   }
 

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -284,6 +284,7 @@ export default class Tile3DLayer extends Layer {
     }
 
     const dataset = datasets[dataId];
+    this.updateLayerMeta(dataset);
     const metadata = (dataset.metadata || {}) as Tile3DDatasetMetadata;
 
     return {
@@ -298,7 +299,10 @@ export default class Tile3DLayer extends Layer {
     }
     const metadata = (dataset.metadata || {}) as Tile3DDatasetMetadata;
     const provider = getTile3DProviderFromUrl(metadata.tile3dUrl);
-    this.updateMeta({provider});
+    this.updateMeta({
+      provider,
+      attribution: provider?.attribution ?? null
+    });
   }
 
   _getDataAndLoaderOptions(
@@ -353,7 +357,8 @@ export default class Tile3DLayer extends Layer {
     this._extractBoundsFromTileset(tileset3d);
 
     const tileUrl = tileset3d.url || '';
-    const isGoogle = getTile3DProviderFromUrl(tileUrl) === TILE3D_PROVIDERS.google;
+    const provider = getTile3DProviderFromUrl(tileUrl);
+    const isGoogle = provider === TILE3D_PROVIDERS.google;
 
     if (!this._hasFittedBounds && this.meta?.bounds && !isGoogle) {
       this._hasFittedBounds = true;
@@ -368,9 +373,14 @@ export default class Tile3DLayer extends Layer {
           if (copyright) copyright.split(';').forEach(c => credits.add(c));
         });
         const title = Array.from(credits).join('; ');
-        this.updateMeta({
-          googleAttribution: title
-        });
+        if (this.meta?.attribution?.title !== title) {
+          this.updateMeta({
+            attribution: {
+              ...TILE3D_PROVIDERS.google.attribution,
+              title
+            }
+          });
+        }
         return selectedTiles;
       };
     }

--- a/src/layers/src/wms-layer/wms-layer.ts
+++ b/src/layers/src/wms-layer/wms-layer.ts
@@ -170,6 +170,17 @@ export default class WMSLayer extends AbstractTileLayer<WMSTile, any[]> {
         bounds: currentLayer.boundingBox
       });
     }
+
+    const metadata = dataset.metadata as WMSDatasetMetadata | undefined;
+    if (metadata?.attribution) {
+      this.updateMeta({
+        attribution: {title: metadata.attribution, url: metadata.tilesetDataUrl || ''}
+      });
+    } else if (metadata?.label) {
+      this.updateMeta({
+        attribution: {title: metadata.label, url: metadata.tilesetDataUrl || ''}
+      });
+    }
   }
 
   hasHoveredObject(objectInfo: any) {

--- a/src/utils/src/application-config.ts
+++ b/src/utils/src/application-config.ts
@@ -83,6 +83,9 @@ export type KeplerApplicationConfig = {
   // WMS layer is under development and not ready for production use. Disabled by default.
   enableWMSLayer?: boolean;
 
+  /** Whether to show example URLs in tileset setup forms (vector tile, raster tile, WMS, 3D tile) */
+  showInlineTilesetExamples?: boolean;
+
   // Image export config
   /** Whether to apply fix for uglify error in dom-to-image (should be true for webpack builds, false for Vite) */
   escapeXhtmlForWebpack?: boolean;
@@ -139,6 +142,8 @@ const DEFAULT_APPLICATION_CONFIG: Required<KeplerApplicationConfig> = {
 
   // WMS layer config
   enableWMSLayer: true,
+
+  showInlineTilesetExamples: true,
 
   // Image export config
   // Default to true for webpack builds, false for other build tools (e.g., Vite)


### PR DESCRIPTION
- fixes for attribution retrieval and display logic for raster tile layer, wms, 3d tile layer
- add inline examples for vector tile layer
- add an application config flag to hide inline examples in Add Tileset modal