### PR TITLE
fix: video export fixes

### DIFF
--- a/src/components/src/modals/export-video-modal.spec.tsx
+++ b/src/components/src/modals/export-video-modal.spec.tsx
@@ -19,6 +19,25 @@ jest.mock('@hubble.gl/react', () => ({
   KeplerUIContext: MockKeplerUIContext
 }));
 
+const mockComputeDeckEffects = jest.fn(() => []);
+
+jest.mock('@kepler.gl/utils', () => {
+  const actual = jest.requireActual('@kepler.gl/utils');
+  return {
+    ...actual,
+    computeDeckEffects: (...args) => mockComputeDeckEffects(...args),
+    patchDeckRendererForPostProcessing: jest.fn()
+  };
+});
+
+jest.mock('@kepler.gl/effects', () => ({
+  DeckShadowCompositingEffect: jest.fn().mockImplementation(() => ({
+    id: 'shadow-compositing-effect',
+    postRender: jest.fn(),
+    cleanup: jest.fn()
+  }))
+}));
+
 jest.mock('./hubble-utils', () => ({
   getStaticMapProps: jest.fn((_state, _onChange, _token) => ({
     latitude: 37.7,
@@ -39,6 +58,7 @@ jest.mock('./hubble-utils', () => ({
 }));
 
 import ExportVideoModalFactory from './export-video-modal';
+import {DeckShadowCompositingEffect} from '@kepler.gl/effects';
 
 function renderWithThemeLocal(component) {
   return render(
@@ -97,6 +117,7 @@ async function renderAndWaitForPanel(props = DEFAULT_PROPS) {
 describe('ExportVideoModal', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockComputeDeckEffects.mockReturnValue([]);
   });
 
   test('renders without crashing', async () => {
@@ -185,5 +206,132 @@ describe('ExportVideoModal', () => {
     const panelProps = mockExportVideoPanelContainer.mock.calls[0][0];
     panelProps.onTripFrameUpdate(42);
     expect(DEFAULT_PROPS.visStateActions.setLayerAnimationTime).toHaveBeenCalledWith(42);
+  });
+
+  describe('NO_MAP_ID handling', () => {
+    const NO_MAP_PROPS = {
+      ...DEFAULT_PROPS,
+      mapStyle: {
+        styleType: 'no_map',
+        mapStyles: {
+          no_map: {
+            id: 'no_map',
+            label: 'No Basemap',
+            // url is intentionally missing to exercise the data-URI patch
+            icon: '',
+            layerGroups: [],
+            colorMode: 'NONE',
+            style: {version: 8, sources: {}, layers: []}
+          }
+        },
+        bottomMapStyle: null,
+        topMapStyle: null
+      }
+    };
+
+    test('renders without crashing when styleType is NO_MAP_ID', async () => {
+      const {container} = await renderAndWaitForPanel(NO_MAP_PROPS);
+      expect(container.querySelector('.export-video-modal')).toBeInTheDocument();
+    });
+
+    test('injects data-URI empty style URL into mapData when NO_MAP_ID entry has no url', async () => {
+      await renderAndWaitForPanel(NO_MAP_PROPS);
+
+      const panelProps = mockExportVideoPanelContainer.mock.calls[0][0];
+      const noMapEntry = panelProps.mapData.mapStyle.mapStyles.no_map;
+
+      expect(noMapEntry.url).toBeDefined();
+      expect(noMapEntry.url).toMatch(/^data:application\/json,/);
+
+      const encoded = noMapEntry.url.replace('data:application/json,', '');
+      const decoded = JSON.parse(decodeURIComponent(encoded));
+      expect(decoded).toEqual({version: 8, sources: {}, layers: []});
+    });
+
+    test('preserves original mapStyle when NO_MAP_ID entry already has a url', async () => {
+      const propsWithUrl = {
+        ...DEFAULT_PROPS,
+        mapStyle: {
+          styleType: 'no_map',
+          mapStyles: {
+            no_map: {
+              id: 'no_map',
+              url: 'https://existing-style.json'
+            }
+          },
+          bottomMapStyle: null,
+          topMapStyle: null
+        }
+      };
+
+      await renderAndWaitForPanel(propsWithUrl);
+
+      const panelProps = mockExportVideoPanelContainer.mock.calls[0][0];
+      expect(panelProps.mapData.mapStyle).toBe(propsWithUrl.mapStyle);
+    });
+  });
+
+  describe('shadow compositing fallback', () => {
+    const mockEffect = {
+      id: 'light-shadow-1',
+      type: 'light-and-shadow',
+      isEnabled: true,
+      clone: jest.fn(() => ({...mockEffect, clone: mockEffect.clone}))
+    };
+
+    function propsWithEffects(effects) {
+      return {
+        ...DEFAULT_PROPS,
+        visState: {
+          ...DEFAULT_PROPS.visState,
+          effects,
+          effectOrder: effects.map(e => e.id)
+        }
+      };
+    }
+
+    test('adds DeckShadowCompositingEffect when shadows exist but no postRender effect', async () => {
+      const shadowDeckEffect = {id: 'lighting', shadow: true};
+      mockComputeDeckEffects.mockReturnValue([shadowDeckEffect]);
+
+      await renderAndWaitForPanel(propsWithEffects([mockEffect]));
+
+      const panelProps = mockExportVideoPanelContainer.mock.calls[0][0];
+      const effects = panelProps.deckProps.effects;
+
+      expect(effects.length).toBe(2);
+      expect(effects[0]).toBe(shadowDeckEffect);
+      expect(effects[1].id).toBe('shadow-compositing-effect');
+      expect(DeckShadowCompositingEffect).toHaveBeenCalled();
+    });
+
+    test('does not add DeckShadowCompositingEffect when a postRender effect already exists', async () => {
+      const shadowDeckEffect = {id: 'lighting', shadow: true};
+      const postProcessEffect = {id: 'fog', postRender: jest.fn()};
+      mockComputeDeckEffects.mockReturnValue([shadowDeckEffect, postProcessEffect]);
+
+      await renderAndWaitForPanel(propsWithEffects([mockEffect]));
+
+      const panelProps = mockExportVideoPanelContainer.mock.calls[0][0];
+      const effects = panelProps.deckProps.effects;
+
+      expect(effects.length).toBe(2);
+      expect(effects[0]).toBe(shadowDeckEffect);
+      expect(effects[1]).toBe(postProcessEffect);
+      expect(effects.every(e => e.id !== 'shadow-compositing-effect')).toBe(true);
+    });
+
+    test('does not add DeckShadowCompositingEffect when no shadow effect exists', async () => {
+      const nonShadowEffect = {id: 'lighting', shadow: false};
+      mockComputeDeckEffects.mockReturnValue([nonShadowEffect]);
+
+      await renderAndWaitForPanel(propsWithEffects([mockEffect]));
+
+      const panelProps = mockExportVideoPanelContainer.mock.calls[0][0];
+      const effects = panelProps.deckProps.effects;
+
+      expect(effects.length).toBe(1);
+      expect(effects[0]).toBe(nonShadowEffect);
+    });
   });
 });

--- a/src/components/src/modals/export-video-modal.tsx
+++ b/src/components/src/modals/export-video-modal.tsx
@@ -7,7 +7,11 @@ import styled, {ThemeProvider, useTheme} from 'styled-components';
 import {DEFAULT_MAPBOX_API_URL, NO_MAP_ID, EMPTY_MAPBOX_STYLE} from '@kepler.gl/constants';
 import {FormattedMessage} from '@kepler.gl/localization';
 import {Viewport, ExportVideo, Effect} from '@kepler.gl/types';
-import {onViewPortChange, computeDeckEffects, patchDeckRendererForPostProcessing} from '@kepler.gl/utils';
+import {
+  onViewPortChange,
+  computeDeckEffects,
+  patchDeckRendererForPostProcessing
+} from '@kepler.gl/utils';
 import {DeckShadowCompositingEffect} from '@kepler.gl/effects';
 import {MapStyle} from '@kepler.gl/reducers';
 import {UIStateActions, VisStateActions} from '@kepler.gl/actions';
@@ -195,7 +199,6 @@ const MODAL_HORIZONTAL_PADDING = 144;
 let _shadowCompositingEffect: InstanceType<typeof DeckShadowCompositingEffect> | null = null;
 
 const ExportVideoModalFactory = () => {
-  patchDeckRendererForPostProcessing();
   const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
     mapboxApiAccessToken,
     mapboxApiUrl = DEFAULT_MAPBOX_API_URL,
@@ -211,10 +214,23 @@ const ExportVideoModalFactory = () => {
     const [hubble, setHubble] = useState<HubbleModule | null>(_hubbleModule);
 
     useEffect(() => {
+      patchDeckRendererForPostProcessing();
+    }, []);
+
+    useEffect(() => {
       if (!hubble) {
         loadHubble().then(setHubble);
       }
     }, [hubble]);
+
+    useEffect(() => {
+      return () => {
+        if (_shadowCompositingEffect) {
+          _shadowCompositingEffect.cleanup();
+          _shadowCompositingEffect = null;
+        }
+      };
+    }, []);
 
     const exportVideoWidth = useMemo(() => {
       const modalInnerW =

--- a/src/components/src/modals/export-video-modal.tsx
+++ b/src/components/src/modals/export-video-modal.tsx
@@ -4,10 +4,11 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import styled, {ThemeProvider, useTheme} from 'styled-components';
 
-import {DEFAULT_MAPBOX_API_URL} from '@kepler.gl/constants';
+import {DEFAULT_MAPBOX_API_URL, NO_MAP_ID, EMPTY_MAPBOX_STYLE} from '@kepler.gl/constants';
 import {FormattedMessage} from '@kepler.gl/localization';
 import {Viewport, ExportVideo, Effect} from '@kepler.gl/types';
-import {onViewPortChange, computeDeckEffects} from '@kepler.gl/utils';
+import {onViewPortChange, computeDeckEffects, patchDeckRendererForPostProcessing} from '@kepler.gl/utils';
+import {DeckShadowCompositingEffect} from '@kepler.gl/effects';
 import {MapStyle} from '@kepler.gl/reducers';
 import {UIStateActions, VisStateActions} from '@kepler.gl/actions';
 
@@ -191,7 +192,10 @@ const HUBBLE_PANEL_OVERHEAD = 2 * 32 + 24 + 280;
 const EXPORT_VIDEO_MODAL_MAX_WIDTH = 1080;
 const MODAL_HORIZONTAL_PADDING = 144;
 
+let _shadowCompositingEffect: InstanceType<typeof DeckShadowCompositingEffect> | null = null;
+
 const ExportVideoModalFactory = () => {
+  patchDeckRendererForPostProcessing();
   const ExportVideoModal: React.FC<ExportVideoModalProps> = ({
     mapboxApiAccessToken,
     mapboxApiUrl = DEFAULT_MAPBOX_API_URL,
@@ -219,10 +223,27 @@ const ExportVideoModalFactory = () => {
       return Math.max(320, Math.min(540, modalInnerW - HUBBLE_PANEL_OVERHEAD));
     }, [containerW]);
 
-    const keplerState = useMemo(
-      () => ({visState, mapState, mapStyle}),
-      [visState, mapState, mapStyle]
-    );
+    const keplerState = useMemo(() => {
+      if (mapStyle?.styleType === NO_MAP_ID) {
+        const noMapEntry = mapStyle.mapStyles?.[NO_MAP_ID];
+        if (noMapEntry && !noMapEntry.url) {
+          const emptyStyleUrl =
+            'data:application/json,' + encodeURIComponent(JSON.stringify(EMPTY_MAPBOX_STYLE));
+          return {
+            visState,
+            mapState,
+            mapStyle: {
+              ...mapStyle,
+              mapStyles: {
+                ...mapStyle.mapStyles,
+                [NO_MAP_ID]: {...noMapEntry, url: emptyStyleUrl}
+              }
+            }
+          };
+        }
+      }
+      return {visState, mapState, mapStyle};
+    }, [visState, mapState, mapStyle]);
 
     const onUpdateMap = useCallback(
       (viewPort: Viewport) => {
@@ -243,15 +264,29 @@ const ExportVideoModalFactory = () => {
     const deckEffects = useMemo(() => {
       if (videoEffects.length === 0) return [];
       const effectOrder = visState.effectOrder || videoEffects.map((e: Effect) => e.id);
-      return computeDeckEffects({
+      const effects = computeDeckEffects({
         visState: {...visState, effects: videoEffects, effectOrder},
         mapState,
         isExport: true
       });
+
+      const hasShadow = effects.some((e: any) => e.shadow === true);
+      const hasPostProcess = effects.some((e: any) => typeof e.postRender === 'function');
+      if (hasShadow && !hasPostProcess) {
+        if (!_shadowCompositingEffect) {
+          _shadowCompositingEffect = new DeckShadowCompositingEffect();
+        }
+        effects.push(_shadowCompositingEffect as any);
+      }
+
+      return effects;
     }, [visState, videoEffects, mapState]);
 
     const deckPropsWithEffects = useMemo(
-      () => ({...hubbleDeckGlProps, effects: deckEffects}),
+      () => ({
+        ...hubbleDeckGlProps,
+        effects: deckEffects
+      }),
       [hubbleDeckGlProps, deckEffects]
     );
 

--- a/src/effects/src/index.ts
+++ b/src/effects/src/index.ts
@@ -3,3 +3,4 @@
 
 export {default as Effect} from './effect';
 export {createEffect} from './utils';
+export {DeckShadowCompositingEffect} from './shader-passes/shadow-compositing';

--- a/src/effects/src/shader-passes/shadow-compositing.ts
+++ b/src/effects/src/shader-passes/shadow-compositing.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {ClipSpace} from '@luma.gl/engine';
+import type {ShaderModule} from '@luma.gl/shadertools';
+
+const BLIT_FS = /* glsl */ `\
+#version 300 es
+precision highp float;
+
+uniform sampler2D texSrc;
+
+in vec2 position;
+in vec2 coordinate;
+in vec2 uv;
+
+out vec4 fragColor;
+
+void main() {
+  fragColor = texture(texSrc, coordinate);
+}
+`;
+
+const screenModule = {
+  name: 'screen',
+  fs: /* glsl */ `\
+uniform screenUniforms {
+  vec2 texSize;
+} screen;
+`,
+  uniformTypes: {
+    texSize: 'vec2<f32>'
+  }
+} as const satisfies ShaderModule;
+
+/**
+ * Pass-through compositing effect for shadow rendering in interleaved mode.
+ *
+ * In interleaved MapboxOverlay rendering, deck.gl layers share MapLibre's
+ * WebGL context and depth buffer. The base LightingEffect renders shadow
+ * maps once per drawLayer call with a single-layer filter, corrupting the
+ * shadow map. When any post-processing effect is present, DeckRenderer
+ * routes layers through offscreen FBOs (clearCanvas=true), giving deck.gl
+ * its own clean depth buffer. The afterRender pass then re-renders all
+ * layers with correct shadow maps into this clean FBO.
+ *
+ * This effect replicates that mechanism: its mere presence as a
+ * post-processing effect (postRender) forces the offscreen FBO path.
+ * The postRender itself is a simple source-over blit — it copies the
+ * rendered layers from the offscreen buffer onto the screen, exactly
+ * like the fog effect's Porter-Duff compositing but without any visual
+ * transformation.
+ */
+export class DeckShadowCompositingEffect {
+  id = 'shadow-compositing-effect';
+  private model: InstanceType<typeof ClipSpace> | null = null;
+
+  setup({device}) {
+    this.model = new ClipSpace(device, {
+      id: 'shadow-compositing-pass',
+      fs: BLIT_FS,
+      modules: [screenModule],
+      parameters: {
+        depthWriteEnabled: false,
+        depthCompare: 'always' as const,
+        blend: true,
+        blendColorSrcFactor: 'one' as const,
+        blendColorDstFactor: 'one-minus-src-alpha' as const,
+        blendAlphaSrcFactor: 'one' as const,
+        blendAlphaDstFactor: 'one-minus-src-alpha' as const,
+        blendColorOperation: 'add' as const,
+        blendAlphaOperation: 'add' as const
+      }
+    });
+  }
+
+  preRender(): void {
+    // no-op — required by the effect interface
+  }
+
+  postRender(params: any): any {
+    const {inputBuffer, swapBuffer, target} = params;
+    const outputBuffer = target !== undefined ? target : swapBuffer;
+
+    if (!this.model) return inputBuffer;
+
+    const texSize: [number, number] = [inputBuffer.width, inputBuffer.height];
+
+    this.model.shaderInputs.setProps({
+      screen: {
+        texSrc: inputBuffer.colorAttachments[0],
+        texSize
+      }
+    });
+
+    const renderPass = this.model.device.beginRenderPass({
+      framebuffer: outputBuffer,
+      parameters: {viewport: [0, 0, ...texSize]},
+      clearColor: params.clearCanvas !== false ? [0, 0, 0, 0] : false,
+      clearDepth: params.clearCanvas !== false ? 1 : false
+    });
+    this.model.draw(renderPass);
+    renderPass.end();
+
+    return outputBuffer || inputBuffer;
+  }
+
+  cleanup(): void {
+    if (this.model) {
+      this.model.destroy();
+      this.model = null;
+    }
+  }
+}


### PR DESCRIPTION
- video export don't crash when there is no basemap
- video export takes into account layer.hidden
- extra logic for effects + video export frame and depth buffer composition