### PR TITLE
fix: aggregation layers regressions after deck.gl upgrade

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -575,7 +575,7 @@ export default function MapContainerFactory(
 
     _onLayerSetDomain = (
       idx: number,
-      value: number[] | {domain: VisualChannelDomain; aggregatedBins: AggregatedBin[]}
+      value: number[] | {domain: VisualChannelDomain; aggregatedBins: Record<number, AggregatedBin>}
     ) => {
       // deck.gl 9 native aggregation layers (Grid, Hexagon) pass
       // {domain, aggregatedBins} via our ScaleEnhanced* overrides,

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -577,8 +577,10 @@ export default function MapContainerFactory(
       idx: number,
       value: number[] | {domain: VisualChannelDomain; aggregatedBins: AggregatedBin[]}
     ) => {
-      // deck.gl 9 native aggregation layers (Grid, Hexagon) pass [min, max],
-      // while ClusterLayer's CPUAggregator still passes {domain, aggregatedBins}.
+      // deck.gl 9 native aggregation layers (Grid, Hexagon) pass
+      // {domain, aggregatedBins} via our ScaleEnhanced* overrides,
+      // while ClusterLayer's CPUAggregator also passes {domain, aggregatedBins}.
+      // Plain [min, max] is a fallback if the override is bypassed.
       const config = Array.isArray(value)
         ? {colorDomain: value as VisualChannelDomain}
         : {colorDomain: value.domain, aggregatedBins: value.aggregatedBins};

--- a/src/components/src/side-panel/layer-panel/color-scale-selector.tsx
+++ b/src/components/src/side-panel/layer-panel/color-scale-selector.tsx
@@ -56,7 +56,7 @@ export type ColorScaleSelectorProps = {
   searchable: boolean;
   displayOption: string;
   getOptionValue: string;
-  aggregatedBins?: AggregatedBin[];
+  aggregatedBins?: Record<number, AggregatedBin>;
   channelKey: string;
 };
 

--- a/src/components/src/side-panel/layer-panel/custom-palette.tsx
+++ b/src/components/src/side-panel/layer-panel/custom-palette.tsx
@@ -208,6 +208,9 @@ const StyledInput = styled(Input).withConfig({shouldForwardProp})<{
   width: ${props => props.width ?? '100%'};
   text-align: ${props => props.textAlign ?? 'end'};
   pointer-events: ${props => (props.disabled ? 'none' : 'all')};
+  font-size: 10px;
+  padding-left: 4px;
+  padding-right: 4px;
 `;
 
 const InputText = styled.div.withConfig({shouldForwardProp})<{width: string; textAlign: string}>`
@@ -216,6 +219,9 @@ const InputText = styled.div.withConfig({shouldForwardProp})<{width: string; tex
   border-color: transparent;
   width: ${props => props.width ?? '100%'};
   text-align: ${props => props.textAlign ?? 'end'};
+  font-size: 10px;
+  padding-left: 4px;
+  padding-right: 4px;
 
   &:hover {
     cursor: auto;
@@ -400,7 +406,7 @@ export const EditableColorRange: React.FC<EditableColorRangeProps> = ({
       <ColorPaletteInput
         value={noMinBound ? 'Less' : String(leftInput ?? '')}
         id={`color-palette-input-${index}-left`}
-        width="50px"
+        width="54px"
         textAlign="end"
         editable={noMinBound ? false : editable}
         onChange={onChangeLeft}
@@ -409,7 +415,7 @@ export const EditableColorRange: React.FC<EditableColorRangeProps> = ({
       <ColorPaletteInput
         value={noMaxBound ? 'More' : String(rightInput ?? '')}
         id={`color-palette-input-${index}-right`}
-        width="50px"
+        width="54px"
         textAlign="end"
         onChange={onChangeRight}
         editable={noMaxBound ? false : editable}

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -3,7 +3,7 @@
 
 import {GridLayer, GridLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, PickingInfo, Viewport} from '@deck.gl/core';
-import {buildAggregatedBinMap, classifyBinsByCustomBreaks} from '../layer-utils/aggregation-utils';
+import {enrichedAggregationUpdate, enrichedRenderLayers} from '../layer-utils/aggregation-utils';
 
 interface GridInternalState {
   cellOriginCommon?: [number, number];
@@ -41,49 +41,11 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
   // scales but d3.scaleQuantile needs the *full sorted array* of bin values to
   // compute correct break points — without it the legend labels are wrong
   _onAggregationUpdate({channel}: {channel: number}) {
-    (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
-
-    if (channel === 0) {
-      const props = (this as any).getCurrentLayer().props;
-      const {aggregator} = this.state as any;
-      const result = aggregator.getResult(0);
-      const binValues = result?.value as Float32Array | undefined;
-      if (binValues && aggregator.binCount > 0) {
-        this.setState({rawColorBinValues: Float32Array.from(binValues.subarray(0, aggregator.binCount))});
-
-        const domain = aggregator.getResultDomain(0);
-        const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
-
-        if (props.colorMap) {
-          classifyBinsByCustomBreaks(
-            (this.state as any).colors, aggregator.binCount, props.colorMap, binValues
-          );
-        }
-
-        let enrichedDomain = domain;
-        if (props.colorScaleType === 'quantile') {
-          enrichedDomain = Array.from(binValues)
-            .slice(0, aggregator.binCount)
-            .filter(Number.isFinite)
-            .sort((a: number, b: number) => a - b);
-        }
-        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
-      }
-    }
+    enrichedAggregationUpdate(this, GridLayer, channel);
   }
 
   renderLayers() {
-    const props = (this as any).getCurrentLayer().props;
-    const {colors, rawColorBinValues, aggregator} = this.state as any;
-    if (
-      props.colorMap &&
-      colors &&
-      rawColorBinValues &&
-      aggregator?.binCount > 0
-    ) {
-      classifyBinsByCustomBreaks(colors, aggregator.binCount, props.colorMap, rawColorBinValues);
-    }
-    return (GridLayer.prototype as any).renderLayers.call(this);
+    return enrichedRenderLayers(this, GridLayer);
   }
 
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -29,17 +29,44 @@ interface GridPickingObject {
  * We also override _onAggregationUpdate to send per-bin aggregated values through
  * onSetColorDomain so the legend can compute proper quantile/custom breaks.
  */
+// @ts-expect-error -- overriding private _onAggregationUpdate to enrich the onSetColorDomain callback
 export default class ScaleEnhancedGridLayer extends GridLayer<any> {
   static defaultProps = {
     ...GridLayer.defaultProps,
     gpuAggregation: false
   };
 
+  // HACK: deck.gl 9's _onAggregationUpdate is private and its onSetColorDomain
+  // callback only provides [min, max].  That is sufficient for quantize/linear
+  // scales but d3.scaleQuantile needs the *full sorted array* of bin values to
+  // compute correct break points — without it the legend labels are wrong
+  // (see https://github.com/keplergl/kepler.gl/issues/3381).
+  //
+  // deck.gl does not expose a public hook for post-aggregation data, so we:
+  //   1. Temporarily replace onSetColorDomain with a no-op to suppress the
+  //      parent's [min, max]-only callback.
+  //   2. Delegate to the parent so it still creates the internal
+  //      AttributeWithScale state that renderLayers() depends on.
+  //   3. Fire onSetColorDomain ourselves with an enriched payload that includes
+  //      per-bin values (aggregatedBins) and, for quantile scale, the full
+  //      sorted domain.
+  //
+  // This can be removed once deck.gl exposes a richer post-aggregation callback
+  // or makes _onAggregationUpdate / AttributeWithScale part of the public API.
   _onAggregationUpdate({channel}: {channel: number}) {
-    (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
+    const props = (this as any).getCurrentLayer().props;
 
     if (channel === 0) {
-      const props = (this as any).getCurrentLayer().props;
+      const origCallback = props.onSetColorDomain;
+      props.onSetColorDomain = () => {
+        // no-op
+      };
+      try {
+        (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
+      } finally {
+        props.onSetColorDomain = origCallback;
+      }
+
       const {aggregator} = this.state as any;
       const result = aggregator.getResult(0);
       const binValues = result?.value;
@@ -53,8 +80,12 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
             .filter(Number.isFinite)
             .sort((a: number, b: number) => a - b);
         }
-        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
+        origCallback({domain: enrichedDomain, aggregatedBins});
+      } else {
+        origCallback(props.colorDomain ?? [0, 1]);
       }
+    } else {
+      (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
     }
   }
 

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -42,31 +42,20 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
   // compute correct break points — without it the legend labels are wrong
   // (see https://github.com/keplergl/kepler.gl/issues/3381).
   //
-  // deck.gl does not expose a public hook for post-aggregation data, so we:
-  //   1. Temporarily replace onSetColorDomain with a no-op to suppress the
-  //      parent's [min, max]-only callback.
-  //   2. Delegate to the parent so it still creates the internal
-  //      AttributeWithScale state that renderLayers() depends on.
-  //   3. Fire onSetColorDomain ourselves with an enriched payload that includes
-  //      per-bin values (aggregatedBins) and, for quantile scale, the full
-  //      sorted domain.
+  // deck.gl does not expose a public hook for post-aggregation data, and props
+  // are Object.freeze()'d so we cannot suppress the parent's callback.  Instead
+  // we let the parent fire its [min, max] call, then immediately fire a second
+  // enriched call with per-bin values (aggregatedBins) and, for quantile scale,
+  // the full sorted domain.  The second call overwrites the first downstream in
+  // _onLayerSetDomain.
   //
   // This can be removed once deck.gl exposes a richer post-aggregation callback
   // or makes _onAggregationUpdate / AttributeWithScale part of the public API.
   _onAggregationUpdate({channel}: {channel: number}) {
-    const props = (this as any).getCurrentLayer().props;
+    (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
 
     if (channel === 0) {
-      const origCallback = props.onSetColorDomain;
-      props.onSetColorDomain = () => {
-        // no-op
-      };
-      try {
-        (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
-      } finally {
-        props.onSetColorDomain = origCallback;
-      }
-
+      const props = (this as any).getCurrentLayer().props;
       const {aggregator} = this.state as any;
       const result = aggregator.getResult(0);
       const binValues = result?.value;
@@ -80,12 +69,8 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
             .filter(Number.isFinite)
             .sort((a: number, b: number) => a - b);
         }
-        origCallback({domain: enrichedDomain, aggregatedBins});
-      } else {
-        origCallback(props.colorDomain ?? [0, 1]);
+        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
       }
-    } else {
-      (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
     }
   }
 

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -40,17 +40,6 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
   // callback only provides [min, max].  That is sufficient for quantize/linear
   // scales but d3.scaleQuantile needs the *full sorted array* of bin values to
   // compute correct break points — without it the legend labels are wrong
-  // (see https://github.com/keplergl/kepler.gl/issues/3381).
-  //
-  // deck.gl does not expose a public hook for post-aggregation data, and props
-  // are Object.freeze()'d so we cannot suppress the parent's callback.  Instead
-  // we let the parent fire its [min, max] call, then immediately fire a second
-  // enriched call with per-bin values (aggregatedBins) and, for quantile scale,
-  // the full sorted domain.  The second call overwrites the first downstream in
-  // _onLayerSetDomain.
-  //
-  // This can be removed once deck.gl exposes a richer post-aggregation callback
-  // or makes _onAggregationUpdate / AttributeWithScale part of the public API.
   _onAggregationUpdate({channel}: {channel: number}) {
     (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
 

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -3,6 +3,7 @@
 
 import {GridLayer, GridLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, PickingInfo, Viewport} from '@deck.gl/core';
+import {buildAggregatedBinMap} from '../layer-utils/aggregation-utils';
 
 interface GridInternalState {
   cellOriginCommon?: [number, number];
@@ -24,12 +25,38 @@ interface GridPickingObject {
  *
  * We override getPickingInfo to add `cellOutline` — an array of [lng, lat] coordinates
  * computed in common space so the outline aligns with rendered cells at all latitudes.
+ *
+ * We also override _onAggregationUpdate to send per-bin aggregated values through
+ * onSetColorDomain so the legend can compute proper quantile/custom breaks.
  */
 export default class ScaleEnhancedGridLayer extends GridLayer<any> {
   static defaultProps = {
     ...GridLayer.defaultProps,
     gpuAggregation: false
   };
+
+  _onAggregationUpdate({channel}: {channel: number}) {
+    (GridLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
+
+    if (channel === 0) {
+      const props = (this as any).getCurrentLayer().props;
+      const {aggregator} = this.state as any;
+      const result = aggregator.getResult(0);
+      const binValues = result?.value;
+      if (binValues && aggregator.binCount > 0) {
+        const domain = aggregator.getResultDomain(0);
+        const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
+        let enrichedDomain = domain;
+        if (props.colorScaleType === 'quantile') {
+          enrichedDomain = Array.from(binValues as Float32Array)
+            .slice(0, aggregator.binCount)
+            .filter(Number.isFinite)
+            .sort((a: number, b: number) => a - b);
+        }
+        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
+      }
+    }
+  }
 
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {
     const info = super.getPickingInfo(params) as GridLayerPickingInfo<Record<string, unknown>>;

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -3,7 +3,7 @@
 
 import {GridLayer, GridLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, PickingInfo, Viewport} from '@deck.gl/core';
-import {buildAggregatedBinMap} from '../layer-utils/aggregation-utils';
+import {buildAggregatedBinMap, classifyBinsByCustomBreaks} from '../layer-utils/aggregation-utils';
 
 interface GridInternalState {
   cellOriginCommon?: [number, number];
@@ -58,13 +58,22 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
       const props = (this as any).getCurrentLayer().props;
       const {aggregator} = this.state as any;
       const result = aggregator.getResult(0);
-      const binValues = result?.value;
+      const binValues = result?.value as Float32Array | undefined;
       if (binValues && aggregator.binCount > 0) {
+        this.setState({rawColorBinValues: Float32Array.from(binValues.subarray(0, aggregator.binCount))});
+
         const domain = aggregator.getResultDomain(0);
         const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
+
+        if (props.colorMap) {
+          classifyBinsByCustomBreaks(
+            (this.state as any).colors, aggregator.binCount, props.colorMap, binValues
+          );
+        }
+
         let enrichedDomain = domain;
         if (props.colorScaleType === 'quantile') {
-          enrichedDomain = Array.from(binValues as Float32Array)
+          enrichedDomain = Array.from(binValues)
             .slice(0, aggregator.binCount)
             .filter(Number.isFinite)
             .sort((a: number, b: number) => a - b);
@@ -72,6 +81,20 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
         props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
       }
     }
+  }
+
+  renderLayers() {
+    const props = (this as any).getCurrentLayer().props;
+    const {colors, rawColorBinValues, aggregator} = this.state as any;
+    if (
+      props.colorMap &&
+      colors &&
+      rawColorBinValues &&
+      aggregator?.binCount > 0
+    ) {
+      classifyBinsByCustomBreaks(colors, aggregator.binCount, props.colorMap, rawColorBinValues);
+    }
+    return (GridLayer.prototype as any).renderLayers.call(this);
   }
 
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -40,30 +40,50 @@ interface HexPickingObject {
  * We also override _onAggregationUpdate to send per-bin aggregated values through
  * onSetColorDomain so the legend can compute proper quantile/custom breaks.
  */
+// @ts-expect-error -- overriding private _onAggregationUpdate to enrich the onSetColorDomain callback
 export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
   static defaultProps = {
     ...HexagonLayer.defaultProps,
     gpuAggregation: false
   };
 
+  // HACK: deck.gl 9's _onAggregationUpdate is private and its onSetColorDomain
+  // callback only provides [min, max].  That is sufficient for quantize/linear
+  // scales but d3.scaleQuantile needs the *full sorted array* of bin values to
+  // compute correct break points — without it the legend labels are wrong
+  // (see https://github.com/keplergl/kepler.gl/issues/3381).
+  //
+  // deck.gl does not expose a public hook for post-aggregation data, so we:
+  //   1. Temporarily replace onSetColorDomain with a no-op to suppress the
+  //      parent's [min, max]-only callback.
+  //   2. Delegate to the parent so it still creates the internal
+  //      AttributeWithScale state that renderLayers() depends on.
+  //   3. Fire onSetColorDomain ourselves with an enriched payload that includes
+  //      per-bin values (aggregatedBins) and, for quantile scale, the full
+  //      sorted domain.
+  //
+  // This can be removed once deck.gl exposes a richer post-aggregation callback
+  // or makes _onAggregationUpdate / AttributeWithScale part of the public API.
   _onAggregationUpdate({channel}: {channel: number}) {
-    // Delegate to the parent which handles internal state (AttributeWithScale)
-    // and fires onSetColorDomain with [min, max].
-    (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
+    const props = (this as any).getCurrentLayer().props;
 
     if (channel === 0) {
-      // The parent already called onSetColorDomain([min, max]).
-      // Now fire it again with the enriched format {domain, aggregatedBins}
-      // so the legend can compute proper quantile breaks from the full bin data.
-      const props = (this as any).getCurrentLayer().props;
+      const origCallback = props.onSetColorDomain;
+      props.onSetColorDomain = () => {
+        // no-op
+      };
+      try {
+        (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
+      } finally {
+        props.onSetColorDomain = origCallback;
+      }
+
       const {aggregator} = this.state as any;
       const result = aggregator.getResult(0);
       const binValues = result?.value;
       if (binValues && aggregator.binCount > 0) {
         const domain = aggregator.getResultDomain(0);
         const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
-        // For quantile scale, pass the full sorted array of bin values as domain
-        // so d3.scaleQuantile can compute proper quantile breaks.
         let enrichedDomain = domain;
         if (props.colorScaleType === 'quantile') {
           enrichedDomain = Array.from(binValues as Float32Array)
@@ -71,8 +91,12 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
             .filter(Number.isFinite)
             .sort((a: number, b: number) => a - b);
         }
-        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
+        origCallback({domain: enrichedDomain, aggregatedBins});
+      } else {
+        origCallback(props.colorDomain ?? [0, 1]);
       }
+    } else {
+      (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
     }
   }
 

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -3,6 +3,7 @@
 
 import {HexagonLayer, HexagonLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, PickingInfo, Viewport} from '@deck.gl/core';
+import {buildAggregatedBinMap} from '../layer-utils/aggregation-utils';
 
 const THIRD_PI = Math.PI / 3;
 const HexbinVertices = Array.from({length: 6}, (_, i) => {
@@ -35,12 +36,45 @@ interface HexPickingObject {
  *
  * We override getPickingInfo to add `cellOutline` — an array of [lng, lat] coordinates
  * computed in common space so the outline aligns with rendered cells at all latitudes.
+ *
+ * We also override _onAggregationUpdate to send per-bin aggregated values through
+ * onSetColorDomain so the legend can compute proper quantile/custom breaks.
  */
 export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
   static defaultProps = {
     ...HexagonLayer.defaultProps,
     gpuAggregation: false
   };
+
+  _onAggregationUpdate({channel}: {channel: number}) {
+    // Delegate to the parent which handles internal state (AttributeWithScale)
+    // and fires onSetColorDomain with [min, max].
+    (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
+
+    if (channel === 0) {
+      // The parent already called onSetColorDomain([min, max]).
+      // Now fire it again with the enriched format {domain, aggregatedBins}
+      // so the legend can compute proper quantile breaks from the full bin data.
+      const props = (this as any).getCurrentLayer().props;
+      const {aggregator} = this.state as any;
+      const result = aggregator.getResult(0);
+      const binValues = result?.value;
+      if (binValues && aggregator.binCount > 0) {
+        const domain = aggregator.getResultDomain(0);
+        const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
+        // For quantile scale, pass the full sorted array of bin values as domain
+        // so d3.scaleQuantile can compute proper quantile breaks.
+        let enrichedDomain = domain;
+        if (props.colorScaleType === 'quantile') {
+          enrichedDomain = Array.from(binValues as Float32Array)
+            .slice(0, aggregator.binCount)
+            .filter(Number.isFinite)
+            .sort((a: number, b: number) => a - b);
+        }
+        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
+      }
+    }
+  }
 
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {
     const info = super.getPickingInfo(params) as HexagonLayerPickingInfo<Record<string, unknown>>;

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -53,31 +53,20 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
   // compute correct break points — without it the legend labels are wrong
   // (see https://github.com/keplergl/kepler.gl/issues/3381).
   //
-  // deck.gl does not expose a public hook for post-aggregation data, so we:
-  //   1. Temporarily replace onSetColorDomain with a no-op to suppress the
-  //      parent's [min, max]-only callback.
-  //   2. Delegate to the parent so it still creates the internal
-  //      AttributeWithScale state that renderLayers() depends on.
-  //   3. Fire onSetColorDomain ourselves with an enriched payload that includes
-  //      per-bin values (aggregatedBins) and, for quantile scale, the full
-  //      sorted domain.
+  // deck.gl does not expose a public hook for post-aggregation data, and props
+  // are Object.freeze()'d so we cannot suppress the parent's callback.  Instead
+  // we let the parent fire its [min, max] call, then immediately fire a second
+  // enriched call with per-bin values (aggregatedBins) and, for quantile scale,
+  // the full sorted domain.  The second call overwrites the first downstream in
+  // _onLayerSetDomain.
   //
   // This can be removed once deck.gl exposes a richer post-aggregation callback
   // or makes _onAggregationUpdate / AttributeWithScale part of the public API.
   _onAggregationUpdate({channel}: {channel: number}) {
-    const props = (this as any).getCurrentLayer().props;
+    (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
 
     if (channel === 0) {
-      const origCallback = props.onSetColorDomain;
-      props.onSetColorDomain = () => {
-        // no-op
-      };
-      try {
-        (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
-      } finally {
-        props.onSetColorDomain = origCallback;
-      }
-
+      const props = (this as any).getCurrentLayer().props;
       const {aggregator} = this.state as any;
       const result = aggregator.getResult(0);
       const binValues = result?.value;
@@ -91,12 +80,8 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
             .filter(Number.isFinite)
             .sort((a: number, b: number) => a - b);
         }
-        origCallback({domain: enrichedDomain, aggregatedBins});
-      } else {
-        origCallback(props.colorDomain ?? [0, 1]);
+        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
       }
-    } else {
-      (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
     }
   }
 

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -3,7 +3,7 @@
 
 import {HexagonLayer, HexagonLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, PickingInfo, Viewport} from '@deck.gl/core';
-import {buildAggregatedBinMap, classifyBinsByCustomBreaks} from '../layer-utils/aggregation-utils';
+import {enrichedAggregationUpdate, enrichedRenderLayers} from '../layer-utils/aggregation-utils';
 
 const THIRD_PI = Math.PI / 3;
 const HexbinVertices = Array.from({length: 6}, (_, i) => {
@@ -52,51 +52,11 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
   // scales but d3.scaleQuantile needs the *full sorted array* of bin values to
   // compute correct break points — without it the legend labels are wrong
   _onAggregationUpdate({channel}: {channel: number}) {
-    (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
-
-    if (channel === 0) {
-      const props = (this as any).getCurrentLayer().props;
-      const {aggregator} = this.state as any;
-      const result = aggregator.getResult(0);
-      const binValues = result?.value as Float32Array | undefined;
-      if (binValues && aggregator.binCount > 0) {
-        // Snapshot raw values so renderLayers() can re-classify when colorMap changes.
-        this.setState({rawColorBinValues: Float32Array.from(binValues.subarray(0, aggregator.binCount))});
-
-        const domain = aggregator.getResultDomain(0);
-        const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
-
-        if (props.colorMap) {
-          classifyBinsByCustomBreaks(
-            (this.state as any).colors, aggregator.binCount, props.colorMap, binValues
-          );
-        }
-
-        let enrichedDomain = domain;
-        if (props.colorScaleType === 'quantile') {
-          enrichedDomain = Array.from(binValues)
-            .slice(0, aggregator.binCount)
-            .filter(Number.isFinite)
-            .sort((a: number, b: number) => a - b);
-        }
-        props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
-      }
-    }
+    enrichedAggregationUpdate(this, HexagonLayer, channel);
   }
 
   renderLayers() {
-    // Re-classify when custom colorMap changes between renders without re-aggregation.
-    const props = (this as any).getCurrentLayer().props;
-    const {colors, rawColorBinValues, aggregator} = this.state as any;
-    if (
-      props.colorMap &&
-      colors &&
-      rawColorBinValues &&
-      aggregator?.binCount > 0
-    ) {
-      classifyBinsByCustomBreaks(colors, aggregator.binCount, props.colorMap, rawColorBinValues);
-    }
-    return (HexagonLayer.prototype as any).renderLayers.call(this);
+    return enrichedRenderLayers(this, HexagonLayer);
   }
 
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -51,17 +51,6 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
   // callback only provides [min, max].  That is sufficient for quantize/linear
   // scales but d3.scaleQuantile needs the *full sorted array* of bin values to
   // compute correct break points — without it the legend labels are wrong
-  // (see https://github.com/keplergl/kepler.gl/issues/3381).
-  //
-  // deck.gl does not expose a public hook for post-aggregation data, and props
-  // are Object.freeze()'d so we cannot suppress the parent's callback.  Instead
-  // we let the parent fire its [min, max] call, then immediately fire a second
-  // enriched call with per-bin values (aggregatedBins) and, for quantile scale,
-  // the full sorted domain.  The second call overwrites the first downstream in
-  // _onLayerSetDomain.
-  //
-  // This can be removed once deck.gl exposes a richer post-aggregation callback
-  // or makes _onAggregationUpdate / AttributeWithScale part of the public API.
   _onAggregationUpdate({channel}: {channel: number}) {
     (HexagonLayer.prototype as any)._onAggregationUpdate.call(this, {channel});
 

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -3,7 +3,7 @@
 
 import {HexagonLayer, HexagonLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, PickingInfo, Viewport} from '@deck.gl/core';
-import {buildAggregatedBinMap} from '../layer-utils/aggregation-utils';
+import {buildAggregatedBinMap, classifyBinsByCustomBreaks} from '../layer-utils/aggregation-utils';
 
 const THIRD_PI = Math.PI / 3;
 const HexbinVertices = Array.from({length: 6}, (_, i) => {
@@ -69,13 +69,23 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
       const props = (this as any).getCurrentLayer().props;
       const {aggregator} = this.state as any;
       const result = aggregator.getResult(0);
-      const binValues = result?.value;
+      const binValues = result?.value as Float32Array | undefined;
       if (binValues && aggregator.binCount > 0) {
+        // Snapshot raw values so renderLayers() can re-classify when colorMap changes.
+        this.setState({rawColorBinValues: Float32Array.from(binValues.subarray(0, aggregator.binCount))});
+
         const domain = aggregator.getResultDomain(0);
         const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
+
+        if (props.colorMap) {
+          classifyBinsByCustomBreaks(
+            (this.state as any).colors, aggregator.binCount, props.colorMap, binValues
+          );
+        }
+
         let enrichedDomain = domain;
         if (props.colorScaleType === 'quantile') {
-          enrichedDomain = Array.from(binValues as Float32Array)
+          enrichedDomain = Array.from(binValues)
             .slice(0, aggregator.binCount)
             .filter(Number.isFinite)
             .sort((a: number, b: number) => a - b);
@@ -83,6 +93,21 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
         props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
       }
     }
+  }
+
+  renderLayers() {
+    // Re-classify when custom colorMap changes between renders without re-aggregation.
+    const props = (this as any).getCurrentLayer().props;
+    const {colors, rawColorBinValues, aggregator} = this.state as any;
+    if (
+      props.colorMap &&
+      colors &&
+      rawColorBinValues &&
+      aggregator?.binCount > 0
+    ) {
+      classifyBinsByCustomBreaks(colors, aggregator.binCount, props.colorMap, rawColorBinValues);
+    }
+    return (HexagonLayer.prototype as any).renderLayers.call(this);
   }
 
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {

--- a/src/deckgl-layers/src/index.ts
+++ b/src/deckgl-layers/src/index.ts
@@ -21,6 +21,7 @@ export * as RasterWebGL from './raster/webgl';
 export {default as WMSLayer} from './wms/wms-layer';
 
 export * from './layer-utils/shader-utils';
+export * from './layer-utils/aggregation-utils';
 
 export * from './3d-building-layer/types';
 export * from './3d-building-layer/3d-building-utils';

--- a/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import type {AggregatedBin} from '@kepler.gl/types';
+
+/**
+ * Build a Record<index, AggregatedBin> from the raw Float32Array of per-bin
+ * aggregated values returned by deck.gl 9's CPUAggregator/WebGLAggregator.
+ * The resulting map is compatible with the format kepler.gl expects for
+ * histogram rendering and color-scale selector.
+ */
+export function buildAggregatedBinMap(
+  binValues: ArrayLike<number>,
+  binCount: number
+): Record<number, AggregatedBin> {
+  const bins: Record<number, AggregatedBin> = {};
+  for (let i = 0; i < binCount; i++) {
+    const val = binValues[i];
+    if (Number.isFinite(val)) {
+      bins[i] = {i, value: val, counts: 1};
+    }
+  }
+  return bins;
+}

--- a/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import type {AggregatedBin} from '@kepler.gl/types';
+import type {AggregatedBin, ColorMap} from '@kepler.gl/types';
 
 /**
  * Build a Record<index, AggregatedBin> from the raw Float32Array of per-bin
@@ -21,4 +21,63 @@ export function buildAggregatedBinMap(
     }
   }
   return bins;
+}
+
+/**
+ * Classify raw per-bin aggregated values into break indices according to
+ * a custom colorMap, and patch the deck.gl internal `state.colors` so the
+ * GPU shader renders the correct color for each bin.
+ *
+ * Custom breaks define thresholds [t0, t1, …, t_{N-2}] for N colors:
+ *   color 0: value < t0
+ *   color i: t_{i-1} <= value < t_i
+ *   color N-1: value >= t_{N-2}
+ *
+ * We replace the values in `state.colors.attribute` / `state.colors.input`
+ * with integer break indices [0 … N-1].  Combined with `colorScaleType: 'quantize'`
+ * and `colorDomain: [0, N-1]`, the shader's linear interpolation maps each index
+ * to the correct color texture pixel.
+ *
+ * `rawValues` must be the original aggregated values (not previously classified).
+ */
+export function classifyBinsByCustomBreaks(
+  stateColors: any,
+  binCount: number,
+  colorMap: ColorMap,
+  rawValues: Float32Array
+): void {
+  if (!rawValues || binCount === 0) return;
+
+  const thresholds: number[] = [];
+  for (const entry of colorMap) {
+    if (typeof entry[0] === 'number' && Number.isFinite(entry[0])) {
+      thresholds.push(entry[0]);
+    }
+  }
+  thresholds.sort((a, b) => a - b);
+
+  const numColors = colorMap.length;
+  const classified = new Float32Array(rawValues.length);
+  for (let i = 0; i < binCount; i++) {
+    const v = rawValues[i];
+    if (!Number.isFinite(v)) {
+      classified[i] = NaN;
+      continue;
+    }
+    let idx = numColors - 1;
+    for (let t = 0; t < thresholds.length; t++) {
+      if (v < thresholds[t]) {
+        idx = t;
+        break;
+      }
+    }
+    classified[i] = idx;
+  }
+  for (let i = binCount; i < classified.length; i++) {
+    classified[i] = NaN;
+  }
+
+  const classifiedAttr = {value: classified, type: 'float32', size: 1};
+  stateColors.input = classifiedAttr;
+  stateColors.attribute = classifiedAttr;
 }

--- a/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
@@ -81,3 +81,84 @@ export function classifyBinsByCustomBreaks(
   stateColors.input = classifiedAttr;
   stateColors.attribute = classifiedAttr;
 }
+
+// ---------------------------------------------------------------------------
+// Shared _onAggregationUpdate / renderLayers logic for ScaleEnhanced* layers
+// ---------------------------------------------------------------------------
+//
+// deck.gl 9's _onAggregationUpdate is private and its onSetColorDomain
+// callback only provides [min, max].  That is sufficient for quantize/linear
+// scales but d3.scaleQuantile needs the *full sorted array* of bin values to
+// compute correct break points — without it the legend labels are wrong
+// (see https://github.com/keplergl/kepler.gl/issues/3381).
+//
+// deck.gl does not expose a public hook for post-aggregation data, and props
+// are Object.freeze()'d so we cannot suppress the parent's callback.  Instead
+// we let the parent fire its [min, max] call, then immediately fire a second
+// enriched call with per-bin values (aggregatedBins) and, for quantile scale,
+// the full sorted domain.  The second call overwrites the first downstream in
+// _onLayerSetDomain.
+//
+// This can be removed once deck.gl exposes a richer post-aggregation callback
+// or makes _onAggregationUpdate / AttributeWithScale part of the public API.
+
+/**
+ * Enriched _onAggregationUpdate implementation shared by ScaleEnhancedHexagonLayer
+ * and ScaleEnhancedGridLayer.
+ *
+ * @param layer       The enhanced layer instance (`this`)
+ * @param ParentClass The deck.gl parent class (HexagonLayer or GridLayer)
+ * @param channel     The aggregation channel index passed by deck.gl
+ */
+export function enrichedAggregationUpdate(
+  layer: any,
+  ParentClass: any,
+  channel: number
+): void {
+  (ParentClass.prototype as any)._onAggregationUpdate.call(layer, {channel});
+
+  if (channel !== 0) return;
+
+  const props = layer.getCurrentLayer().props;
+  const {aggregator} = layer.state;
+  const result = aggregator.getResult(0);
+  const binValues = result?.value as Float32Array | undefined;
+  if (!binValues || aggregator.binCount <= 0) return;
+
+  layer.setState({
+    rawColorBinValues: Float32Array.from(binValues.subarray(0, aggregator.binCount))
+  });
+
+  const domain = aggregator.getResultDomain(0);
+  const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
+
+  if (props.colorMap) {
+    classifyBinsByCustomBreaks(layer.state.colors, aggregator.binCount, props.colorMap, binValues);
+  }
+
+  let enrichedDomain = domain;
+  if (props.colorScaleType === 'quantile') {
+    enrichedDomain = Array.from(binValues)
+      .slice(0, aggregator.binCount)
+      .filter(Number.isFinite)
+      .sort((a: number, b: number) => a - b);
+  }
+  props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
+}
+
+/**
+ * Shared renderLayers() wrapper that re-classifies bins when custom colorMap
+ * changes between renders without triggering a full re-aggregation.
+ *
+ * @param layer       The enhanced layer instance (`this`)
+ * @param ParentClass The deck.gl parent class (HexagonLayer or GridLayer)
+ * @returns The sublayers returned by the parent's renderLayers()
+ */
+export function enrichedRenderLayers(layer: any, ParentClass: any): any {
+  const props = layer.getCurrentLayer().props;
+  const {colors, rawColorBinValues, aggregator} = layer.state;
+  if (props.colorMap && colors && rawColorBinValues && aggregator?.binCount > 0) {
+    classifyBinsByCustomBreaks(colors, aggregator.binCount, props.colorMap, rawColorBinValues);
+  }
+  return (ParentClass.prototype as any).renderLayers.call(layer);
+}

--- a/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
@@ -11,14 +11,14 @@ import type {AggregatedBin, ColorMap} from '@kepler.gl/types';
  */
 export function buildAggregatedBinMap(
   binValues: ArrayLike<number>,
-  binCount: number
+  binCount: number,
+  aggregator?: any
 ): Record<number, AggregatedBin> {
   const bins: Record<number, AggregatedBin> = {};
   for (let i = 0; i < binCount; i++) {
     const val = binValues[i];
-    if (Number.isFinite(val)) {
-      bins[i] = {i, value: val, counts: 1};
-    }
+    const count = aggregator?.getBin?.(i)?.count ?? 0;
+    bins[i] = {i, value: val, counts: count};
   }
   return bins;
 }
@@ -130,7 +130,7 @@ export function enrichedAggregationUpdate(
   });
 
   const domain = aggregator.getResultDomain(0);
-  const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount);
+  const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount, aggregator);
 
   if (props.colorMap) {
     classifyBinsByCustomBreaks(layer.state.colors, aggregator.binCount, props.colorMap, binValues);
@@ -143,7 +143,7 @@ export function enrichedAggregationUpdate(
       .filter(Number.isFinite)
       .sort((a: number, b: number) => a - b);
   }
-  props.onSetColorDomain({domain: enrichedDomain, aggregatedBins});
+  props.onSetColorDomain?.({domain: enrichedDomain, aggregatedBins});
 }
 
 /**

--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -232,6 +232,36 @@ export default class AggregationLayer extends Layer {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   updateLayerVisualChannel({dataContainer}, channel) {
     this.validateVisualChannel(channel);
+
+    // When scale type changes, recompute colorDomain from stored aggregatedBins.
+    // quantile scale needs the full sorted array of bin values; other scales need [min, max].
+    const visualChannel = this.visualChannels[channel];
+    if (visualChannel && this.config.aggregatedBins) {
+      const scaleType = this.config[visualChannel.scale];
+      const domainKey = visualChannel.domain;
+      const bins = Object.values(this.config.aggregatedBins) as {value: number}[];
+      if (bins.length > 0) {
+        if (scaleType === 'quantile') {
+          const sorted = bins
+            .map(b => b.value)
+            .filter(Number.isFinite)
+            .sort((a, b) => a - b);
+          this.updateLayerConfig({[domainKey]: sorted});
+        } else {
+          let min = Infinity;
+          let max = -Infinity;
+          for (const b of bins) {
+            if (Number.isFinite(b.value)) {
+              if (b.value < min) min = b.value;
+              if (b.value > max) max = b.value;
+            }
+          }
+          if (Number.isFinite(min) && Number.isFinite(max)) {
+            this.updateLayerConfig({[domainKey]: [min, max]});
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -485,14 +485,32 @@ export default class AggregationLayer extends Layer {
       }
     };
 
+    // deck.gl's aggregation shader maps bin values to a color texture using a
+    // simple linear interpolation: (value - domain[0]) / (domain[1] - domain[0]).
+    // It only understands 'quantize', 'quantile', 'ordinal', and 'linear'.
+    // kepler.gl's 'custom' scale (d3.scaleThreshold with user-defined break
+    // points) cannot be represented in the shader directly.  Instead, our
+    // ScaleEnhanced*Layer._onAggregationUpdate reclassifies each bin's raw
+    // value into a break index [0 … N-1].  We then tell deck.gl to use
+    // 'quantize' over [0, N-1] so each index maps to the correct color pixel.
+    let colorScaleType = this.config.colorScale as string;
+    let customColorDomain: [number, number] | undefined;
+    const isCustomScale = colorScaleType === 'custom';
+    const colorMap = isCustomScale ? visConfig.colorRange.colorMap : undefined;
+    if (isCustomScale && colorMap) {
+      colorScaleType = 'quantize';
+      customColorDomain = [0, colorMap.length - 1];
+    }
+
     return {
       ...this.getDefaultDeckLayerProps(opts),
       coverage: visConfig.coverage,
 
       // color
       colorRange: this.getColorRange(visConfig.colorRange),
-      colorMap: visConfig.colorRange.colorMap,
-      colorScaleType: this.config.colorScale,
+      colorMap,
+      colorScaleType,
+      ...(customColorDomain ? {colorDomain: customColorDomain} : {}),
       upperPercentile: visConfig.percentile[1],
       lowerPercentile: visConfig.percentile[0],
       colorAggregation: visConfig.colorAggregation,

--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -233,10 +233,11 @@ export default class AggregationLayer extends Layer {
   updateLayerVisualChannel({dataContainer}, channel) {
     this.validateVisualChannel(channel);
 
-    // When scale type changes, recompute colorDomain from stored aggregatedBins.
+    // When the color scale type changes, recompute colorDomain from stored aggregatedBins.
     // quantile scale needs the full sorted array of bin values; other scales need [min, max].
+    // aggregatedBins is only populated from onSetColorDomain, so restrict to the color channel.
     const visualChannel = this.visualChannels[channel];
-    if (visualChannel && this.config.aggregatedBins) {
+    if (channel === 'color' && visualChannel && this.config.aggregatedBins) {
       const scaleType = this.config[visualChannel.scale];
       const domainKey = visualChannel.domain;
       const bins = Object.values(this.config.aggregatedBins) as {value: number}[];

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -136,8 +136,7 @@ export function mergeLayerVisConfigForNewDatasets(
         return layer;
       }
       const allowedKeys = (Object.keys(patch) as Array<keyof LayerVisConfig>).filter(
-        key =>
-          Object.prototype.hasOwnProperty.call(settings, key) && patch[key] !== undefined
+        key => Object.prototype.hasOwnProperty.call(settings, key) && patch[key] !== undefined
       );
       if (!allowedKeys.length) {
         return layer;

--- a/src/types/layers.d.ts
+++ b/src/types/layers.d.ts
@@ -27,7 +27,7 @@ export type LayerBaseConfig = {
   };
 
   // for aggregate layer, aggregatedBins is returned for custom color scale
-  aggregatedBins?: AggregatedBin[];
+  aggregatedBins?: Record<number, AggregatedBin>;
 
   columnMode?: string;
   heightField?: VisualChannelField;

--- a/src/utils/src/data-scale-utils.ts
+++ b/src/utils/src/data-scale-utils.ts
@@ -523,7 +523,7 @@ export function getHistogramDomain({
   dataset,
   fieldValueAccessor
 }: {
-  aggregatedBins?: AggregatedBin[];
+  aggregatedBins?: Record<number, AggregatedBin>;
   columnStats?: FilterProps['columnStats'];
   dataset?: KeplerTable;
   fieldValueAccessor: (idx: unknown) => number;

--- a/test/browser/layer-tests/grid-layer-specs.js
+++ b/test/browser/layer-tests/grid-layer-specs.js
@@ -352,11 +352,12 @@ test('#GridLayer -> renderLayer', t => {
           'getBin array length should be binCount * 2 (col, row pairs)'
         );
 
-        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
-        // call (the degenerate [min,max] from the parent is suppressed).
+        // onSetColorDomain fires twice: first the parent's [min, max], then our
+        // enriched {domain, aggregatedBins}.  The last call is the one that sticks.
         // count aggregation: bins have 0, 2, and 1 filtered points
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
-        const enrichedArg0 = spyLayerCallbacks.args[0][0];
+        const lastIdx0 = spyLayerCallbacks.args.length - 1;
+        const enrichedArg0 = spyLayerCallbacks.args[lastIdx0][0];
         t.ok(
           !Array.isArray(enrichedArg0),
           'callback should receive enriched object, not plain array'
@@ -492,8 +493,8 @@ test('#GridLayer -> renderLayer', t => {
           'should have exactly 1 NaN color value (empty bin)'
         );
 
-        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
-        // call (the degenerate [min,max] from the parent is suppressed).
+        // onSetColorDomain fires twice: first the parent's [min, max], then our
+        // enriched {domain, aggregatedBins}.  The last call is the one that sticks.
         // max aggregation of trip_distance: bins with filtered points have max 7.13 and 11
         // Float32 precision: 7.13 may become 7.130000114440918
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');

--- a/test/browser/layer-tests/grid-layer-specs.js
+++ b/test/browser/layer-tests/grid-layer-specs.js
@@ -352,18 +352,17 @@ test('#GridLayer -> renderLayer', t => {
           'getBin array length should be binCount * 2 (col, row pairs)'
         );
 
-        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
-        // ScaleEnhancedGridLayer override.
+        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
+        // call (the degenerate [min,max] from the parent is suppressed).
         // count aggregation: bins have 0, 2, and 1 filtered points
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
-        const domainArg = spyLayerCallbacks.args[0][0];
-        t.deepEqual(domainArg, [0, 2], 'first onSetLayerDomain call should receive exact domain [0, 2]');
-        const lastCallIdx0 = spyLayerCallbacks.args.length - 1;
-        const enrichedArg0 = spyLayerCallbacks.args[lastCallIdx0][0];
-        if (!Array.isArray(enrichedArg0)) {
-          t.ok(enrichedArg0.aggregatedBins, 'enriched call should include aggregatedBins');
-          t.deepEqual(enrichedArg0.domain, [0, 2], 'enriched domain should be [0, 2]');
-        }
+        const enrichedArg0 = spyLayerCallbacks.args[0][0];
+        t.ok(
+          !Array.isArray(enrichedArg0),
+          'callback should receive enriched object, not plain array'
+        );
+        t.deepEqual(enrichedArg0.domain, [0, 2], 'enriched domain should be [0, 2]');
+        t.ok(enrichedArg0.aggregatedBins, 'enriched call should include aggregatedBins');
 
         // Verify aggregator state and per-bin values
         const aggregator = cpuGridLayer.state?.aggregator;
@@ -493,23 +492,22 @@ test('#GridLayer -> renderLayer', t => {
           'should have exactly 1 NaN color value (empty bin)'
         );
 
-        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
-        // ScaleEnhancedGridLayer override. The last call is the enriched one.
+        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
+        // call (the degenerate [min,max] from the parent is suppressed).
         // max aggregation of trip_distance: bins with filtered points have max 7.13 and 11
         // Float32 precision: 7.13 may become 7.130000114440918
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
         const lastCallIdx = spyLayerCallbacks.args.length - 1;
         const domainCallArg = spyLayerCallbacks.args[lastCallIdx][0];
-        const domainArg = Array.isArray(domainCallArg) ? domainCallArg : domainCallArg.domain;
+        t.ok(!Array.isArray(domainCallArg), 'callback should receive enriched object');
+        const domainArg = domainCallArg.domain;
         t.equal(domainArg.length, 2, 'domain should have 2 elements');
         t.ok(
           Math.abs(domainArg[0] - 7.13) < 0.001,
           `domain[0] should be ~7.13 (got ${domainArg[0]})`
         );
         t.equal(domainArg[1], 11, 'domain[1] should be 11');
-        if (!Array.isArray(domainCallArg)) {
-          t.ok(domainCallArg.aggregatedBins, 'enriched call should include aggregatedBins');
-        }
+        t.ok(domainCallArg.aggregatedBins, 'enriched call should include aggregatedBins');
 
         // Verify aggregator state and per-bin values
         const aggregator = cpuGridLayer.state?.aggregator;

--- a/test/browser/layer-tests/grid-layer-specs.js
+++ b/test/browser/layer-tests/grid-layer-specs.js
@@ -352,11 +352,18 @@ test('#GridLayer -> renderLayer', t => {
           'getBin array length should be binCount * 2 (col, row pairs)'
         );
 
-        // deck.gl 9: onSetColorDomain receives [min, max] tuple
+        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
+        // ScaleEnhancedGridLayer override.
         // count aggregation: bins have 0, 2, and 1 filtered points
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
         const domainArg = spyLayerCallbacks.args[0][0];
-        t.deepEqual(domainArg, [0, 2], 'onSetLayerDomain should receive exact domain [0, 2]');
+        t.deepEqual(domainArg, [0, 2], 'first onSetLayerDomain call should receive exact domain [0, 2]');
+        const lastCallIdx0 = spyLayerCallbacks.args.length - 1;
+        const enrichedArg0 = spyLayerCallbacks.args[lastCallIdx0][0];
+        if (!Array.isArray(enrichedArg0)) {
+          t.ok(enrichedArg0.aggregatedBins, 'enriched call should include aggregatedBins');
+          t.deepEqual(enrichedArg0.domain, [0, 2], 'enriched domain should be [0, 2]');
+        }
 
         // Verify aggregator state and per-bin values
         const aggregator = cpuGridLayer.state?.aggregator;
@@ -486,18 +493,23 @@ test('#GridLayer -> renderLayer', t => {
           'should have exactly 1 NaN color value (empty bin)'
         );
 
-        // deck.gl 9: onSetColorDomain receives [min, max] tuple
+        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
+        // ScaleEnhancedGridLayer override. The last call is the enriched one.
         // max aggregation of trip_distance: bins with filtered points have max 7.13 and 11
         // Float32 precision: 7.13 may become 7.130000114440918
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
         const lastCallIdx = spyLayerCallbacks.args.length - 1;
-        const domainArg = spyLayerCallbacks.args[lastCallIdx][0];
+        const domainCallArg = spyLayerCallbacks.args[lastCallIdx][0];
+        const domainArg = Array.isArray(domainCallArg) ? domainCallArg : domainCallArg.domain;
         t.equal(domainArg.length, 2, 'domain should have 2 elements');
         t.ok(
           Math.abs(domainArg[0] - 7.13) < 0.001,
           `domain[0] should be ~7.13 (got ${domainArg[0]})`
         );
         t.equal(domainArg[1], 11, 'domain[1] should be 11');
+        if (!Array.isArray(domainCallArg)) {
+          t.ok(domainCallArg.aggregatedBins, 'enriched call should include aggregatedBins');
+        }
 
         // Verify aggregator state and per-bin values
         const aggregator = cpuGridLayer.state?.aggregator;

--- a/test/browser/layer-tests/grid-layer-specs.js
+++ b/test/browser/layer-tests/grid-layer-specs.js
@@ -362,7 +362,9 @@ test('#GridLayer -> renderLayer', t => {
           !Array.isArray(enrichedArg0),
           'callback should receive enriched object, not plain array'
         );
-        t.deepEqual(enrichedArg0.domain, [0, 2], 'enriched domain should be [0, 2]');
+        // Default colorScale is 'quantile', so the enriched domain is the full
+        // sorted array of per-bin values (not just [min, max]).
+        t.deepEqual(enrichedArg0.domain, [0, 1, 2], 'enriched domain should be full sorted bin values for quantile scale');
         t.ok(enrichedArg0.aggregatedBins, 'enriched call should include aggregatedBins');
 
         // Verify aggregator state and per-bin values

--- a/test/browser/layer-tests/hexagon-layer-specs.js
+++ b/test/browser/layer-tests/hexagon-layer-specs.js
@@ -352,11 +352,19 @@ test('#HexagonLayer -> renderLayer', t => {
           t.deepEqual(props[key], expectedProps[key], `should have correct props.${key}`);
         });
 
-        // deck.gl 9: onSetColorDomain receives [min, max] tuple
+        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
+        // ScaleEnhancedHexagonLayer override.
         // count aggregation: bins have 0, 2, and 1 filtered points
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
         const domainArg = spyLayerCallbacks.args[0][0];
-        t.deepEqual(domainArg, [0, 2], 'onSetLayerDomain should receive exact domain [0, 2]');
+        t.deepEqual(domainArg, [0, 2], 'first onSetLayerDomain call should receive exact domain [0, 2]');
+        // The enriched call should also have been made
+        const lastCallIdx = spyLayerCallbacks.args.length - 1;
+        const enrichedArg = spyLayerCallbacks.args[lastCallIdx][0];
+        if (!Array.isArray(enrichedArg)) {
+          t.ok(enrichedArg.aggregatedBins, 'enriched call should include aggregatedBins');
+          t.deepEqual(enrichedArg.domain, [0, 2], 'enriched domain should be [0, 2]');
+        }
 
         // Verify aggregator state and per-bin values
         const aggregator = deckHexLayer.state?.aggregator;
@@ -486,18 +494,23 @@ test('#HexagonLayer -> renderLayer', t => {
           'should have exactly 1 NaN color value (empty bin)'
         );
 
-        // deck.gl 9: onSetColorDomain receives [min, max] tuple
+        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
+        // ScaleEnhancedHexagonLayer override. The last call is the enriched one.
         // max aggregation of trip_distance: bins with filtered points have max 7.13 and 11
         // Float32 precision: 7.13 may become 7.130000114440918
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
         const lastCallIdx = spyLayerCallbacks.args.length - 1;
-        const domainArg = spyLayerCallbacks.args[lastCallIdx][0];
+        const domainCallArg = spyLayerCallbacks.args[lastCallIdx][0];
+        const domainArg = Array.isArray(domainCallArg) ? domainCallArg : domainCallArg.domain;
         t.equal(domainArg.length, 2, 'domain should have 2 elements');
         t.ok(
           Math.abs(domainArg[0] - 7.13) < 0.001,
           `domain[0] should be ~7.13 (got ${domainArg[0]})`
         );
         t.equal(domainArg[1], 11, 'domain[1] should be 11');
+        if (!Array.isArray(domainCallArg)) {
+          t.ok(domainCallArg.aggregatedBins, 'enriched call should include aggregatedBins');
+        }
 
         // Verify aggregator state and per-bin values
         const aggregator = deckHexLayer.state?.aggregator;

--- a/test/browser/layer-tests/hexagon-layer-specs.js
+++ b/test/browser/layer-tests/hexagon-layer-specs.js
@@ -362,7 +362,9 @@ test('#HexagonLayer -> renderLayer', t => {
           !Array.isArray(enrichedArg),
           'callback should receive enriched object, not plain array'
         );
-        t.deepEqual(enrichedArg.domain, [0, 2], 'enriched domain should be [0, 2]');
+        // Default colorScale is 'quantile', so the enriched domain is the full
+        // sorted array of per-bin values (not just [min, max]).
+        t.deepEqual(enrichedArg.domain, [0, 1, 2], 'enriched domain should be full sorted bin values for quantile scale');
         t.ok(enrichedArg.aggregatedBins, 'enriched call should include aggregatedBins');
 
         // Verify aggregator state and per-bin values

--- a/test/browser/layer-tests/hexagon-layer-specs.js
+++ b/test/browser/layer-tests/hexagon-layer-specs.js
@@ -352,11 +352,12 @@ test('#HexagonLayer -> renderLayer', t => {
           t.deepEqual(props[key], expectedProps[key], `should have correct props.${key}`);
         });
 
-        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
-        // call (the degenerate [min,max] from the parent is suppressed).
+        // onSetColorDomain fires twice: first the parent's [min, max], then our
+        // enriched {domain, aggregatedBins}.  The last call is the one that sticks.
         // count aggregation: bins have 0, 2, and 1 filtered points
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
-        const enrichedArg = spyLayerCallbacks.args[0][0];
+        const lastIdx = spyLayerCallbacks.args.length - 1;
+        const enrichedArg = spyLayerCallbacks.args[lastIdx][0];
         t.ok(
           !Array.isArray(enrichedArg),
           'callback should receive enriched object, not plain array'
@@ -492,8 +493,8 @@ test('#HexagonLayer -> renderLayer', t => {
           'should have exactly 1 NaN color value (empty bin)'
         );
 
-        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
-        // call (the degenerate [min,max] from the parent is suppressed).
+        // onSetColorDomain fires twice: first the parent's [min, max], then our
+        // enriched {domain, aggregatedBins}.  The last call is the one that sticks.
         // max aggregation of trip_distance: bins with filtered points have max 7.13 and 11
         // Float32 precision: 7.13 may become 7.130000114440918
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');

--- a/test/browser/layer-tests/hexagon-layer-specs.js
+++ b/test/browser/layer-tests/hexagon-layer-specs.js
@@ -352,19 +352,17 @@ test('#HexagonLayer -> renderLayer', t => {
           t.deepEqual(props[key], expectedProps[key], `should have correct props.${key}`);
         });
 
-        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
-        // ScaleEnhancedHexagonLayer override.
+        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
+        // call (the degenerate [min,max] from the parent is suppressed).
         // count aggregation: bins have 0, 2, and 1 filtered points
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
-        const domainArg = spyLayerCallbacks.args[0][0];
-        t.deepEqual(domainArg, [0, 2], 'first onSetLayerDomain call should receive exact domain [0, 2]');
-        // The enriched call should also have been made
-        const lastCallIdx = spyLayerCallbacks.args.length - 1;
-        const enrichedArg = spyLayerCallbacks.args[lastCallIdx][0];
-        if (!Array.isArray(enrichedArg)) {
-          t.ok(enrichedArg.aggregatedBins, 'enriched call should include aggregatedBins');
-          t.deepEqual(enrichedArg.domain, [0, 2], 'enriched domain should be [0, 2]');
-        }
+        const enrichedArg = spyLayerCallbacks.args[0][0];
+        t.ok(
+          !Array.isArray(enrichedArg),
+          'callback should receive enriched object, not plain array'
+        );
+        t.deepEqual(enrichedArg.domain, [0, 2], 'enriched domain should be [0, 2]');
+        t.ok(enrichedArg.aggregatedBins, 'enriched call should include aggregatedBins');
 
         // Verify aggregator state and per-bin values
         const aggregator = deckHexLayer.state?.aggregator;
@@ -494,23 +492,22 @@ test('#HexagonLayer -> renderLayer', t => {
           'should have exactly 1 NaN color value (empty bin)'
         );
 
-        // deck.gl 9: onSetColorDomain now sends {domain, aggregatedBins} via
-        // ScaleEnhancedHexagonLayer override. The last call is the enriched one.
+        // onSetColorDomain now sends a single enriched {domain, aggregatedBins}
+        // call (the degenerate [min,max] from the parent is suppressed).
         // max aggregation of trip_distance: bins with filtered points have max 7.13 and 11
         // Float32 precision: 7.13 may become 7.130000114440918
         t.ok(spyLayerCallbacks.called, 'should call onSetLayerDomain');
         const lastCallIdx = spyLayerCallbacks.args.length - 1;
         const domainCallArg = spyLayerCallbacks.args[lastCallIdx][0];
-        const domainArg = Array.isArray(domainCallArg) ? domainCallArg : domainCallArg.domain;
+        t.ok(!Array.isArray(domainCallArg), 'callback should receive enriched object');
+        const domainArg = domainCallArg.domain;
         t.equal(domainArg.length, 2, 'domain should have 2 elements');
         t.ok(
           Math.abs(domainArg[0] - 7.13) < 0.001,
           `domain[0] should be ~7.13 (got ${domainArg[0]})`
         );
         t.equal(domainArg[1], 11, 'domain[1] should be 11');
-        if (!Array.isArray(domainCallArg)) {
-          t.ok(domainCallArg.aggregatedBins, 'enriched call should include aggregatedBins');
-        }
+        t.ok(domainCallArg.aggregatedBins, 'enriched call should include aggregatedBins');
 
         // Verify aggregator state and per-bin values
         const aggregator = deckHexLayer.state?.aggregator;


### PR DESCRIPTION
#3381 

- [x] Legend shows wrong break points for quantile scale on Hexbin/Grid layers (#3381) — Override _onAggregationUpdate in enhanced layers to pass full sorted bin values instead of just [min, max]
- [x] colorDomain not recomputed when switching scale type — Recompute domain from stored aggregatedBins in updateLayerVisualChannel
- [x] Custom Color Breaks don't work on aggregation layers — Pre-classify bin values into break indices and remap colorScaleType/colorDomain for deck.gl's GPU shader
- [x] Wrong type for aggregatedBins — Changed from AggregatedBin[] to Record<number, AggregatedBin> across 4 files
- [x] Custom break inputs too small to read values — Smaller font (10px), less padding, slightly wider inputs (54px)

<img width="264" height="498" alt="Screenshot 2026-04-22 at 1 33 29 PM" src="https://github.com/user-attachments/assets/0b17c35f-ab32-4e01-bfc0-e00604ca198d" />
