### PR TITLE
feat: add override for vis config

### DIFF
--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -129,8 +129,8 @@ export function mergeLayerVisConfigForNewDatasets(
       if (!settings) {
         return layer;
       }
-      const allowedKeys = (Object.keys(patch) as Array<keyof LayerVisConfig>).filter(
-        key => key in settings
+      const allowedKeys = (Object.keys(patch) as Array<keyof LayerVisConfig>).filter(key =>
+        Object.prototype.hasOwnProperty.call(settings, key)
       );
       if (!allowedKeys.length) {
         return layer;

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -8,6 +8,7 @@ import {Layer as DeckLayer} from '@deck.gl/core';
 type DeckLayerProps = any;
 import {
   Field,
+  LayerVisConfig,
   TooltipField,
   CompareType,
   SplitMapLayers,
@@ -99,6 +100,46 @@ export function findDefaultLayer(dataset: KeplerTable, layerClasses: LayerClasse
       ? layer.setInitialLayerConfig(dataset)
       : layer;
   });
+}
+
+/**
+ * Applies `patch` to `config.visConfig` only for layers whose `dataId` is in `datasetIdsToPatch`.
+ * Layers for datasets that were already on the map are left unchanged — `addDataToMap`
+ * appends datasets and may auto-create layers, so we must not alter unrelated layers.
+ * Only keys present on each layer's `visConfigSettings` are applied (others skipped).
+ */
+export function mergeLayerVisConfigForNewDatasets(
+  state: VisState,
+  patch: Partial<LayerVisConfig> | undefined,
+  datasetIdsToPatch: string[]
+): VisState {
+  if (!patch || !Object.keys(patch).length) {
+    return state;
+  }
+
+  return {
+    ...state,
+    layers: state.layers.map(layer => {
+      if (!layer.config.dataId || !datasetIdsToPatch.includes(layer.config.dataId)) {
+        return layer;
+      }
+      const settings = layer.visConfigSettings;
+      if (!settings) {
+        return layer;
+      }
+      const allowedKeys = (Object.keys(patch) as Array<keyof LayerVisConfig>).filter(
+        key => key in settings
+      );
+      if (!allowedKeys.length) {
+        return layer;
+      }
+      const partial = allowedKeys.reduce<Partial<LayerVisConfig>>((acc, key) => {
+        acc[key] = patch[key];
+        return acc;
+      }, {});
+      return layer.updateLayerVisConfig(partial);
+    })
+  };
 }
 
 type MinVisStateForLayerData = {

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -117,10 +117,12 @@ export function mergeLayerVisConfigForNewDatasets(
     return state;
   }
 
+  const datasetIdSet = new Set(datasetIdsToPatch);
+
   return {
     ...state,
     layers: state.layers.map(layer => {
-      if (!layer.config.dataId || !datasetIdsToPatch.includes(layer.config.dataId)) {
+      if (!layer.config.dataId || !datasetIdSet.has(layer.config.dataId)) {
         return layer;
       }
       const settings = layer.visConfigSettings;

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -105,8 +105,7 @@ export function findDefaultLayer(dataset: KeplerTable, layerClasses: LayerClasse
 /**
  * Applies `patch` to `config.visConfig` only for layers whose `dataId` is in `datasetIdsToPatch`.
  * Layers for datasets that were already on the map are left unchanged — `addDataToMap`
- * appends datasets and may auto-create layers, so we must not alter unrelated layers.
- * Only keys present on each layer's `visConfigSettings` are applied (others skipped).
+ * Keys whose patch value is `undefined` are skipped so existing visConfig is not cleared.
  */
 export function mergeLayerVisConfigForNewDatasets(
   state: VisState,
@@ -114,6 +113,13 @@ export function mergeLayerVisConfigForNewDatasets(
   datasetIdsToPatch: string[]
 ): VisState {
   if (!patch || !Object.keys(patch).length) {
+    return state;
+  }
+
+  const hasDefinedPatchValue = (Object.keys(patch) as Array<keyof LayerVisConfig>).some(
+    key => patch[key] !== undefined
+  );
+  if (!hasDefinedPatchValue) {
     return state;
   }
 
@@ -129,8 +135,9 @@ export function mergeLayerVisConfigForNewDatasets(
       if (!settings) {
         return layer;
       }
-      const allowedKeys = (Object.keys(patch) as Array<keyof LayerVisConfig>).filter(key =>
-        Object.prototype.hasOwnProperty.call(settings, key)
+      const allowedKeys = (Object.keys(patch) as Array<keyof LayerVisConfig>).filter(
+        key =>
+          Object.prototype.hasOwnProperty.call(settings, key) && patch[key] !== undefined
       );
       if (!allowedKeys.length) {
         return layer;

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -129,6 +129,7 @@ import {
   FilterAnimationConfig,
   Editor,
   Field,
+  LayerVisConfig,
   TimeRangeFilter
 } from '@kepler.gl/types';
 import {Loader} from '@loaders.gl/loader-utils';
@@ -143,7 +144,12 @@ import {
   sortDatasetByColumn
 } from '@kepler.gl/table';
 import {findFieldsToShow} from './interaction-utils';
-import {calculateLayerData, findDefaultLayer, getLayerOrderFromLayers} from './layer-utils';
+import {
+  calculateLayerData,
+  findDefaultLayer,
+  getLayerOrderFromLayers,
+  mergeLayerVisConfigForNewDatasets
+} from './layer-utils';
 import {getPropValueToMerger, hasPropsToMerge} from './merger-handler';
 import {mergeDatasetsByOrder} from './vis-state-merger';
 import {
@@ -2508,6 +2514,20 @@ export function applyMergersUpdater(
     : mergeStateResult.mergedState;
 }
 
+/** Reads `options.layerVisConfig` from add-data-to-map (see `AddDataToMapOptions`). */
+function layerVisConfigFromAddDataOptions(
+  options: PostMergerPayload['options'] | undefined
+): Partial<LayerVisConfig> | undefined {
+  if (!options || !('layerVisConfig' in options)) {
+    return undefined;
+  }
+  const patch = (options as {layerVisConfig?: unknown}).layerVisConfig;
+  if (patch == null || typeof patch !== 'object' || Array.isArray(patch)) {
+    return undefined;
+  }
+  return patch as Partial<LayerVisConfig>;
+}
+
 /**
  * Add new dataset to `visState`, with option to load a map config along with the datasets
  */
@@ -2550,6 +2570,12 @@ function postMergeUpdater(mergedState: VisState, postMergerPayload: PostMergerPa
       splitMaps: addNewLayersToSplitMap(mergedState.splitMaps, newLayers)
     };
   }
+
+  mergedState = mergeLayerVisConfigForNewDatasets(
+    mergedState,
+    layerVisConfigFromAddDataOptions(options),
+    newDataIds
+  );
 
   // if no tooltips merged add default tooltips
   newDataIds.forEach(dataId => {

--- a/src/types/actions.d.ts
+++ b/src/types/actions.d.ts
@@ -70,7 +70,6 @@ export type AddDataToMapOptions = {
   keepExistingConfig?: boolean;
   autoCreateLayers?: boolean;
   autoCreateTooltips?: boolean;
-  /** Shallow merge into each new layer's `config.visConfig` (keys must exist on `visConfigSettings`). */
   layerVisConfig?: Partial<LayerVisConfig>;
 };
 

--- a/src/types/actions.d.ts
+++ b/src/types/actions.d.ts
@@ -2,6 +2,7 @@
 // Copyright contributors to the kepler.gl project
 
 import {SavedMap, ParsedConfig, SavedConfigV1, MinSavedConfigV1} from './schemas';
+import type {LayerVisConfig} from './layers';
 
 /** EXPORT_FILE_TO_CLOUD */
 export type MapData = {
@@ -69,6 +70,8 @@ export type AddDataToMapOptions = {
   keepExistingConfig?: boolean;
   autoCreateLayers?: boolean;
   autoCreateTooltips?: boolean;
+  /** Shallow merge into each new layer's `config.visConfig` (keys must exist on `visConfigSettings`). */
+  layerVisConfig?: Partial<LayerVisConfig>;
 };
 
 export type AddDataToMapPayload = {

--- a/test/node/reducers/composer-state-test.js
+++ b/test/node/reducers/composer-state-test.js
@@ -399,6 +399,77 @@ test('#composerStateReducer - addDataToMapUpdater: autoCreateLayers', t => {
   t.end();
 });
 
+test('#composerStateReducer - addDataToMapUpdater: layerVisConfig only affects new datasets; unknown keys ignored', t => {
+  const data = processCsvData(testCsvData);
+  const state = keplerGlReducer({}, registerEntry({id: 'test'})).test;
+
+  let oldState = addDataToMapUpdater(state, {
+    payload: {
+      datasets: {
+        data,
+        info: {id: 'first-csv-dataset'}
+      }
+    }
+  });
+  oldState = {
+    ...oldState,
+    visState: applyExistingDatasetTasks(visStateReducer, oldState.visState)
+  };
+  drainTasksForTesting();
+
+  const firstLayer = oldState.visState.layers.find(l => l.config.dataId === 'first-csv-dataset');
+  t.ok(firstLayer, 'first dataset should have a layer');
+  const allowHoverFirstBefore = firstLayer.config.visConfig.allowHover;
+
+  let nextState = addDataToMapUpdater(oldState, {
+    payload: {
+      datasets: {
+        data,
+        info: {id: 'second-csv-dataset'}
+      },
+      options: {
+        keepExistingConfig: true,
+        layerVisConfig: {
+          allowHover: false,
+          totallyUnknownVisKey999: 'strip-me'
+        }
+      }
+    }
+  });
+  nextState = {
+    ...nextState,
+    visState: applyExistingDatasetTasks(visStateReducer, nextState.visState)
+  };
+  drainTasksForTesting();
+
+  const layerFirst = nextState.visState.layers.find(l => l.config.dataId === 'first-csv-dataset');
+  const layerSecond = nextState.visState.layers.find(l => l.config.dataId === 'second-csv-dataset');
+
+  t.ok(layerSecond, 'second dataset should have a layer');
+  t.equal(
+    layerFirst.config.visConfig.allowHover,
+    allowHoverFirstBefore,
+    'layerVisConfig must not change visConfig for layers tied to prior datasets'
+  );
+  t.equal(
+    layerSecond.config.visConfig.allowHover,
+    false,
+    'layerVisConfig should merge allowHover onto layers for datasets added in this action'
+  );
+  t.equal(
+    layerFirst.config.visConfig.totallyUnknownVisKey999,
+    undefined,
+    'unknown keys must not be applied to existing layers'
+  );
+  t.equal(
+    layerSecond.config.visConfig.totallyUnknownVisKey999,
+    undefined,
+    'unknown keys must not be merged into visConfig when absent from visConfigSettings'
+  );
+
+  t.end();
+});
+
 test('#composerStateReducer - replaceDataInMapUpdater', t => {
   const dataIdToReplace = 'dataset_to_replace';
   const datasets = {

--- a/test/node/reducers/composer-state-test.js
+++ b/test/node/reducers/composer-state-test.js
@@ -431,6 +431,7 @@ test('#composerStateReducer - addDataToMapUpdater: layerVisConfig only affects n
         keepExistingConfig: true,
         layerVisConfig: {
           allowHover: false,
+          opacity: undefined,
           totallyUnknownVisKey999: 'strip-me'
         }
       }
@@ -465,6 +466,10 @@ test('#composerStateReducer - addDataToMapUpdater: layerVisConfig only affects n
     layerSecond.config.visConfig.totallyUnknownVisKey999,
     undefined,
     'unknown keys must not be merged into visConfig when absent from visConfigSettings'
+  );
+  t.ok(
+    typeof layerSecond.config.visConfig.opacity === 'number',
+    'undefined patch values must not overwrite visConfig (e.g. opacity)'
   );
 
   t.end();


### PR DESCRIPTION
Extend Kepler’s addDataToMap flow with an optional layerVisConfig on AddDataToMapOptions (Partial<LayerVisConfig>). Using it you can override a layer visualization style