### PR TITLE
fix: fixes related to deck.gl upgrade

### DIFF
--- a/src/components/src/modals/export-video-modal.spec.tsx
+++ b/src/components/src/modals/export-video-modal.spec.tsx
@@ -158,6 +158,7 @@ describe('ExportVideoModal', () => {
       parameters: {blend: true},
       controller: true,
       views: {},
+      _isExport: true,
       effects: []
     });
   });

--- a/src/components/src/modals/export-video-modal.tsx
+++ b/src/components/src/modals/export-video-modal.tsx
@@ -328,6 +328,7 @@ const ExportVideoModalFactory = () => {
     const deckPropsWithEffects = useMemo(
       () => ({
         ...hubbleDeckGlProps,
+        _isExport: true,
         effects: deckEffects
       }),
       [hubbleDeckGlProps, deckEffects]

--- a/src/components/src/plot-container.tsx
+++ b/src/components/src/plot-container.tsx
@@ -360,6 +360,7 @@ export default function PlotContainerFactory(
         isExport: true,
         deckGlProps: {
           ...mapFields.deckGlProps,
+          _isExport: true,
           useDevicePixels: false,
           deviceProps: {
             webgl: {

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1409,8 +1409,8 @@ export const LIGHT_AND_SHADOW_EFFECT: EffectDescription = {
   parameters: [
     {name: 'timestamp', min: 0, max: Number.MAX_SAFE_INTEGER},
     {name: 'shadowIntensity', min: 0, max: 1, defaultValue: DEFAULT_SHADOW_INTENSITY},
-    {name: 'sunLightIntensity', min: 0, max: 10, defaultValue: DEFAULT_LIGHT_INTENSITY},
-    {name: 'ambientLightIntensity', min: 0, max: 10, defaultValue: DEFAULT_LIGHT_INTENSITY},
+    {name: 'sunLightIntensity', min: 0, max: 5, defaultValue: DEFAULT_LIGHT_INTENSITY},
+    {name: 'ambientLightIntensity', min: 0, max: 5, defaultValue: DEFAULT_LIGHT_INTENSITY},
     {name: 'shadowColor', type: 'color', min: 0, max: 255, defaultValue: DEFAULT_SHADOW_COLOR},
     {name: 'sunLightColor', type: 'color', min: 0, max: 255, defaultValue: DEFAULT_LIGHT_COLOR},
     {name: 'ambientLightColor', type: 'color', min: 0, max: 255, defaultValue: DEFAULT_LIGHT_COLOR}

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -158,6 +158,22 @@ class CustomDeckLightingEffect extends LightingEffect {
       } as unknown as ReturnType<LightingEffect['getShaderModuleProps']>;
     }
 
+    // When the effect is disabled (ghost kept alive to preserve the shadow
+    // shader module), return neutral lighting props. Without this, the
+    // base LightingEffect.getShaderModuleProps returns the stale custom
+    // light sources (ambient color/intensity, directional lights) from
+    // when the effect was last active, causing tiles to be tinted/dimmed.
+    if (!this._private.shadow) {
+      return {
+        shadow: {
+          shadowEnabled: false,
+          dummyShadowMap: this._private.dummyShadowMap
+        },
+        lighting: {enabled: false},
+        pbrMaterial: {unlit: 1}
+      } as unknown as ReturnType<LightingEffect['getShaderModuleProps']>;
+    }
+
     const props = super.getShaderModuleProps(layer, otherShaderModuleProps);
 
     if (
@@ -171,6 +187,11 @@ class CustomDeckLightingEffect extends LightingEffect {
     if (props.shadow) {
       (props.shadow as CustomShadowProps).outputUniformShadow = this.outputUniformShadow;
     }
+
+    // Reset unlit to 0 so PBR models respond to lighting. Without this,
+    // models that had unlit=1 set by the ghost effect (disabled phase)
+    // would permanently ignore lighting uniform changes.
+    (props as any).pbrMaterial = {unlit: 0};
 
     return props;
   }

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -127,6 +127,10 @@ class CustomDeckLightingEffect extends LightingEffect {
   preRender(opts) {
     if (!this._private.shadow) return;
 
+    // Filter editor layers out of the shadow pass so they don't cast shadows.
+    const originalLayers = opts.layers;
+    opts.layers = originalLayers.filter(l => !l.id.startsWith(EDITOR_LAYER_ID));
+
     let unpatch: (() => void) | undefined;
     if (this.isExportMode) {
       unpatch = patchTileViewportIds(opts);
@@ -135,6 +139,8 @@ class CustomDeckLightingEffect extends LightingEffect {
     super.preRender(opts);
 
     unpatch?.();
+
+    opts.layers = originalLayers;
   }
 
   cleanup(context) {

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -4,6 +4,7 @@
 import {LightingEffect, shadow} from '@deck.gl/core';
 import type {Texture} from '@luma.gl/core';
 import type {ShaderModule} from '@luma.gl/shadertools';
+import {EDITOR_LAYER_ID} from '@kepler.gl/constants';
 
 /**
  * Exposes private members of LightingEffect that we need to access.
@@ -37,6 +38,9 @@ function insertBefore(source: string, target: string, textToInsert: string): str
  * shadow UBO. When true, `shadow_getShadowWeight` returns 1.0 (full
  * uniform shadow) instead of sampling the shadow map. Used for nighttime
  * rendering to avoid partial shadows from below.
+ *
+ * Also fixes the vertex injection to be a no-op when shadows are disabled,
+ * preventing position corruption in billboard layers (e.g. the editor layer).
  */
 function createCustomShadowModule(): ShaderModule | null {
   if (!shadow) return null;
@@ -52,6 +56,19 @@ function createCustomShadowModule(): ShaderModule | null {
     'vec4 rgbaDepth = texture(shadowMap, position.xy);',
     'if (shadow.outputUniformShadow > 0.5) return 1.0;\n  '
   );
+
+  // Fix: guard the vertex injection so it's a no-op when shadows are disabled.
+  // The original `return gl_Position` in shadow_setVertexPosition is incorrect
+  // for billboard layers where gl_Position isn't yet assigned when the
+  // DECKGL_FILTER_GL_POSITION hook fires.
+  if (mod.inject) {
+    mod.inject = {...mod.inject};
+    mod.inject['vs:DECKGL_FILTER_GL_POSITION'] = `
+    if (shadow.drawShadowMap || shadow.useShadowMap) {
+      position = shadow_setVertexPosition(geometry.position);
+    }
+    `;
+  }
 
   mod.uniformTypes = {
     ...shadow.uniformTypes,
@@ -117,6 +134,20 @@ class CustomDeckLightingEffect extends LightingEffect {
   }
 
   getShaderModuleProps(layer, otherShaderModuleProps) {
+    // Skip lighting/shadow for the editor layer and its sublayers.
+    // These are 2D overlays that should not be affected by lighting effects.
+    if (layer.id.startsWith(EDITOR_LAYER_ID)) {
+      return {
+        shadow: {
+          shadowEnabled: false,
+          dummyShadowMap: this._private.dummyShadowMap
+        },
+        lighting: {enabled: false},
+        phongMaterial: null,
+        gouraudMaterial: null
+      } as unknown as ReturnType<LightingEffect['getShaderModuleProps']>;
+    }
+
     const props = super.getShaderModuleProps(layer, otherShaderModuleProps);
 
     if (

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -7,6 +7,12 @@ import type {ShaderModule} from '@luma.gl/shadertools';
 import {EDITOR_LAYER_ID} from '@kepler.gl/constants';
 import {patchTileViewportIds} from './tile-viewport-fix';
 
+// A plain LightingEffect() — its constructor calls _applyDefaultLights()
+// which populates the same default lights that deck.gl's EffectManager
+// uses internally. We delegate to this when the ghost is disabled so
+// phong/gouraud layers get their original shading back.
+const DEFAULT_LIGHTING_EFFECT = new LightingEffect();
+
 /**
  * Exposes private members of LightingEffect that we need to access.
  * These are runtime-accessible but TypeScript marks them as private.
@@ -58,6 +64,26 @@ function createCustomShadowModule(): ShaderModule | null {
     'if (shadow.outputUniformShadow > 0.5) return 1.0;\n  '
   );
 
+  // Patch the VS so the fallback returns the caller's position instead of
+  // gl_Position (which is uninitialised when the hook fires in billboard
+  // layers like PathLayer / the editor polygon tool).
+  mod.vs = mod.vs
+    .replace(
+      'vec4 shadow_setVertexPosition(vec4 position_commonspace)',
+      'vec4 shadow_setVertexPosition(vec4 position_commonspace, vec4 currentPosition)'
+    )
+    .replace(
+      /return gl_Position;\s*\}/,
+      'return currentPosition;\n}'
+    );
+
+  // Update the inject hook to pass the current position into the patched fn.
+  mod.inject = {
+    ...shadow.inject,
+    'vs:DECKGL_FILTER_GL_POSITION': `
+    position = shadow_setVertexPosition(geometry.position, position);
+    `
+  };
 
   mod.uniformTypes = {
     ...shadow.uniformTypes,
@@ -159,17 +185,19 @@ class CustomDeckLightingEffect extends LightingEffect {
     }
 
     // When the effect is disabled (ghost kept alive to preserve the shadow
-    // shader module), return neutral lighting props. Without this, the
-    // base LightingEffect.getShaderModuleProps returns the stale custom
-    // light sources (ambient color/intensity, directional lights) from
-    // when the effect was last active, causing tiles to be tinted/dimmed.
+    // shader module), delegate to a default LightingEffect so phong/gouraud
+    // layers get the same shading they had before the effect was ever added.
+    // Our ghost is an instanceof LightingEffect, which prevents EffectManager
+    // from appending its own built-in default — so we replicate it here.
+    // For PBR tiles we also force unlit=1 so they render with base color.
     if (!this._private.shadow) {
+      const defaults = DEFAULT_LIGHTING_EFFECT.getShaderModuleProps(layer, otherShaderModuleProps);
       return {
+        ...defaults,
         shadow: {
           shadowEnabled: false,
           dummyShadowMap: this._private.dummyShadowMap
         },
-        lighting: {enabled: false},
         pbrMaterial: {unlit: 1}
       } as unknown as ReturnType<LightingEffect['getShaderModuleProps']>;
     }

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -9,8 +9,7 @@ import {patchTileViewportIds} from './tile-viewport-fix';
 
 // A plain LightingEffect() — its constructor calls _applyDefaultLights()
 // which populates the same default lights that deck.gl's EffectManager
-// uses internally. We delegate to this when the ghost is disabled so
-// phong/gouraud layers get their original shading back.
+// uses internally. This is used to restore the original shading.
 const DEFAULT_LIGHTING_EFFECT = new LightingEffect();
 
 /**

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -58,18 +58,6 @@ function createCustomShadowModule(): ShaderModule | null {
     'if (shadow.outputUniformShadow > 0.5) return 1.0;\n  '
   );
 
-  // Fix: guard the vertex injection so it's a no-op when shadows are disabled.
-  // The original `return gl_Position` in shadow_setVertexPosition is incorrect
-  // for billboard layers where gl_Position isn't yet assigned when the
-  // DECKGL_FILTER_GL_POSITION hook fires.
-  if (mod.inject) {
-    mod.inject = {...mod.inject};
-    mod.inject['vs:DECKGL_FILTER_GL_POSITION'] = `
-    if (shadow.drawShadowMap || shadow.useShadowMap) {
-      position = shadow_setVertexPosition(geometry.position);
-    }
-    `;
-  }
 
   mod.uniformTypes = {
     ...shadow.uniformTypes,

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -27,6 +27,7 @@ interface LightingEffectPrivate {
 /** Extended shadow module props with our custom field. */
 interface CustomShadowProps {
   outputUniformShadow?: boolean;
+  useSimplePhong?: boolean;
   dummyShadowMap?: Texture | null;
   [key: string]: unknown;
 }
@@ -41,10 +42,12 @@ function insertBefore(source: string, target: string, textToInsert: string): str
 }
 
 /**
- * Create a patched shadow module that adds `outputUniformShadow` to the
- * shadow UBO. When true, `shadow_getShadowWeight` returns 1.0 (full
- * uniform shadow) instead of sampling the shadow map. Used for nighttime
- * rendering to avoid partial shadows from below.
+ * Create a patched shadow module that adds:
+ * - `outputUniformShadow`: when true, shadow_getShadowWeight returns 1.0
+ *   (full uniform shadow) instead of sampling the shadow map.
+ * - `useSimplePhong`: when true, replaces PBR lighting with simple
+ *   Lambertian diffuse (ambient + NdotL) for 3D tile layers, avoiding
+ *   the PBR microfacet specular artifacts on flat surfaces.
  *
  * Also fixes the vertex injection to be a no-op when shadows are disabled,
  * preventing position corruption in billboard layers (e.g. the editor layer).
@@ -54,9 +57,13 @@ function createCustomShadowModule(): ShaderModule | null {
 
   const mod = {...shadow} as Record<string, any>;
 
-  const uboField = '  float outputUniformShadow;\n';
+  const uboField = '  float outputUniformShadow;\n  float useSimplePhong;\n';
   mod.vs = insertBefore(mod.vs, '} shadow;', uboField);
   mod.fs = insertBefore(mod.fs, '} shadow;', uboField);
+
+  // Add a varying to carry the common-space position for simple phong normals.
+  mod.vs = 'out vec3 custom_vWorldPos;\n' + mod.vs;
+  mod.fs = 'in vec3 custom_vWorldPos;\n' + mod.fs;
 
   mod.fs = insertBefore(
     mod.fs,
@@ -77,17 +84,36 @@ function createCustomShadowModule(): ShaderModule | null {
       'return currentPosition;\n}'
     );
 
-  // Update the inject hook to pass the current position into the patched fn.
   mod.inject = {
     ...shadow.inject,
     'vs:DECKGL_FILTER_GL_POSITION': `
     position = shadow_setVertexPosition(geometry.position, position);
+    custom_vWorldPos = geometry.position.xyz;
+    `,
+    'fs:DECKGL_FILTER_COLOR': `
+    #ifdef LIGHTING_FRAGMENT
+    if (shadow.useSimplePhong > 0.5) {
+      vec3 spDx = dFdx(custom_vWorldPos);
+      vec3 spDy = dFdy(custom_vWorldPos);
+      vec3 spN = normalize(cross(spDx, spDy));
+      vec3 spLit = lighting.ambientColor;
+      for (int i = 0; i < 3; i++) {
+        if (i >= lighting.directionalLightCount) break;
+        vec3 spDir = lighting_getDirectionalLight(i).direction;
+        float spNdotL = max(dot(spN, -normalize(spDir)), 0.0);
+        spLit += lighting_getDirectionalLight(i).color * spNdotL;
+      }
+      color.rgb *= spLit;
+    }
+    #endif
+    color = shadow_filterShadowColor(color);
     `
   };
 
   mod.uniformTypes = {
     ...shadow.uniformTypes,
-    outputUniformShadow: 'f32'
+    outputUniformShadow: 'f32',
+    useSimplePhong: 'f32'
   };
 
   const originalGetUniforms = shadow.getUniforms as (
@@ -97,6 +123,7 @@ function createCustomShadowModule(): ShaderModule | null {
   mod.getUniforms = (opts: CustomShadowProps = {}, context = {}) => {
     const u = originalGetUniforms(opts, context);
     u.outputUniformShadow = opts.outputUniformShadow ? 1.0 : 0.0;
+    u.useSimplePhong = opts.useSimplePhong ? 1.0 : 0.0;
     return u;
   };
 
@@ -106,11 +133,20 @@ function createCustomShadowModule(): ShaderModule | null {
 const CustomShadowModule = createCustomShadowModule();
 
 /**
+ * Detect layers that use the PBR shader module (3D tile sublayers:
+ * ScenegraphLayer sets `_lighting: 'pbr'`, SimpleMeshLayer sets `pbrMaterial`).
+ */
+function isPbrLayer(layer: any): boolean {
+  return layer.props?._lighting === 'pbr' || layer.props?.pbrMaterial !== undefined;
+}
+
+/**
  * Custom LightingEffect for kepler.gl.
  *
  * Extends deck.gl's LightingEffect with:
  * - A patched shadow module with `outputUniformShadow` for uniform shadow
  *   during nighttime (avoids partial shadows from below).
+ * - Simple phong replacement for PBR layers (avoids microfacet specular).
  * - getShaderModuleProps override that always provides dummyShadowMap
  *   to prevent "Bad texture binding" errors when shadows are disabled.
  */
@@ -171,7 +207,6 @@ class CustomDeckLightingEffect extends LightingEffect {
 
   getShaderModuleProps(layer, otherShaderModuleProps) {
     // Skip lighting/shadow for the editor layer and its sublayers.
-    // These are 2D overlays that should not be affected by lighting effects.
     if (layer.id.startsWith(EDITOR_LAYER_ID)) {
       return {
         shadow: {
@@ -187,9 +222,6 @@ class CustomDeckLightingEffect extends LightingEffect {
     // When the effect is disabled (ghost kept alive to preserve the shadow
     // shader module), delegate to a default LightingEffect so phong/gouraud
     // layers get the same shading they had before the effect was ever added.
-    // Our ghost is an instanceof LightingEffect, which prevents EffectManager
-    // from appending its own built-in default — so we replicate it here.
-    // For PBR tiles we also force unlit=1 so they render with base color.
     if (!this._private.shadow) {
       const defaults = DEFAULT_LIGHTING_EFFECT.getShaderModuleProps(layer, otherShaderModuleProps);
       return {
@@ -216,9 +248,19 @@ class CustomDeckLightingEffect extends LightingEffect {
       (props.shadow as CustomShadowProps).outputUniformShadow = this.outputUniformShadow;
     }
 
-    // Reset unlit to 0 so PBR models respond to lighting. Without this,
-    // models that had unlit=1 set by the ghost effect (disabled phase)
-    // would permanently ignore lighting uniform changes.
+    if (isPbrLayer(layer)) {
+      // PBR layers: disable PBR lighting (unlit=1 → outputs base texture color),
+      // keep directional lights in the lighting uniforms, and enable our simple
+      // phong replacement in the DECKGL_FILTER_COLOR hook. This gives us
+      // ambient + NdotL diffuse without PBR microfacet specular artifacts.
+      // Light direction is sky→surface (deck.gl convention), negated in GLSL.
+      (props as any).pbrMaterial = {unlit: 1};
+      if (props.shadow) {
+        (props.shadow as CustomShadowProps).useSimplePhong = true;
+      }
+      return props;
+    }
+
     (props as any).pbrMaterial = {unlit: 0};
 
     return props;

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -55,6 +55,12 @@ function _checkLightingActive(context: any): boolean {
  */
 // @ts-expect-error Types have separate declarations of a private property '_loadTileset'.
 class KeplerTile3DLayer extends DeckTile3DLayer {
+  shouldUpdateState(params: any): boolean {
+    if (super.shouldUpdateState(params)) return true;
+    const lightingActive = _checkLightingActive(this.context);
+    return lightingActive !== ((this.state as any)?._lightingWasActive ?? false);
+  }
+
   // deck.gl Tile3DLayer.updateState only sets `needsUpdate` on cached tile
   // sub-layers when `propsChanged` fires, but NOT when `extensionsChanged`
   // fires (e.g. the shadow module being added/removed). The LayerManager sets

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -123,6 +123,7 @@ class KeplerTile3DLayer extends DeckTile3DLayer {
     const viewportsNumber = Object.keys(viewports).length;
     if (!timeline || !viewportsNumber || !tileset3d) return;
 
+    // We want higher detail for video/image export.
     const isExporting = (this.context as any)?.deck?.props?._isExport;
     if (isExporting) {
       const baseSSE: number = tileset3d.options?.maximumScreenSpaceError ?? 8;

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -83,10 +83,7 @@ class KeplerTile3DLayer extends DeckTile3DLayer {
       const {layerMap} = this.state as any;
       if (layerMap) {
         for (const key in layerMap) {
-          const entry = layerMap[key];
-          if (entry?.layer) {
-            entry.layer.needsUpdate = true;
-          }
+          layerMap[key].needsUpdate = true;
         }
       }
     }

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -123,6 +123,12 @@ class KeplerTile3DLayer extends DeckTile3DLayer {
     const viewportsNumber = Object.keys(viewports).length;
     if (!timeline || !viewportsNumber || !tileset3d) return;
 
+    const isExporting = (this.context as any)?.deck?.props?._isExport;
+    if (isExporting) {
+      const baseSSE: number = tileset3d.options?.maximumScreenSpaceError ?? 8;
+      tileset3d.memoryAdjustedScreenSpaceError = baseSSE / 2;
+    }
+
     tileset3d
       .selectTiles(Object.values(viewports))
       .then((frameNumber: number) => {
@@ -278,11 +284,11 @@ class KeplerTile3DLayer extends DeckTile3DLayer {
   }
 
   /**
-   * During video export (preserveDrawingBuffer), report the layer as not loaded
-   * until every selected tile has a renderable sublayer.  Hubble.gl's
-   * DeckAdapter.onAfterRender checks layer.isLoaded on every top-level layer
-   * before capturing a frame, so returning false here makes it wait until the
-   * LOD transition is complete — no frame is captured with missing tiles.
+   * During video/image export, report the layer as not loaded until every
+   * selected tile has a renderable sublayer.  Hubble.gl's DeckAdapter and
+   * PlotContainer check layer.isLoaded before capturing a frame, so
+   * returning false here makes them wait until the LOD transition is
+   * complete — no frame is captured with missing tiles.
    */
   get isLoaded(): boolean {
     const baseLoaded = super.isLoaded;
@@ -290,8 +296,7 @@ class KeplerTile3DLayer extends DeckTile3DLayer {
       return false;
     }
 
-    const gl = this.context?.gl;
-    const isExporting = gl?.getContextAttributes?.()?.preserveDrawingBuffer;
+    const isExporting = (this.context as any)?.deck?.props?._isExport;
     if (!isExporting) {
       return true;
     }


### PR DESCRIPTION
- [x] 1) Fix polygon tool invisible after Light & Shadow effect 2) Exclude editor layers from shadow pass
- [x] Fix extruded layers stuck with wrong shading after effect removal
- [x] Replace PBR specular with simple Lambertian diffuse for 3D tile layers
- [x] Fix tile3d sublayer cache invalidation
- [x] Higher detail 3D tiles during video/image export
- [x] Fix export detection: Replace unreliable preserveDrawingBuffer check with deck.props._isExport flag, set explicitly in PlotContainer and ExportVideoModal.
- [x] Limit sun/ambient intensity slider max from 10 to 5.