### PR TITLE
chore: Sync all localization files with English base translation

### DIFF
--- a/src/localization/src/translations/ca.ts
+++ b/src/localization/src/translations/ca.ts
@@ -122,7 +122,7 @@ export default {
       tile3d: 'mosaic 3D'
     },
     wms: {
-      hover: 'Value:'
+      hover: 'Valor:'
     },
     layerUpdateError:
       "S'ha produït un error durant l'actualització de la capa: {errorMessage}. Assegureu-vos que el format de les dades d’entrada sigui vàlid.",
@@ -298,7 +298,7 @@ export default {
     removeBaseMapStyle: 'Elimina estil de mapa base',
     delete: 'Esborra',
     timePlayback: 'Reproducció de temps',
-    timeFilterSync: 'Sync with a column from another dataset',
+    timeFilterSync: "Sincronitza amb una columna d'un altre conjunt de dades",
     cloudStorage: 'Emmagatzematge al núvol',
     '3DMap': 'Mapa 3D',
     animationByWindow: 'Finestra Temporal Mòbil',
@@ -391,7 +391,7 @@ export default {
       filteredData: 'Dades filtrades',
       unfilteredData: 'Dades sense filtrar',
       fileCount: '{fileCount} Arxius',
-      rowCount: '{rowCount} Files',
+      rowCount: '{rowCount} files',
       tiledDatasetWarning: "* L'exportació de dades per a conjunts de dades en mosaic no és compatible"
     },
     deleteData: {
@@ -409,11 +409,11 @@ export default {
         'aquí. *kepler.gl és una aplicació client, les dades romanen al teu navegador..',
       exampleToken: 'p.ex. pk.abcdefg.xxxxxx',
       pasteTitle: "1. Enganxa la URL de l'estil",
-      pasteSubtitle0: 'Style url can be a mapbox',
+      pasteSubtitle0: "La URL de l'estil pot ser una URL de Mapbox",
       pasteSubtitle1: 'Què és un',
       pasteSubtitle2: "URL de l'estil",
-      pasteSubtitle3: 'or a style.json using the',
-      pasteSubtitle4: 'Mapbox GL Style Spec',
+      pasteSubtitle3: "o un style.json que utilitzi l'",
+      pasteSubtitle4: "especificació d'estil de Mapbox GL",
       namingTitle: '3. Posa nom al teu estil'
     },
     shareMap: {
@@ -648,20 +648,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Origen',
+          targetColor: 'Destinació'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Origen',
+          targetColor: 'Destinació'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: 'Color de farciment',
+          strokeColor: 'Contorn'
         }
       }
     }

--- a/src/localization/src/translations/ca.ts
+++ b/src/localization/src/translations/ca.ts
@@ -26,7 +26,8 @@ export default {
     selectType: 'Selecciona un Tipus',
     selectValue: 'Selecciona un Valor',
     enterValue: 'Entra un valor',
-    empty: 'buit'
+    empty: 'buit',
+    selectLayer: 'Selecciona una capa'
   },
   misc: {
     by: '',
@@ -53,9 +54,12 @@ export default {
       labelWithId: 'Etiqueta {labelId}',
       fontSize: 'Mida de la font',
       fontColor: 'Color de la font',
+      backgroundColor: 'Color de fons',
       textAnchor: 'Àncora del text',
       alignment: 'Alineació',
-      addMoreLabel: 'Afegeix més etiquetes'
+      addMoreLabel: 'Afegeix més etiquetes',
+      outlineWidth: 'Amplada del contorn',
+      outlineColor: 'Color del contorn'
     }
   },
   sidebar: {
@@ -64,10 +68,15 @@ export default {
       filter: 'Filtres',
       interaction: 'Interaccions',
       basemap: 'Mapa base'
+    },
+    panelViewToggle: {
+      list: 'Visualitza Llista',
+      byDataset: 'Visualitza per Conjunt de dades'
     }
   },
   layer: {
     required: 'Requerit*',
+    columnModesSeparator: 'O',
     radius: 'Radi',
     color: 'Color',
     fillColor: 'Color fons',
@@ -87,6 +96,10 @@ export default {
     aggregateBy: '{field} agregat per',
     '3DModel': 'Model 3D',
     '3DModelOptions': 'Opcions del model 3D',
+    service: 'Servei',
+    layer: 'Capa',
+    appearance: 'Aparença',
+    uniqueIdField: 'Camp ID únic',
     type: {
       point: 'punt',
       arc: 'arc',
@@ -102,10 +115,18 @@ export default {
       hexagonid: 'H3',
       trip: 'viatge',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'mosaic vectorial',
+      rastertile: 'mosaic ràster',
+      wms: 'WMS',
+      tile3d: 'mosaic 3D'
+    },
+    wms: {
+      hover: 'Value:'
     },
     layerUpdateError:
       "S'ha produït un error durant l'actualització de la capa: {errorMessage}. Assegureu-vos que el format de les dades d’entrada sigui vàlid.",
+    interaction: 'Interacció',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
@@ -123,6 +144,7 @@ export default {
     billboardDescription: 'Orientar la geometria cap a la càmera',
     fadeTrail: 'Rastre de desvaniment',
     opacity: 'Opacitat',
+    pointSize: 'Mida del punt',
     coverage: 'Cobertura',
     outline: 'Outline',
     colorRange: 'Rang de color',
@@ -160,12 +182,17 @@ export default {
     fixedHeightDescription: "Utilitzeu l'alçada sense modificacions",
     allowHover: "Mostra informació d'eina",
     allowHoverDescription:
-      "Mostra o oculta la informació d'eina en passar el cursor per sobre de les característiques de la capa"
+      "Mostra o oculta la informació d'eina en passar el cursor per sobre de les característiques de la capa",
+    showNeighborOnHover: 'Ressalta veïns en passar el cursor',
+    showHighlightColor: 'Mostra color de ressaltat',
+    darkModeEnabled: 'Mapa base fosc',
+    transparentBackground: 'Fons transparent'
   },
   layerManager: {
     addData: 'Afegeix Dades',
     addLayer: 'Afegeix Capes',
-    layerBlending: 'Combinar capes'
+    layerBlending: 'Combinar capes',
+    overlayBlending: 'Combinació de superposició'
   },
   mapManager: {
     mapStyle: 'Estil de mapa',
@@ -173,19 +200,76 @@ export default {
     '3dBuildingColor': 'Color edifici 3D',
     backgroundColor: 'Color de fons'
   },
+  effectManager: {
+    effects: 'Efectes',
+    addEffect: 'Afegeix efecte',
+    pickDateTime: 'Selecciona data/hora',
+    currentTime: 'Hora actual',
+    pickCurrrentTime: 'Selecciona hora actual',
+    date: 'Data',
+    time: 'Hora',
+    timezone: 'Zona horària'
+  },
+  effectDescription: {
+    lightAndShadow:
+      "Simula il·luminació solar realista i ombres basades en l'hora del dia i la ubicació geogràfica. Intensitat d'ombra, colors de llum solar i ambiental ajustables.",
+    ink: "Aplica un estil artístic de tinta que enfosqueix les vores i crea una aparença dibuixada a mà. Ajusta la intensitat per controlar l'efecte.",
+    brightnessContrast:
+      "Ajusta la brillantor i el contrast generals del mapa. Utilitza valors positius per augmentar la brillantor o el contrast, valors negatius per enfosquir o aplanar la imatge.",
+    hueSaturation:
+      "Canvia el to de color i ajusta la saturació de tot el mapa. Útil per crear temes de color o desaturar la vista.",
+    vibrance:
+      "Augmenta selectivament la intensitat dels colors apagats sense sobresaturar els ja vius. Produeix una millora de color més natural que la saturació.",
+    sepia:
+      "Aplica un to marró càlid reminiscent de fotografies antigues. Controla la quantitat per barrejar entre els colors originals i l'aspecte sèpia.",
+    dotScreen:
+      "Converteix la imatge en un patró de punts monocroms, semblant a la impressió de mitjos tons de diari. Ajusta l'angle, la mida dels punts i la posició central.",
+    colorHalftone:
+      "Simula la impressió de mitjos tons de color CMYK amb patrons de punts separats per a cada canal de color. Controla l'angle, la mida dels punts i la posició central.",
+    noise:
+      "Afegeix soroll aleatori estil gra de pel·lícula al mapa. Útil per a una estètica texturitzada i analògica o per reduir el banding de color.",
+    triangleBlur:
+      "Aplica un desenfocament suau de tipus gaussià uniformement al mapa. Controla el radi de desenfocament per ajustar el nivell de suavitat.",
+    zoomBlur:
+      "Crea un desenfocament de moviment radial que emana d'un punt central, simulant un zoom de càmera. Ajusta la intensitat i la posició central.",
+    tiltShift:
+      "Simula un efecte de lent tilt-shift que desenfoca les àrees fora d'una banda focal, creant un aspecte de maqueta en miniatura. Estableix la banda focal amb posicions d'inici/fi.",
+    edgeWork:
+      "Ressalta les vores estructurals de la imatge utilitzant un estil artístic de dibuix al carbó. Ajusta el radi de detecció per controlar el gruix de la línia.",
+    vignette:
+      "Enfosqueix les cantonades i vores del mapa, dirigint l'atenció cap al centre. Controla la quantitat d'enfosquiment i el radi de l'àrea clara.",
+    magnify:
+      "Crea una superposició de lupa circular en una posició configurable. Ajusta la mida, el nivell de zoom i l'amplada de la vora.",
+    hexagonalPixelate:
+      "Substitueix la imatge per una quadrícula de mosaic hexagonal, cadascun omplert amb el color mitjà de l'àrea que cobreix. Ajusta l'escala del mosaic.",
+    distanceFog:
+      "Desvaneix els objectes llunyans en un color de boira basat en la seva profunditat respecte a la càmera, millorant la sensació de profunditat. Controla la densitat, la distància d'inici, l'abast i el color de la boira.",
+    surfaceFog:
+      "Renderitza una capa de boira a una elevació específica sobre la superfície del terreny. Ajusta l'elevació, el gruix de transició, la densitat, el color i un patró de soroll opcional."
+  },
   layerConfiguration: {
     defaultDescription: 'Calcula {property} segons el camp seleccionat',
-    howTo: 'How to'
+    howTo: 'Com funciona',
+    showColorChart: 'Mostra gràfic de colors',
+    hideColorChart: 'Amaga gràfic de colors'
   },
   filterManager: {
-    addFilter: 'Afegeix Filtre'
+    addFilter: 'Afegeix Filtre',
+    timeFilterSync: 'Conjunts sincronitzats',
+    timeLayerSync: 'Vincula amb la línia de temps de la capa',
+    timeLayerUnsync: 'Desvincula de la línia de temps de la capa',
+    column: 'Columna'
   },
   datasetTitle: {
     showDataTable: 'Mostra taula de dades',
     removeDataset: 'Elimina conjunt de dades'
   },
   datasetInfo: {
-    rowCount: '{rowCount} files'
+    rowCount: '{rowCount} files',
+    vectorTile: 'Mosaic vectorial',
+    rasterTile: 'Mosaic ràster',
+    wmsTile: 'Mosaic WMS',
+    tile3d: 'Mosaic 3D'
   },
   tooltip: {
     hideLayer: 'oculta la capa',
@@ -195,6 +279,8 @@ export default {
     hide: 'amaga',
     show: 'mostra',
     removeLayer: 'Elimina capa',
+    duplicateLayer: 'Duplica capa',
+    zoomToLayer: 'Zoom a la capa',
     resetAfterError: 'Intenteu habilitar la capa després dun error',
     layerSettings: 'Configuració de capa',
     closePanel: 'Tanca panel actual',
@@ -209,8 +295,10 @@ export default {
     showLayerPanel: 'Mostra el tauler de capes',
     moveToTop: 'Desplaça a dalt de tot de les capes de dades',
     selectBaseMapStyle: 'Selecciona estil de mapa base',
+    removeBaseMapStyle: 'Elimina estil de mapa base',
     delete: 'Esborra',
     timePlayback: 'Reproducció de temps',
+    timeFilterSync: 'Sync with a column from another dataset',
     cloudStorage: 'Emmagatzematge al núvol',
     '3DMap': 'Mapa 3D',
     animationByWindow: 'Finestra Temporal Mòbil',
@@ -219,12 +307,22 @@ export default {
     play: 'iniciar',
     pause: 'pausar',
     reset: 'reiniciar',
-    export: 'exportar'
+    export: 'exportar',
+    timeLayerSync: 'Vincula amb la línia de temps de la capa',
+    timeLayerUnsync: 'Desvincula de la línia de temps de la capa',
+    syncTimelineStart: "Inici del període de temps del filtre actual",
+    syncTimelineEnd: "Fi del període de temps del filtre actual",
+    showEffectPanel: "Mostra el panell d'efectes",
+    hideEffectPanel: "Amaga el panell d'efectes",
+    removeEffect: "Elimina l'efecte",
+    disableEffect: "Desactiva l'efecte",
+    effectSettings: "Configuració de l'efecte"
   },
   toolbar: {
     exportImage: 'Exporta imatge',
     exportData: 'Exporta dades',
     exportMap: 'Exporta mapa',
+    exportVideo: 'Exporta Vídeo',
     shareMapURL: 'Comparteix URL del mapa',
     saveMap: 'Desa mapa',
     select: 'selecciona',
@@ -233,6 +331,16 @@ export default {
     hide: 'amaga',
     show: 'mostra',
     ...LOCALES
+  },
+  editor: {
+    filterLayer: 'Filtra capes',
+    filterLayerDisabled: 'Les geometries no poligonals no es poden utilitzar per filtrar',
+    copyGeometry: 'Copia geometria',
+    noLayersToFilter: 'No hi ha capes per filtrar'
+  },
+  exportVideoModal: {
+    animation: 'Animació',
+    settings: 'Configuració'
   },
   modal: {
     title: {
@@ -243,7 +351,8 @@ export default {
       exportMap: 'Exporta mapa',
       addCustomMapboxStyle: 'Afegeix estil Mapbox propi',
       saveMap: 'Desa mapa',
-      shareURL: 'Comparteix URL'
+      shareURL: 'Comparteix URL',
+      exportVideo: 'Exporta Vídeo'
     },
     button: {
       delete: 'Esborra',
@@ -267,6 +376,10 @@ export default {
       mapLegendTitle: 'Llegenda del mapa',
       mapLegendAdd: 'Afegir llegenda al mapa'
     },
+    exportVideo: {
+      animation: 'Animació',
+      settings: 'Configuració'
+    },
     exportData: {
       datasetTitle: 'Conjunt de dades',
       datasetSubtitle: 'Escull els conjunts de dades que vols exportar',
@@ -278,7 +391,8 @@ export default {
       filteredData: 'Dades filtrades',
       unfilteredData: 'Dades sense filtrar',
       fileCount: '{fileCount} Arxius',
-      rowCount: '{rowCount} Files'
+      rowCount: '{rowCount} Files',
+      tiledDatasetWarning: "* L'exportació de dades per a conjunts de dades en mosaic no és compatible"
     },
     deleteData: {
       warning: "estàs a punt d'esborrar aquest conjunt de dades. Afectarà {length} capes"
@@ -295,11 +409,15 @@ export default {
         'aquí. *kepler.gl és una aplicació client, les dades romanen al teu navegador..',
       exampleToken: 'p.ex. pk.abcdefg.xxxxxx',
       pasteTitle: "1. Enganxa la URL de l'estil",
+      pasteSubtitle0: 'Style url can be a mapbox',
       pasteSubtitle1: 'Què és un',
       pasteSubtitle2: "URL de l'estil",
+      pasteSubtitle3: 'or a style.json using the',
+      pasteSubtitle4: 'Mapbox GL Style Spec',
       namingTitle: '3. Posa nom al teu estil'
     },
     shareMap: {
+      title: 'Comparteix mapa',
       shareUriTitle: 'Comparteix URL del mapa',
       shareUriSubtitle: 'Genera una URL del mapa per compartir amb altri',
       cloudTitle: 'Emmagatzematge al núvol',
@@ -327,6 +445,8 @@ export default {
         tokenPlaceholder: "Enganxa el teu token d'accés a Mapbox",
         tokenMisuseWarning:
           '* Si no proporciones el teu propi token, el mapa podria fallar en qualsevol moment quan reemplacem el nostre token per evitar abusos. ',
+        tokenSecurityWarning:
+          "* Avís: el vostre token de Mapbox s'incrustarà al fitxer HTML exportat. Qualsevol persona amb accés a aquest fitxer podrà veure i utilitzar el vostre token. Utilitzeu un token amb restriccions d'URL quan sigui possible. ",
         tokenDisclaimer:
           'Pots canviar el toke de Mapbox més endavant fent servir aquestes instruccions: ',
         tokenUpdate: 'Com actualitzar un token preexistent.',
@@ -353,6 +473,7 @@ export default {
     },
     loadData: {
       upload: 'Carregar arxius',
+      tileset: 'Conjunt de mosaic',
       storage: "Carregar des d'emmagatzematge"
     },
     tripInfo: {
@@ -362,7 +483,10 @@ export default {
       code: ' [longitude, latitude, altitude, timestamp] ',
       description2:
         'i el darrer element ha de ser la marca de temps. Els formats vàlids per a la marca de temps inclouen Unix en segons com `1564184363` o en milisegons com `1564184363000`.',
-      example: 'Exemple:'
+      example: 'Exemple:',
+      titleTable: 'Crear viatges a partir d\'una llista de punts',
+      descriptionTable1:
+        'Els viatges es poden crear unint una llista de punts de latitud i longitud, ordenant per marques de temps i agrupant per identificadors únics.'
     },
     iconInfo: {
       title: 'Com dibuixar icones',
@@ -372,6 +496,20 @@ export default {
       description2: " kepler.gl automàticament crearà una capa d'icona.",
       example: 'Exemple:',
       icons: 'Icones'
+    },
+    polygonInfo: {
+      title: 'Crear capa de polígons a partir de funcions GeoJSON',
+      titleTable: 'Crear camí a partir de punts',
+      descriptionTable: `Els camins es poden crear unint una llista de punts de latitud i longitud, ordenant per un camp d'índex (p.ex. marca de temps) i agrupant per identificadors únics.
+
+  ### Columnes de la capa:
+  - **id**: - *obligatori*&nbsp;- Una columna \`id\` s'utilitza per agrupar punts. Els punts amb el mateix id s'uniran en un únic camí.
+  - **lat**: - *obligatori*&nbsp;- La latitud del punt
+  - **lon**: - *obligatori*&nbsp;- La longitud del punt
+  - **alt**: - *opcional*&nbsp;- L'altitud del punt
+  - **sort by**: - *opcional*&nbsp;- Una columna \`sort by\` s'utilitza per ordenar els punts; si no s'especifica, els punts s'ordenaran per índex de fila.
+`,
+      exampleTable: 'Example CSV'
     },
     storageMapViewer: {
       lastModified: 'Darrera modificació fa {lastUpdated}',
@@ -385,7 +523,9 @@ export default {
       back: 'Enrere',
       goToPage: 'Ves a la pàgina {displayName} de Kepler.gl',
       storageMaps: 'Emmagatzematge / Mapes',
-      noSavedMaps: 'Cap mapa desat encara'
+      noSavedMaps: 'Cap mapa desat encara',
+      foursquareStorageMessage:
+        "Només es mostren aquí els mapes desats amb l'opció Kepler.gl > Desar > Emmagatzematge de Foursquare"
     }
   },
   header: {
@@ -404,13 +544,29 @@ export default {
     normal: 'normal',
     subtractive: 'substractiva'
   },
+  overlayBlending: {
+    title: 'Combinació de superposició del mapa',
+    description: 'Combina les capes amb el mapa base perquè ambdós siguin visibles.',
+    screen: 'mapa base fosc',
+    normal: 'normal',
+    darken: 'mapa base clar'
+  },
   columns: {
     title: 'Columnes',
     lat: 'lat',
     lng: 'lon',
     altitude: 'alçada',
+    alt: 'altitud',
+    id: 'id',
+    timestamp: 'temps',
     icon: 'icona',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow origen',
+    geoarrow1: 'geoarrow destinació',
+    token: 'token',
+    sortBy: 'ordenar per',
+    neighbors: 'veïns',
     arc: {
       lat0: 'lat origen',
       lng0: 'lng origen ',
@@ -433,12 +589,17 @@ export default {
     customPalette: 'Paleta personalitzada',
     steps: 'intervals',
     type: 'tipus',
-    reversed: 'invertida'
+    colorBlindSafe: 'Segur per a daltònics',
+    reversed: 'invertida',
+    disableStepReason: "No es pot canviar el nombre de passos amb talls de color personalitzats, utilitza la paleta personalitzada per editar els passos",
+    preset: 'Colors predefinits',
+    picker: 'Selector de color'
   },
   scale: {
     colorScale: 'Escala de color',
     sizeScale: 'Escala de mides',
     strokeScale: 'Escala de traç',
+    strokeColorScale: 'Escala de color de traç',
     scale: 'Escala'
   },
   fileUploader: {
@@ -454,6 +615,11 @@ export default {
     uploading: 'Carregant',
     fileNotSupported: "L'arxiu {errorFiles} no és compatible.",
     or: 'o'
+  },
+  tilesetSetup: {
+    header: 'Configurar mosaics vectorials',
+    rasterTileHeader: 'Configurar mosaics ràster',
+    addTilesetText: 'Afegir conjunt de mosaic'
   },
   geocoder: {
     title: 'Introdueix una adreça'
@@ -477,5 +643,27 @@ export default {
   'Bug Report': "Informe d'errors",
   'User Guide': "Guia d'usuari",
   Save: 'Desa',
-  Share: 'Comparteix'
+  Share: 'Comparteix',
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/cn.ts
+++ b/src/localization/src/translations/cn.ts
@@ -26,7 +26,8 @@ export default {
     selectType: '选择类型',
     selectValue: '选择值',
     enterValue: '输入值',
-    empty: '未选择'
+    empty: '未选择',
+    selectLayer: '选择图层'
   },
   misc: {
     by: '',
@@ -44,7 +45,8 @@ export default {
     building: '建筑物',
     water: '水',
     land: '地面',
-    '3dBuilding': '3D建筑'
+    '3dBuilding': '3D建筑',
+    background: '背景'
   },
   panel: {
     text: {
@@ -52,9 +54,12 @@ export default {
       labelWithId: '标签 {labelId}',
       fontSize: '字体大小',
       fontColor: '字体颜色',
+      backgroundColor: '背景色',
       textAnchor: '文本锚',
       alignment: '对齐方式',
-      addMoreLabel: '添加更多标签'
+      addMoreLabel: '添加更多标签',
+      outlineWidth: '轮廓宽度',
+      outlineColor: '轮廓颜色'
     }
   },
   sidebar: {
@@ -63,10 +68,15 @@ export default {
       filter: '过滤器',
       interaction: '交互',
       basemap: '底图'
+    },
+    panelViewToggle: {
+      list: '查看列表',
+      byDataset: '按数据集查看'
     }
   },
   layer: {
     required: '必填*',
+    columnModesSeparator: '或',
     radius: '半径',
     color: '颜色',
     fillColor: '填充色',
@@ -86,6 +96,10 @@ export default {
     aggregateBy: '{field}聚合如下: ',
     '3DModel': '3D模型',
     '3DModelOptions': '3D模型选项',
+    service: '服务',
+    layer: '图层',
+    appearance: '外观',
+    uniqueIdField: '唯一ID字段',
     type: {
       point: 'point',
       arc: 'arc',
@@ -101,8 +115,18 @@ export default {
       hexagonid: 'H3',
       trip: 'trip',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'vector tile',
+      rastertile: 'raster tile',
+      wms: 'WMS',
+      tile3d: '3D tile'
     },
+    wms: {
+      hover: 'Value:'
+    },
+    layerUpdateError:
+      '图层更新时发生错误：{errorMessage}。请确保输入数据的格式有效。',
+    interaction: '交互',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
@@ -116,7 +140,11 @@ export default {
     radiusRange: '半径范围',
     clusterRadius: '聚类半径',
     radiusRangePixels: '半径范围[像素]',
+    billboard: '公告板模式',
+    billboardDescription: '将几何体朝向相机',
+    fadeTrail: '渐隐轨迹',
     opacity: '透明度',
+    pointSize: '点大小',
     coverage: '覆盖范围',
     outline: '轮廓',
     colorRange: '色彩范围',
@@ -133,6 +161,7 @@ export default {
     elevationScale: '海拔比例',
     enableElevationZoomFactor: '使用高程缩放系数',
     enableElevationZoomFactorDescription: '根据当前缩放系数调整海拔',
+    enableHeightZoomFactor: '使用高度缩放因子',
     heightScale: '高度比例',
     coverageRange: '覆盖范围',
     highPrecisionRendering: '高精度渲染',
@@ -147,32 +176,98 @@ export default {
     threshold: 'Threshold',
     zoomScale: '缩放比例',
     heightRange: '高度范围',
+    heightMultiplier: '高度倍增器',
+    fixedHeight: '固定高度',
+    fixedHeightDescription: '使用未修改的高度',
     allowHover: '显示工具提示',
-    allowHoverDescription: '悬停在图层要素上时显示或隐藏工具提示'
+    allowHoverDescription: '悬停在图层要素上时显示或隐藏工具提示',
+    showNeighborOnHover: '悬停时高亮邻居',
+    showHighlightColor: '显示高亮颜色',
+    darkModeEnabled: '深色底图',
+    transparentBackground: '透明背景'
   },
   layerManager: {
     addData: '添加数据',
     addLayer: '添加图层',
-    layerBlending: '混合图层'
+    layerBlending: '混合图层',
+    overlayBlending: '叠加混合'
   },
   mapManager: {
     mapStyle: '地图样式',
     addMapStyle: '添加地图样式',
-    '3dBuildingColor': '3D 建筑颜色'
+    '3dBuildingColor': '3D 建筑颜色',
+    backgroundColor: '背景色'
+  },
+  effectManager: {
+    effects: '效果',
+    addEffect: '添加效果',
+    pickDateTime: '选择日期/时间',
+    currentTime: '当前时间',
+    pickCurrrentTime: '选择当前时间',
+    date: '日期',
+    time: '时间',
+    timezone: '时区'
+  },
+  effectDescription: {
+    lightAndShadow:
+      '根据一天中的时间和地理位置模拟逼真的阳光照射和阴影投射。可调节阴影强度、阳光和环境光颜色。',
+    ink: '应用水墨艺术风格，使边缘变暗并创建手绘外观。调整强度以控制效果的程度。',
+    brightnessContrast:
+      '调整地图的整体亮度和对比度。使用正值来增加亮度或对比度，负值来变暗或平坦化图像。',
+    hueSaturation:
+      '改变色调并调整整个地图的饱和度。适用于创建颜色主题或降低视图饱和度。',
+    vibrance:
+      '选择性地增强暗淡颜色的强度，而不会使已经鲜艳的颜色过度饱和。比饱和度产生更自然的颜色增强效果。',
+    sepia:
+      '应用一种温暖的棕色调，让人联想到老照片。控制混合量以在原始颜色和怀旧色调之间切换。',
+    dotScreen:
+      '将图像转换为单色点图案，类似于报纸半色调印刷。调整角度、点大小和中心位置。',
+    colorHalftone:
+      '模拟CMYK彩色半色调印刷，每个颜色通道使用单独的点图案。控制角度、点大小和中心位置。',
+    noise:
+      '在地图上添加随机的胶片颗粒风格噪点。适用于创建纹理化、模拟美学效果或减少颜色条带。',
+    triangleBlur:
+      '在地图上均匀应用平滑的高斯模糊。控制模糊半径以调整柔化程度。',
+    zoomBlur:
+      '创建从中心点向外辐射的径向运动模糊，模拟相机变焦效果。调整强度和中心位置。',
+    tiltShift:
+      '模拟移轴镜头效果，模糊焦点带之外的区域，创造微缩模型的外观。通过起始/结束位置设置焦点带。',
+    edgeWork:
+      '使用艺术炭笔素描风格突出图像中的结构边缘。调整检测半径以控制线条粗细。',
+    vignette:
+      '使地图的角落和边缘变暗，将注意力引导向中心。控制变暗程度和清晰区域的半径。',
+    magnify:
+      '在可配置位置创建圆形放大镜叠加层。调整大小、缩放级别和边框宽度。',
+    hexagonalPixelate:
+      '将图像替换为六边形瓦片网格，每个瓦片填充其覆盖区域的平均颜色。调整瓦片缩放比例。',
+    distanceFog:
+      '根据物体到相机的深度将远处物体淡入雾色，增强纵深感。控制密度、起始距离、范围和雾色。',
+    surfaceFog:
+      '在地形表面上方的特定高度渲染雾层。调整高度、过渡厚度、密度、颜色和可选的噪声图案。'
   },
   layerConfiguration: {
     defaultDescription: '根据所选字段计算 {property}',
-    howTo: '使用方法'
+    howTo: '使用方法',
+    showColorChart: '显示颜色图表',
+    hideColorChart: '隐藏颜色图表'
   },
   filterManager: {
-    addFilter: '添加过滤器'
+    addFilter: '添加过滤器',
+    timeFilterSync: '同步数据集',
+    timeLayerSync: '与图层时间线联动',
+    timeLayerUnsync: '取消与图层时间线联动',
+    column: '列'
   },
   datasetTitle: {
     showDataTable: '显示数据表',
     removeDataset: '删除数据集'
   },
   datasetInfo: {
-    rowCount: '{rowCount}行'
+    rowCount: '{rowCount}行',
+    vectorTile: '矢量瓦片',
+    rasterTile: '栅格瓦片',
+    wmsTile: 'WMS瓦片',
+    tile3d: '3D瓦片'
   },
   tooltip: {
     hideLayer: '隐藏图层',
@@ -184,6 +279,7 @@ export default {
     removeLayer: '删除图层',
     zoomToLayer: '缩放☞图层',
     duplicateLayer: '复制图层',
+    resetAfterError: '尝试在错误后启用图层',
     layerSettings: '图层设置',
     closePanel: '关闭当前面板',
     switchToDualView: '切换到双地图视图',
@@ -197,8 +293,10 @@ export default {
     showLayerPanel: '显示图层面板',
     moveToTop: '移至图层顶部',
     selectBaseMapStyle: '选择底图样式',
+    removeBaseMapStyle: '移除底图样式',
     delete: '删除',
     timePlayback: '时空回放',
+    timeFilterSync: 'Sync with a column from another dataset',
     cloudStorage: '云存储',
     '3DMap': '3D 地图',
     animationByWindow: '移动时间窗口',
@@ -207,12 +305,22 @@ export default {
     play: '播放',
     pause: '暂停',
     reset: '重置',
-    export: '导出'
+    export: '导出',
+    timeLayerSync: '与图层时间线联动',
+    timeLayerUnsync: '取消与图层时间线联动',
+    syncTimelineStart: '当前过滤时间段的起始',
+    syncTimelineEnd: '当前过滤时间段的结束',
+    showEffectPanel: '显示效果面板',
+    hideEffectPanel: '隐藏效果面板',
+    removeEffect: '移除效果',
+    disableEffect: '禁用效果',
+    effectSettings: '效果设置'
   },
   toolbar: {
     exportImage: '导出图片',
     exportData: '导出数据',
     exportMap: '导出地图',
+    exportVideo: '导出视频',
     shareMapURL: '分享地图网址',
     saveMap: '保存地图',
     select: '选择',
@@ -224,7 +332,13 @@ export default {
   },
   editor: {
     filterLayer: '过滤图层',
-    copyGeometry: '复制几何图形'
+    filterLayerDisabled: '非多边形几何图形不能用于过滤',
+    copyGeometry: '复制几何图形',
+    noLayersToFilter: '没有可过滤的图层'
+  },
+  exportVideoModal: {
+    animation: '动画',
+    settings: '设置'
   },
   modal: {
     title: {
@@ -233,6 +347,7 @@ export default {
       exportImage: '导出图片',
       exportData: '导出数据',
       exportMap: '导出地图',
+      exportVideo: '导出视频',
       addCustomMapboxStyle: '添加自定义地图',
       saveMap: '保存地图',
       shareURL: '分享网址'
@@ -259,6 +374,10 @@ export default {
       mapLegendTitle: '地图图例',
       mapLegendAdd: '在地图上添加图例'
     },
+    exportVideo: {
+      animation: '动画',
+      settings: '设置'
+    },
     exportData: {
       datasetTitle: '数据集',
       datasetSubtitle: '选择要导出的数据集',
@@ -270,7 +389,8 @@ export default {
       filteredData: '过滤数据',
       unfilteredData: '元数据',
       fileCount: '{fileCount} 个文件',
-      rowCount: '{rowCount} 行'
+      rowCount: '{rowCount} 行',
+      tiledDatasetWarning: "* 不支持导出瓦片数据集的数据"
     },
     deleteData: {
       warning: '确认要删除这个数据集。它会影响 {length} 个层'
@@ -295,6 +415,7 @@ export default {
       namingTitle: '3. 命名你的样式'
     },
     shareMap: {
+      title: '分享地图',
       shareUriTitle: '分享地图网址',
       shareUriSubtitle: '生成分享地图的链接',
       cloudTitle: '云存储',
@@ -322,6 +443,8 @@ export default {
         tokenPlaceholder: '粘贴个人的 Mapbox 访问令牌access token）',
         tokenMisuseWarning:
           '* 如果您不提供自己的令牌，则在我们更换令牌时，地图可能随时无法显示，以免被滥用。',
+        tokenSecurityWarning:
+          '* 警告：您的Mapbox令牌将嵌入导出的HTML文件中。任何有权访问此文件的人都可以看到并使用您的令牌。请尽可能使用带有URL限制的范围令牌。',
         tokenDisclaimer: '可以稍后使用以下说明更改 Mapbox 令牌：',
         tokenUpdate: '如何更新现有的地图令牌。',
         modeTitle: '地图模式',
@@ -347,16 +470,21 @@ export default {
     },
     loadData: {
       upload: '上传文件',
+      tileset: '瓦片集',
       storage: '从存储中加载'
     },
     tripInfo: {
       title: '如何启用移动动画',
+      titleTable: '从点列表创建行程',
       description1:
         '要路径设置动画，geoJSON 数据必须包含 `LineString` 作为要素几何。此外，LineString 的坐标有四个元素',
+      descriptionTable1:
+        '行程可以通过连接经纬度点列表、按时间戳排序并按唯一标识符分组来创建。',
       code: ' [经度，纬度，高程，时间戳] ',
       description2:
         '最后一个元素是时间戳。有效的时间戳格式包括以秒为单位的 unix，例如`1564184363`或以毫秒为单位的`1564184363000`。',
-      example: '例：'
+      example: '例：',
+      exampleTable: 'Example Csv'
     },
     iconInfo: {
       title: '如何绘制图标',
@@ -366,6 +494,20 @@ export default {
       description2: '时，kepler.gl 会自动为你创建一个图标层。',
       example: '例:',
       icons: '图标一览'
+    },
+    polygonInfo: {
+      title: '从GeoJSON要素创建多边形图层',
+      titleTable: '从点创建路径',
+      descriptionTable: `路径可以通过连接经纬度点列表、按索引字段（如时间戳）排序并按唯一标识符分组来创建。
+
+  ### 图层列：
+  - **id**: - *必填*&nbsp;- \`id\` 列用于按点分组。具有相同id的点将合并为单条路径。
+  - **lat**: - *必填*&nbsp;- 点的纬度
+  - **lon**: - *必填*&nbsp;- 点的经度
+  - **alt**: - *可选*&nbsp;- 点的高度
+  - **sort by**: - *可选*&nbsp;- \`sort by\` 列用于对点进行排序；如果未指定，点将按行索引排序。
+`,
+      exampleTable: 'Example CSV'
     },
     storageMapViewer: {
       lastModified: '上次修改 {lastUpdated} 前',
@@ -379,7 +521,9 @@ export default {
       back: '返回',
       goToPage: '跳转到 Kepler.gl 的 {displayName} 页面',
       storageMaps: '存储 / 地図',
-      noSavedMaps: '还没有保存的地图'
+      noSavedMaps: '还没有保存的地图',
+      foursquareStorageMessage:
+        '仅显示使用 Kepler.gl > 保存 > Foursquare存储 选项保存的地图'
     }
   },
   header: {
@@ -398,19 +542,38 @@ export default {
     normal: 'normal',
     subtractive: 'subtractive'
   },
+  overlayBlending: {
+    title: '地图叠加混合',
+    description: '将图层与底图混合，使两者都可见。',
+    screen: '深色底图',
+    normal: '正常',
+    darken: '浅色底图'
+  },
   columns: {
     title: '列',
     lat: '纬度',
     lng: '经度',
     altitude: '海拔',
+    alt: '高度',
+    id: 'id',
+    timestamp: '时间',
     icon: '图标',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow 起点',
+    geoarrow1: 'geoarrow 终点',
     token: '令牌',
+    sortBy: '排序依据',
+    neighbors: '邻居',
     arc: {
       lat0: '起点 纬度',
       lng0: '起点 经度',
       lat1: '终点 纬度',
       lng1: '终点 经度'
+    },
+    line: {
+      alt0: '起点海拔',
+      alt1: '终点海拔'
     },
     grid: {
       worldUnitSize: '网格大小 (km)'
@@ -424,12 +587,17 @@ export default {
     customPalette: '自定义调色板',
     steps: '步骤',
     type: '类型',
-    reversed: '反转'
+    colorBlindSafe: '色盲安全',
+    reversed: '反转',
+    disableStepReason: "使用自定义颜色断点时无法更改步数，请使用自定义调色板编辑步数",
+    preset: '预设颜色',
+    picker: '颜色选择器'
   },
   scale: {
     colorScale: '色阶',
     sizeScale: '大小比例',
     strokeScale: '描边比例',
+    strokeColorScale: '线条颜色比例',
     scale: '规模'
   },
   fileUploader: {
@@ -445,6 +613,11 @@ export default {
     uploading: '上传',
     fileNotSupported: '不支持文件 {errorFiles}。',
     or: '或'
+  },
+  tilesetSetup: {
+    header: '设置矢量瓦片',
+    rasterTileHeader: '设置栅格瓦片',
+    addTilesetText: '添加瓦片集'
   },
   geocoder: {
     title: '输入地址或坐标（例： 37.79,-122.40）'
@@ -468,5 +641,27 @@ export default {
   'Bug Report': '错误报告',
   'User Guide': '用户指南',
   Save: '保存',
-  Share: '分享'
+  Share: '分享',
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/cn.ts
+++ b/src/localization/src/translations/cn.ts
@@ -122,7 +122,7 @@ export default {
       tile3d: '3D tile'
     },
     wms: {
-      hover: 'Value:'
+      hover: '值:'
     },
     layerUpdateError:
       '图层更新时发生错误：{errorMessage}。请确保输入数据的格式有效。',
@@ -296,7 +296,7 @@ export default {
     removeBaseMapStyle: '移除底图样式',
     delete: '删除',
     timePlayback: '时空回放',
-    timeFilterSync: 'Sync with a column from another dataset',
+    timeFilterSync: '与另一个数据集中的列同步',
     cloudStorage: '云存储',
     '3DMap': '3D 地图',
     animationByWindow: '移动时间窗口',
@@ -646,20 +646,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: '源',
+          targetColor: '目标'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: '源',
+          targetColor: '目标'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: '填充色',
+          strokeColor: '轮廓线'
         }
       }
     }

--- a/src/localization/src/translations/es.ts
+++ b/src/localization/src/translations/es.ts
@@ -26,7 +26,8 @@ export default {
     selectType: 'Selecciona un Tipo',
     selectValue: 'Selecciona un Valor',
     enterValue: 'Entra un valor',
-    empty: 'vacio'
+    empty: 'vacio',
+    selectLayer: 'Selecciona una capa'
   },
   misc: {
     by: '',
@@ -53,9 +54,12 @@ export default {
       labelWithId: 'Etiqueta {labelId}',
       fontSize: 'Tamaño de fuente',
       fontColor: 'Color de fuente',
+      backgroundColor: 'Color de fondo',
       textAnchor: 'Anclaje del texto',
       alignment: 'Alineación',
-      addMoreLabel: 'Añadir más etiquetas'
+      addMoreLabel: 'Añadir más etiquetas',
+      outlineWidth: 'Ancho del contorno',
+      outlineColor: 'Color del contorno'
     }
   },
   sidebar: {
@@ -64,10 +68,15 @@ export default {
       filter: 'Filtros',
       interaction: 'Interacciones',
       basemap: 'Mapa base'
+    },
+    panelViewToggle: {
+      list: 'Ver Lista',
+      byDataset: 'Ver por Conjunto de datos'
     }
   },
   layer: {
     required: 'Requerido*',
+    columnModesSeparator: 'O',
     radius: 'Radio',
     color: 'Color',
     fillColor: 'Color de relleno',
@@ -87,6 +96,10 @@ export default {
     aggregateBy: '{field} agregado por',
     '3DModel': 'Modelo 3D',
     '3DModelOptions': 'Opciones del modelo 3D',
+    service: 'Servicio',
+    layer: 'Capa',
+    appearance: 'Apariencia',
+    uniqueIdField: 'Campo ID único',
     type: {
       point: 'punto',
       arc: 'arco',
@@ -102,10 +115,18 @@ export default {
       hexagonid: 'H3',
       trip: 'viaje',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'mosaico vectorial',
+      rastertile: 'mosaico ráster',
+      wms: 'WMS',
+      tile3d: 'mosaico 3D'
+    },
+    wms: {
+      hover: 'Value:'
     },
     layerUpdateError:
       'Se produjo un error durante la actualización de la capa: {errorMessage}. Asegúrese de que el formato de los datos de entrada sea válido.',
+    interaction: 'Interacción',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
@@ -123,6 +144,7 @@ export default {
     billboardDescription: 'Oriente la geometría hacia la cámara',
     fadeTrail: 'Sendero de desvanecimiento',
     opacity: 'Opacidad',
+    pointSize: 'Tamaño del punto',
     coverage: 'Cobertura',
     outline: 'Contorno',
     colorRange: 'Rango de color',
@@ -161,12 +183,17 @@ export default {
     fixedHeightDescription: 'Usar altura sin modificaciones',
     allowHover: 'Mostrar descripción emergente',
     allowHoverDescription:
-      'Mostrar u ocultar información emergente al pasar el cursor sobre las características de la capa'
+      'Mostrar u ocultar información emergente al pasar el cursor sobre las características de la capa',
+    showNeighborOnHover: 'Resaltar vecinos al pasar el cursor',
+    showHighlightColor: 'Mostrar color de resaltado',
+    darkModeEnabled: 'Mapa base oscuro',
+    transparentBackground: 'Fondo transparente'
   },
   layerManager: {
     addData: 'Añadir datos',
     addLayer: 'Añadir capa',
-    layerBlending: 'Combinar capas'
+    layerBlending: 'Combinar capas',
+    overlayBlending: 'Combinación de superposición'
   },
   mapManager: {
     mapStyle: 'Estilo de mapa',
@@ -174,19 +201,76 @@ export default {
     '3dBuildingColor': 'Color edificios 3D',
     backgroundColor: 'Color de fondo'
   },
+  effectManager: {
+    effects: 'Efectos',
+    addEffect: 'Añadir efecto',
+    pickDateTime: 'Seleccionar fecha/hora',
+    currentTime: 'Hora actual',
+    pickCurrrentTime: 'Seleccionar hora actual',
+    date: 'Fecha',
+    time: 'Hora',
+    timezone: 'Zona horaria'
+  },
+  effectDescription: {
+    lightAndShadow:
+      'Simula iluminación solar realista y proyección de sombras basada en la hora del día y la ubicación geográfica. Intensidad de sombra, colores de luz solar y ambiental ajustables.',
+    ink: 'Aplica un estilo artístico de tinta que oscurece los bordes y crea una apariencia dibujada a mano. Ajusta la intensidad para controlar el efecto.',
+    brightnessContrast:
+      'Ajusta el brillo y contraste generales del mapa. Usa valores positivos para aumentar el brillo o el contraste, valores negativos para oscurecer o aplanar la imagen.',
+    hueSaturation:
+      'Cambia el tono de color y ajusta la saturación en todo el mapa. Útil para crear temas de color o desaturar la vista.',
+    vibrance:
+      'Aumenta selectivamente la intensidad de los colores apagados sin sobresaturar los ya vivos. Produce una mejora de color más natural que la saturación.',
+    sepia:
+      'Aplica un tono marrón cálido reminiscente de fotografías antiguas. Controla la cantidad para mezclar entre los colores originales y el aspecto sepia.',
+    dotScreen:
+      'Convierte la imagen en un patrón de puntos monocromos, similar a la impresión de semitonos de periódico. Ajusta el ángulo, el tamaño de los puntos y la posición central.',
+    colorHalftone:
+      'Simula la impresión de semitonos de color CMYK con patrones de puntos separados para cada canal de color. Controla el ángulo, el tamaño de los puntos y la posición central.',
+    noise:
+      'Añade ruido aleatorio estilo grano de película al mapa. Útil para una estética texturizada y analógica o para reducir el banding de color.',
+    triangleBlur:
+      'Aplica un desenfoque suave de tipo gaussiano uniformemente en el mapa. Controla el radio de desenfoque para ajustar el nivel de suavidad.',
+    zoomBlur:
+      'Crea un desenfoque de movimiento radial que emana de un punto central, simulando un zoom de cámara. Ajusta la intensidad y la posición central.',
+    tiltShift:
+      'Simula un efecto de lente tilt-shift que desenfoca las áreas fuera de una banda focal, creando un aspecto de maqueta en miniatura. Establece la banda focal con posiciones de inicio/fin.',
+    edgeWork:
+      'Resalta los bordes estructurales de la imagen usando un estilo artístico de dibujo al carbón. Ajusta el radio de detección para controlar el grosor de la línea.',
+    vignette:
+      'Oscurece las esquinas y bordes del mapa, dirigiendo la atención hacia el centro. Controla la cantidad de oscurecimiento y el radio del área clara.',
+    magnify:
+      'Crea una superposición de lupa circular en una posición configurable. Ajusta el tamaño, el nivel de zoom y el ancho del borde.',
+    hexagonalPixelate:
+      'Reemplaza la imagen con una cuadrícula de mosaicos hexagonales, cada uno relleno con el color promedio del área que cubre. Ajusta la escala del mosaico.',
+    distanceFog:
+      'Desvanece los objetos distantes en un color de niebla basado en su profundidad desde la cámara, mejorando la sensación de profundidad. Controla la densidad, la distancia de inicio, el rango y el color de la niebla.',
+    surfaceFog:
+      'Renderiza una capa de niebla a una elevación específica sobre la superficie del terreno. Ajusta la elevación, el grosor de transición, la densidad, el color y un patrón de ruido opcional.'
+  },
   layerConfiguration: {
     defaultDescription: 'Calcular {property} según el campo seleccionado',
-    howTo: 'How to'
+    howTo: 'Cómo funciona',
+    showColorChart: 'Mostrar gráfico de colores',
+    hideColorChart: 'Ocultar gráfico de colores'
   },
   filterManager: {
-    addFilter: 'Añadir filtro'
+    addFilter: 'Añadir filtro',
+    timeFilterSync: 'Conjuntos sincronizados',
+    timeLayerSync: 'Vincular con la línea de tiempo de la capa',
+    timeLayerUnsync: 'Desvincular de la línea de tiempo de la capa',
+    column: 'Columna'
   },
   datasetTitle: {
     showDataTable: 'Mostar la tabla de datos',
     removeDataset: 'Eliminar conjunto de datos'
   },
   datasetInfo: {
-    rowCount: '{rowCount} files'
+    rowCount: '{rowCount} files',
+    vectorTile: 'Mosaico vectorial',
+    rasterTile: 'Mosaico ráster',
+    wmsTile: 'Mosaico WMS',
+    tile3d: 'Mosaico 3D'
   },
   tooltip: {
     hideLayer: 'Ocultar la capa',
@@ -196,6 +280,8 @@ export default {
     hide: 'Ocultar',
     show: 'Mostrar',
     removeLayer: 'Eliminar capa',
+    duplicateLayer: 'Duplicar capa',
+    zoomToLayer: 'Zoom a la capa',
     resetAfterError: 'Intente habilitar la capa después de un error',
     layerSettings: 'Configuración de capa',
     closePanel: 'Cerrar el panel actual',
@@ -210,8 +296,10 @@ export default {
     showLayerPanel: 'Mostrar la tabla  de capas',
     moveToTop: 'Desplazar arriba de las capas de datos',
     selectBaseMapStyle: 'Seleccionar estilo de mapa base',
+    removeBaseMapStyle: 'Eliminar estilo de mapa base',
     delete: 'Borrar',
     timePlayback: 'Reproducción de tiempo',
+    timeFilterSync: 'Sync with a column from another dataset',
     cloudStorage: 'Almacenaje en la nube',
     '3DMap': 'Mapa 3D',
     animationByWindow: 'Ventana Temporal Móvil',
@@ -220,12 +308,22 @@ export default {
     play: 'iniciar',
     pause: 'pausar',
     reset: 'reiniciar',
-    export: 'exportar'
+    export: 'exportar',
+    timeLayerSync: 'Vincular con la línea de tiempo de la capa',
+    timeLayerUnsync: 'Desvincular de la línea de tiempo de la capa',
+    syncTimelineStart: 'Inicio del período de tiempo del filtro actual',
+    syncTimelineEnd: 'Fin del período de tiempo del filtro actual',
+    showEffectPanel: 'Mostrar panel de efectos',
+    hideEffectPanel: 'Ocultar panel de efectos',
+    removeEffect: 'Eliminar efecto',
+    disableEffect: 'Desactivar efecto',
+    effectSettings: 'Configuración de efecto'
   },
   toolbar: {
     exportImage: 'Exportar imagen',
     exportData: 'Exportar datos',
     exportMap: 'Exportar mapa',
+    exportVideo: 'Exportar Vídeo',
     shareMapURL: 'Compartir el enlace del mapa',
     saveMap: 'Guardar mapa',
     select: 'selecciona',
@@ -235,6 +333,16 @@ export default {
     show: 'mostrar',
     ...LOCALES
   },
+  editor: {
+    filterLayer: 'Filtrar capas',
+    filterLayerDisabled: 'Las geometrías no poligonales no se pueden usar para filtrar',
+    copyGeometry: 'Copiar geometría',
+    noLayersToFilter: 'No hay capas para filtrar'
+  },
+  exportVideoModal: {
+    animation: 'Animación',
+    settings: 'Configuración'
+  },
   modal: {
     title: {
       deleteDataset: 'Borrar conjunto de datos',
@@ -242,6 +350,7 @@ export default {
       exportImage: 'Exportar imagen',
       exportData: 'Exportar datos',
       exportMap: 'Exportar mapa',
+      exportVideo: 'Exportar Vídeo',
       addCustomMapboxStyle: 'Añadir estilo de Mapbox propio',
       saveMap: 'Guardar mapa',
       shareURL: 'Compartir enlace'
@@ -268,6 +377,10 @@ export default {
       mapLegendTitle: 'Leyenda del mapa',
       mapLegendAdd: 'Añadir leyenda al mapa'
     },
+    exportVideo: {
+      animation: 'Animación',
+      settings: 'Configuración'
+    },
     exportData: {
       datasetTitle: 'Conjunto de datos',
       datasetSubtitle: 'Escoger los conjuntos de datos a exportar',
@@ -279,7 +392,8 @@ export default {
       filteredData: 'Datos filtrados',
       unfilteredData: 'Datos sin filtrar',
       fileCount: '{fileCount} Archivos',
-      rowCount: '{rowCount} Files'
+      rowCount: '{rowCount} Files',
+      tiledDatasetWarning: "* La exportación de datos para conjuntos de datos en mosaico no es compatible"
     },
     deleteData: {
       warning: 'estás a punto de borrar este conjunto de datos. Afectará a {length} capas'
@@ -296,11 +410,15 @@ export default {
         'aquí. *kepler.gl es una aplicación cliente, los datos quedan en tu navegador..',
       exampleToken: 'p.e. pk.abcdefg.xxxxxx',
       pasteTitle: '2. Engancha el enlace del estilo',
+      pasteSubtitle0: 'Style url can be a mapbox',
       pasteSubtitle1: 'Qué es un',
       pasteSubtitle2: 'enlace del estilo',
+      pasteSubtitle3: 'or a style.json using the',
+      pasteSubtitle4: 'Mapbox GL Style Spec',
       namingTitle: '3. Poner nombre a tu estilo'
     },
     shareMap: {
+      title: 'Compartir mapa',
       shareUriTitle: 'Compartir el enlace del mapa',
       shareUriSubtitle: 'Generar un enlace del mapa para compartir con otros',
       cloudTitle: 'Almacenage en la nube',
@@ -328,6 +446,8 @@ export default {
         tokenPlaceholder: 'Enganchar tu token de acceso a Mapbox',
         tokenMisuseWarning:
           '* Si no proporcionas tu propio token, el mapa podría fallar en cualquier momento cuando reemplacemos nuestro token para evitar abusos. ',
+        tokenSecurityWarning:
+          '* Advertencia: su token de Mapbox se incrustará en el archivo HTML exportado. Cualquier persona con acceso a este archivo podrá ver y usar su token. Utilice un token con restricciones de URL cuando sea posible. ',
         tokenDisclaimer:
           'Puedes cambiar el token de Mapbox posteriormente utilizando estas instrucciones: ',
         tokenUpdate: 'Como actualitzar un token preexistente.',
@@ -354,15 +474,19 @@ export default {
     },
     loadData: {
       upload: 'Cargar archivos',
+      tileset: 'Conjunto de mosaico',
       storage: 'Cargar desde almacenage'
     },
     tripInfo: {
       title: 'Como habilitar la animación de viaje',
+      titleTable: 'Crear viajes a partir de una lista de puntos',
       description1:
         'Para animar la ruta, los datos geoJSON han de contener `LineString` en su geometría y las coordenadas de LineString deben tener 4 elementos en los formats de ',
       code: ' [longitude, latitude, altitude, timestamp] ',
       description2:
         'y el último elemento debe ser la marca del tiempo. Los formatos válidos para la marca de tiempo incluyen Unix en segundos como `1564184363` o en milisegundos como `1564184363000`.',
+      descriptionTable1:
+        'Los viajes se pueden crear uniendo una lista de puntos de latitud y longitud, ordenando por marcas de tiempo y agrupando por identificadores únicos.',
       example: 'Ejemplo:'
     },
     iconInfo: {
@@ -373,6 +497,20 @@ export default {
       description2: ' kepler.gl automáticamente creará una capa de ícono.',
       example: 'Ejemplo:',
       icons: 'Iconos'
+    },
+    polygonInfo: {
+      title: 'Crear capa de polígonos a partir de características GeoJSON',
+      titleTable: 'Crear ruta a partir de puntos',
+      descriptionTable: `Las rutas se pueden crear uniendo una lista de puntos de latitud y longitud, ordenando por un campo de índice (p.ej. marca de tiempo) y agrupando por identificadores únicos.
+
+  ### Columnas de la capa:
+  - **id**: - *obligatorio*&nbsp;- Una columna \`id\` se usa para agrupar puntos. Los puntos con el mismo id se unirán en una sola ruta.
+  - **lat**: - *obligatorio*&nbsp;- La latitud del punto
+  - **lon**: - *obligatorio*&nbsp;- La longitud del punto
+  - **alt**: - *opcional*&nbsp;- La altitud del punto
+  - **sort by**: - *opcional*&nbsp;- Una columna \`sort by\` se usa para ordenar los puntos; si no se especifica, los puntos se ordenarán por índice de fila.
+`,
+      exampleTable: 'Example CSV'
     },
     storageMapViewer: {
       lastModified: 'Última modificación hace {lastUpdated}',
@@ -386,7 +524,9 @@ export default {
       back: 'Atrás',
       goToPage: 'Ves a la página {displayName} de Kepler.gl',
       storageMaps: 'Almancenage / Mapas',
-      noSavedMaps: 'No hay ningún mapa guardado todavía'
+      noSavedMaps: 'No hay ningún mapa guardado todavía',
+      foursquareStorageMessage:
+        'Solo se muestran aquí los mapas guardados con la opción Kepler.gl > Guardar > Almacenamiento de Foursquare'
     }
   },
   header: {
@@ -405,13 +545,29 @@ export default {
     normal: 'normal',
     subtractive: 'substractiva'
   },
+  overlayBlending: {
+    title: 'Combinación de superposición del mapa',
+    description: 'Combinar capas con el mapa base para que ambos sean visibles.',
+    screen: 'mapa base oscuro',
+    normal: 'normal',
+    darken: 'mapa base claro'
+  },
   columns: {
     title: 'Columnas',
     lat: 'lat',
     lng: 'lon',
     altitude: 'altura',
+    alt: 'altitud',
+    id: 'id',
+    timestamp: 'tiempo',
     icon: 'ícono',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow origen',
+    geoarrow1: 'geoarrow destino',
+    token: 'token',
+    sortBy: 'ordenar por',
+    neighbors: 'vecinos',
     arc: {
       lat0: 'lat origen',
       lng0: 'lng origen ',
@@ -434,12 +590,17 @@ export default {
     customPalette: 'Paleta personalizada',
     steps: 'pasos',
     type: 'tipo',
-    reversed: 'invertida'
+    colorBlindSafe: 'Seguro para daltónicos',
+    reversed: 'invertida',
+    disableStepReason: "No se puede cambiar el número de pasos con cortes de color personalizados, use la paleta personalizada para editar los pasos",
+    preset: 'Colores predefinidos',
+    picker: 'Selector de color'
   },
   scale: {
     colorScale: 'Escala de color',
     sizeScale: 'Escala de medidas',
     strokeScale: 'Escala de trazo',
+    strokeColorScale: 'Escala de color de trazo',
     scale: 'Escala'
   },
   fileUploader: {
@@ -455,6 +616,11 @@ export default {
     uploading: 'Cargando',
     fileNotSupported: 'El archivo {errorFiles} no es compatible.',
     or: 'o'
+  },
+  tilesetSetup: {
+    header: 'Configurar mosaicos vectoriales',
+    rasterTileHeader: 'Configurar mosaicos ráster',
+    addTilesetText: 'Añadir conjunto de mosaico'
   },
   geocoder: {
     title: 'Introduce una dirección'
@@ -478,5 +644,27 @@ export default {
   'Bug Report': 'Informe de errores',
   'User Guide': 'Guía de usuario',
   Save: 'Guadar',
-  Share: 'Compartir'
+  Share: 'Compartir',
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/es.ts
+++ b/src/localization/src/translations/es.ts
@@ -122,7 +122,7 @@ export default {
       tile3d: 'mosaico 3D'
     },
     wms: {
-      hover: 'Value:'
+      hover: 'Valor:'
     },
     layerUpdateError:
       'Se produjo un error durante la actualización de la capa: {errorMessage}. Asegúrese de que el formato de los datos de entrada sea válido.',
@@ -266,7 +266,7 @@ export default {
     removeDataset: 'Eliminar conjunto de datos'
   },
   datasetInfo: {
-    rowCount: '{rowCount} files',
+    rowCount: '{rowCount} filas',
     vectorTile: 'Mosaico vectorial',
     rasterTile: 'Mosaico ráster',
     wmsTile: 'Mosaico WMS',
@@ -299,7 +299,7 @@ export default {
     removeBaseMapStyle: 'Eliminar estilo de mapa base',
     delete: 'Borrar',
     timePlayback: 'Reproducción de tiempo',
-    timeFilterSync: 'Sync with a column from another dataset',
+    timeFilterSync: 'Sincronizar con una columna de otro conjunto de datos',
     cloudStorage: 'Almacenaje en la nube',
     '3DMap': 'Mapa 3D',
     animationByWindow: 'Ventana Temporal Móvil',
@@ -392,7 +392,7 @@ export default {
       filteredData: 'Datos filtrados',
       unfilteredData: 'Datos sin filtrar',
       fileCount: '{fileCount} Archivos',
-      rowCount: '{rowCount} Files',
+      rowCount: '{rowCount} Filas',
       tiledDatasetWarning: "* La exportación de datos para conjuntos de datos en mosaico no es compatible"
     },
     deleteData: {
@@ -410,11 +410,11 @@ export default {
         'aquí. *kepler.gl es una aplicación cliente, los datos quedan en tu navegador..',
       exampleToken: 'p.e. pk.abcdefg.xxxxxx',
       pasteTitle: '2. Engancha el enlace del estilo',
-      pasteSubtitle0: 'Style url can be a mapbox',
+      pasteSubtitle0: 'La URL del estilo puede ser de Mapbox',
       pasteSubtitle1: 'Qué es un',
       pasteSubtitle2: 'enlace del estilo',
-      pasteSubtitle3: 'or a style.json using the',
-      pasteSubtitle4: 'Mapbox GL Style Spec',
+      pasteSubtitle3: 'o un style.json que use la',
+      pasteSubtitle4: 'especificación de estilos de Mapbox GL',
       namingTitle: '3. Poner nombre a tu estilo'
     },
     shareMap: {
@@ -649,20 +649,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Origen',
+          targetColor: 'Destino'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Origen',
+          targetColor: 'Destino'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: 'Color de relleno',
+          strokeColor: 'Contorno'
         }
       }
     }

--- a/src/localization/src/translations/fi.ts
+++ b/src/localization/src/translations/fi.ts
@@ -121,7 +121,7 @@ export default {
       tile3d: '3D-tiili'
     },
     wms: {
-      hover: 'Value:'
+      hover: 'Arvo:'
     },
     layerUpdateError:
       'Tason päivityksen aikana tapahtui virhe: {errorMessage}. Varmista, että syötetietojen muoto on kelvollinen.',
@@ -299,8 +299,8 @@ export default {
     timePlayback: 'Ajan animointi',
     cloudStorage: 'Pilvitallennus',
     '3DMap': '3D-näkymä',
-    animationByWindow: 'Moving Time Window',
-    animationByIncremental: 'Incremental Time Window',
+    animationByWindow: 'Liukuva aikaikkuna',
+    animationByIncremental: 'Kasvava aikaikkuna',
     speed: 'nopeus',
     play: 'toista',
     pause: 'tauko',
@@ -408,11 +408,11 @@ export default {
         'tänne. *kepler.gl on client-side sovellus, data pysyy vain selaimessasi...',
       exampleToken: 'esim. pk.abcdefg.xxxxxx',
       pasteTitle: '2. Liitä tyyli-URL',
-      pasteSubtitle0: 'Style url can be a mapbox',
+      pasteSubtitle0: 'Tyyli-URL voi olla Mapboxin',
       pasteSubtitle1: 'Mikä on',
       pasteSubtitle2: 'tyyli-URL?',
-      pasteSubtitle3: 'or a style.json using the',
-      pasteSubtitle4: 'Mapbox GL Style Spec',
+      pasteSubtitle3: 'tai style.json, joka käyttää',
+      pasteSubtitle4: 'Mapbox GL Style Spec -määritystä',
       namingTitle: '3. Nimeä tyylisi'
     },
     shareMap: {
@@ -647,20 +647,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Lähde',
+          targetColor: 'Kohde'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Lähde',
+          targetColor: 'Kohde'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: 'Täyttöväri',
+          strokeColor: 'Ääriviiva'
         }
       }
     }

--- a/src/localization/src/translations/fi.ts
+++ b/src/localization/src/translations/fi.ts
@@ -25,7 +25,8 @@ export default {
     selectType: 'Valitse tyyppi',
     selectValue: 'Valitse arvo',
     enterValue: 'Anna arvo',
-    empty: 'tyhjä'
+    empty: 'tyhjä',
+    selectLayer: 'Valitse taso'
   },
   misc: {
     by: '',
@@ -52,9 +53,12 @@ export default {
       labelWithId: 'Nimiö {labelId}',
       fontSize: 'Fontin koko',
       fontColor: 'Fontin väri',
+      backgroundColor: 'Taustaväri',
       textAnchor: 'Tekstin ankkuri',
       alignment: 'Sijoittelu',
-      addMoreLabel: 'Lisää uusia nimiöitä'
+      addMoreLabel: 'Lisää uusia nimiöitä',
+      outlineWidth: 'Ääriviivan leveys',
+      outlineColor: 'Ääriviivan väri'
     }
   },
   sidebar: {
@@ -63,10 +67,15 @@ export default {
       filter: 'Suodattimet',
       interaction: 'Interaktiot',
       basemap: 'Taustakartta'
+    },
+    panelViewToggle: {
+      list: 'Näytä lista',
+      byDataset: 'Näytä aineistoittain'
     }
   },
   layer: {
     required: 'Pakollinen*',
+    columnModesSeparator: 'Tai',
     radius: 'Säde',
     weight: 'Painotus',
     propertyBasedOn: '{property} perustuen arvoon',
@@ -86,6 +95,10 @@ export default {
     aggregateBy: 'Aggregoi kenttä {field} by',
     '3DModel': '3D-malli',
     '3DModelOptions': '3D-mallin asetukset',
+    service: 'Palvelu',
+    layer: 'Taso',
+    appearance: 'Ulkoasu',
+    uniqueIdField: 'Yksilöivä ID-kenttä',
     type: {
       point: 'piste',
       arc: 'kaari',
@@ -101,14 +114,23 @@ export default {
       hexagonid: 'H3',
       trip: 'matka',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'vektoritiili',
+      rastertile: 'rasteritiili',
+      wms: 'WMS',
+      tile3d: '3D-tiili'
+    },
+    wms: {
+      hover: 'Value:'
     },
     layerUpdateError:
       'Tason päivityksen aikana tapahtui virhe: {errorMessage}. Varmista, että syötetietojen muoto on kelvollinen.',
+    interaction: 'Vuorovaikutus',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
   layerVisConfigs: {
+    angle: 'Kulma',
     strokeWidth: 'Viivan paksuus',
     strokeWidthRange: 'Viivan paksuuden rajat',
     radius: 'Säde',
@@ -121,6 +143,7 @@ export default {
     billboardDescription: 'Suuntaa geometria kameraa kohti',
     fadeTrail: 'Häipyvä polku',
     opacity: 'Läpinäkyvyys',
+    pointSize: 'Pisteen koko',
     coverage: 'Kattavuus',
     outline: 'Ääriviiva',
     colorRange: 'Värien rajat',
@@ -158,12 +181,17 @@ export default {
     fixedHeightDescription: 'Käytä korkeutta ilman muutoksia',
     allowHover: 'Näytä työkaluvihje',
     allowHoverDescription:
-      'Näytä tai piilota työkaluvihje, kun osoitin on tason ominaisuuksien päällä'
+      'Näytä tai piilota työkaluvihje, kun osoitin on tason ominaisuuksien päällä',
+    showNeighborOnHover: 'Korosta naapurit osoittaessa',
+    showHighlightColor: 'Näytä korostusväri',
+    darkModeEnabled: 'Tumma taustakartta',
+    transparentBackground: 'Läpinäkyvä tausta'
   },
   layerManager: {
     addData: 'Lisää aineisto',
     addLayer: 'Lisää taso',
-    layerBlending: 'Tasojen sekoittuvuus'
+    layerBlending: 'Tasojen sekoittuvuus',
+    overlayBlending: 'Päällekkäissekoitus'
   },
   mapManager: {
     mapStyle: 'Kartan tyyli',
@@ -171,19 +199,76 @@ export default {
     '3dBuildingColor': '3D-rakennusten väri',
     backgroundColor: 'Taustaväri'
   },
+  effectManager: {
+    effects: 'Efektit',
+    addEffect: 'Lisää efekti',
+    pickDateTime: 'Valitse päivämäärä/aika',
+    currentTime: 'Nykyinen aika',
+    pickCurrrentTime: 'Valitse nykyinen aika',
+    date: 'Päivämäärä',
+    time: 'Aika',
+    timezone: 'Aikavyöhyke'
+  },
+  effectDescription: {
+    lightAndShadow:
+      'Simuloi realistista auringonvaloa ja varjojen heijastusta vuorokaudenajan ja maantieteellisen sijainnin perusteella. Säädettävä varjon voimakkuus, auringon- ja ympäristövalon värit.',
+    ink: 'Käyttää mustepesumaista taiteellista tyyliä, joka tummentaa reunoja ja luo käsin piirretyn ulkoasun. Säädä voimakkuutta tehon hallitsemiseksi.',
+    brightnessContrast:
+      'Säätää kartan yleistä kirkkautta ja kontrastia. Käytä positiivisia arvoja kirkastaaksesi tai lisätäksesi kontrastia, negatiivisia arvoja tummentaaksesi tai tasoittaaksesi kuvaa.',
+    hueSaturation:
+      'Siirtää värisävyä ja säätää kylläisyyttä koko kartalla. Hyödyllinen väriteemojen luomiseen tai näkymän värikylläisyyden vähentämiseen.',
+    vibrance:
+      'Nostaa valikoivasti himeiden värien voimakkuutta ylikyllästämättä jo eläviä värejä. Tuottaa luonnollisemman näköisen värinparannuksen kuin kylläisyys.',
+    sepia:
+      'Käyttää lämmintä ruskeaa sävyä, joka muistuttaa vanhoja valokuvia. Hallitse määrää sekoittaaksesi alkuperäisten värien ja seepiamaisen ulkoasun välillä.',
+    dotScreen:
+      'Muuntaa kuvan mustavalkoisten pisteiden kuvioksi, joka muistuttaa sanomalehtien rasteripainatusta. Säädä kulmaa, pisteen kokoa ja keskikohtaa.',
+    colorHalftone:
+      'Simuloi CMYK-värirasteripinatusta erillisillä pistekuvioilla kullekin värikanavalle. Hallitse kulmaa, pisteen kokoa ja keskikohtaa.',
+    noise:
+      'Lisää satunnaista filmirakeista kohinaa kartalle. Hyödyllinen teksturoidun, analogisen estetiikan luomiseen tai väriporrastuksen vähentämiseen.',
+    triangleBlur:
+      'Käyttää tasaista gaussimaista sumennusta tasaisesti kartalla. Hallitse sumennuksen sädettä pehmeyden tason säätämiseksi.',
+    zoomBlur:
+      'Luo säteittäisen liikesumennuksen, joka lähtee keskipisteestä simuloiden kamerazoomia. Säädä voimakkuutta ja keskikohtaa.',
+    tiltShift:
+      'Simuloi tilt-shift-linssitehostetta, joka sumentaa tarkennuskaistan ulkopuoliset alueet luoden pienoismallimaisen ulkoasun. Aseta tarkennuskaista alku-/loppukohdilla.',
+    edgeWork:
+      'Korostaa kuvan rakenteellisia reunoja taiteellisella hiilipiirrostyylillä. Säädä tunnistussädettä viivan paksuuden hallitsemiseksi.',
+    vignette:
+      'Tummentaa kartan kulmat ja reunat ohjaten huomion keskelle. Hallitse tummentamisen määrää ja kirkkaan alueen sädettä.',
+    magnify:
+      'Luo pyöreän suurennuslasin peiton asetettavaan kohtaan. Säädä kokoa, zoomaustasoa ja reunuksen leveyttä.',
+    hexagonalPixelate:
+      'Korvaa kuvan heksagonaalisten laattojen ruudukolla, joista kukin on täytetty kattamansa alueen keskivärillä. Säädä laatan mittakaavaa.',
+    distanceFog:
+      'Häivyttää kaukaisia kohteita sumuväriksi niiden syvyyden perusteella kamerasta, tehostamalla syvyysvaikutelmaa. Hallitse tiheyttä, alkuetäisyyttä, aluetta ja sumun väriä.',
+    surfaceFog:
+      'Renderöi sumukerroksen tietyllä korkeudella maanpinnan yläpuolella. Säädä korkeutta, siirtymän paksuutta, tiheyttä, väriä ja valinnaista kohinakuviota.'
+  },
   layerConfiguration: {
     defaultDescription: 'Laske suureen {property} arvo valitun kentän perusteella',
-    howTo: 'Miten toimii'
+    howTo: 'Miten toimii',
+    showColorChart: 'Näytä värikartta',
+    hideColorChart: 'Piilota värikartta'
   },
   filterManager: {
-    addFilter: 'Lisää suodatin'
+    addFilter: 'Lisää suodatin',
+    timeFilterSync: 'Synkronoidut aineistot',
+    timeLayerSync: 'Linkitä tason aikajanaan',
+    timeLayerUnsync: 'Poista linkitys tason aikajanasta',
+    column: 'Sarake'
   },
   datasetTitle: {
     showDataTable: 'Näytä attribuuttitaulu',
     removeDataset: 'Poista aineisto'
   },
   datasetInfo: {
-    rowCount: '{rowCount} riviä'
+    rowCount: '{rowCount} riviä',
+    vectorTile: 'Vektoritiili',
+    rasterTile: 'Rasteritiili',
+    wmsTile: 'WMS-tiili',
+    tile3d: '3D-tiili'
   },
   tooltip: {
     hideLayer: 'Piilota taso',
@@ -193,6 +278,8 @@ export default {
     hide: 'piilota',
     show: 'näytä',
     removeLayer: 'Poista taso',
+    duplicateLayer: 'Kopioi taso',
+    zoomToLayer: 'Zoomaa tasoon',
     resetAfterError: 'Yritä ottaa taso käyttöön virheen jälkeen',
     layerSettings: 'Tason asetukset',
     closePanel: 'Sulje paneeli',
@@ -207,16 +294,34 @@ export default {
     showLayerPanel: 'Näytä tasopaneeli',
     moveToTop: 'Siirrä tasojen päällimmäiseksi',
     selectBaseMapStyle: 'Valitse taustakarttatyyli',
+    removeBaseMapStyle: 'Poista taustakartan tyyli',
     delete: 'Poista',
     timePlayback: 'Ajan animointi',
     cloudStorage: 'Pilvitallennus',
     '3DMap': '3D-näkymä',
-    export: 'vie'
+    animationByWindow: 'Moving Time Window',
+    animationByIncremental: 'Incremental Time Window',
+    speed: 'nopeus',
+    play: 'toista',
+    pause: 'tauko',
+    reset: 'nollaa',
+    export: 'vie',
+    timeFilterSync: 'Synkronoi toisen aineiston sarakkeen kanssa',
+    syncTimelineStart: 'Nykyisen suodattimen aikajakson alku',
+    syncTimelineEnd: 'Nykyisen suodattimen aikajakson loppu',
+    showEffectPanel: 'Näytä efektipaneeli',
+    hideEffectPanel: 'Piilota efektipaneeli',
+    removeEffect: 'Poista efekti',
+    disableEffect: 'Poista efekti käytöstä',
+    effectSettings: 'Efektiasetukset',
+    timeLayerSync: 'Linkitä tason aikajanaan',
+    timeLayerUnsync: 'Poista linkitys tason aikajanasta'
   },
   toolbar: {
     exportImage: 'Vie kuva',
     exportData: 'Vie aineistot',
     exportMap: 'Vie kartta',
+    exportVideo: 'Vie video',
     shareMapURL: 'Jaa kartan URL',
     saveMap: 'Tallenna kartta',
     select: 'valitse',
@@ -226,6 +331,16 @@ export default {
     show: 'näytä',
     ...LOCALES
   },
+  editor: {
+    filterLayer: 'Suodata tasoja',
+    filterLayerDisabled: 'Ei-monikulmiogeometrioita ei voi käyttää suodatukseen',
+    copyGeometry: 'Kopioi geometria',
+    noLayersToFilter: 'Ei tasoja suodatettavaksi'
+  },
+  exportVideoModal: {
+    animation: 'Animaatio',
+    settings: 'Asetukset'
+  },
   modal: {
     title: {
       deleteDataset: 'Poista aineisto',
@@ -233,6 +348,7 @@ export default {
       exportImage: 'Vie kuva',
       exportData: 'Vie aineistot',
       exportMap: 'Vie kartta',
+      exportVideo: 'Vie video',
       addCustomMapboxStyle: 'Lisää oma Mapbox-tyyli',
       saveMap: 'Tallenna kartta',
       shareURL: 'Jaa URL'
@@ -259,6 +375,10 @@ export default {
       mapLegendTitle: 'Kartan selite',
       mapLegendAdd: 'Lisää selite karttaan'
     },
+    exportVideo: {
+      animation: 'Animaatio',
+      settings: 'Asetukset'
+    },
     exportData: {
       datasetTitle: 'Aineistot',
       datasetSubtitle: 'Valitse aineisto, jonka aiot viedä',
@@ -270,7 +390,8 @@ export default {
       filteredData: 'Suodatetut aineistot',
       unfilteredData: 'Suodattamattomat aineistot',
       fileCount: '{fileCount} tiedostoa',
-      rowCount: '{rowCount} riviä'
+      rowCount: '{rowCount} riviä',
+      tiledDatasetWarning: "* Tietojen vienti tiiliaineistoille ei ole tuettu"
     },
     deleteData: {
       warning: 'aiot poistaa tämän aineiston. Aineostoa käyttävien tasojen lukumäärä: {length}'
@@ -287,11 +408,15 @@ export default {
         'tänne. *kepler.gl on client-side sovellus, data pysyy vain selaimessasi...',
       exampleToken: 'esim. pk.abcdefg.xxxxxx',
       pasteTitle: '2. Liitä tyyli-URL',
+      pasteSubtitle0: 'Style url can be a mapbox',
       pasteSubtitle1: 'Mikä on',
       pasteSubtitle2: 'tyyli-URL?',
+      pasteSubtitle3: 'or a style.json using the',
+      pasteSubtitle4: 'Mapbox GL Style Spec',
       namingTitle: '3. Nimeä tyylisi'
     },
     shareMap: {
+      title: 'Jaa kartta',
       shareUriTitle: 'Jaa kartan URL',
       shareUriSubtitle: 'Luo kartalle URL, jonka voit jakaa muiden kanssa',
       cloudTitle: 'Pilvitallennus',
@@ -320,6 +445,8 @@ export default {
         tokenPlaceholder: 'Liitä Mapbox-tunnisteesi',
         tokenMisuseWarning:
           '* Jos et käytä omaa tunnistettasi, kartta voi lakata toimimasta milloin vain kun vaihdamme omaa tunnistettamme väärinkäytön estämiseksi. ',
+        tokenSecurityWarning:
+          '* Varoitus: Mapbox-tunnisteesi upotetaan vietyyn HTML-tiedostoon. Kuka tahansa, jolla on pääsy tähän tiedostoon, voi nähdä ja käyttää tunnistettasi. Käytä mahdollisuuksien mukaan URL-rajoitettua tunnistetta. ',
         tokenDisclaimer: 'Voit vaihtaa Mapbox-tunnisteesi näiden ohjeiden avulla: ',
         tokenUpdate: 'Kuinka vaihtaa olemassaoleva Mapbox-tunniste',
         modeTitle: 'Kartan tila',
@@ -345,15 +472,19 @@ export default {
     },
     loadData: {
       upload: 'Lataa tiedostot',
+      tileset: 'Tiilijoukko',
       storage: 'Lataa tallennustilasta'
     },
     tripInfo: {
       title: 'Kuinka käyttää matka-animaatiota',
+      titleTable: 'Luo matkoja pisteluettelosta',
       description1:
         'Reitin animoimiseksi geoJSON-aineiston täytyy olla geometriatyypiltään `LineString`, LineString-koordinaattien täytyy sisältää 4 elementtiä formaatissa:',
       code: ' [pituusaste, leveysaste, korkeus, aikaleima] ',
       description2:
         'siten, että viimeinen elementti on aikaleima. Aikaleima voi olla muodoltaan unix-sekunteja, kuten `1564184363` tai millisekunteja, kuten `1564184363000`.',
+      descriptionTable1:
+        'Matkat voidaan luoda yhdistämällä luettelo pisteistä leveys- ja pituusasteista, lajittelemalla aikaleiman mukaan ja ryhmittelemällä yksilöivillä tunnuksilla.',
       example: 'Esimerkki:'
     },
     iconInfo: {
@@ -364,6 +495,20 @@ export default {
       description2: ' kepler.gl luo automaattisesti kuvatason sinua varten.',
       example: 'Esimerkki:',
       icons: 'Kuvat'
+    },
+    polygonInfo: {
+      title: 'Luo monikulmiotaso GeoJSON-ominaisuudesta',
+      titleTable: 'Luo polku pisteistä',
+      descriptionTable: `Polut voidaan luoda yhdistämällä luettelo pisteistä leveys- ja pituusasteista, lajittelemalla indeksikentän (esim. aikaleima) mukaan ja ryhmittelemällä yksilöivillä tunnuksilla.
+
+  ### Tason sarakkeet:
+  - **id**: - *pakollinen*&nbsp;- \`id\`-saraketta käytetään pisteiden ryhmittelyyn. Pisteet, joilla on sama id, yhdistetään yhdeksi poluksi.
+  - **lat**: - *pakollinen*&nbsp;- Pisteen leveysaste
+  - **lon**: - *pakollinen*&nbsp;- Pisteen pituusaste
+  - **alt**: - *valinnainen*&nbsp;- Pisteen korkeus
+  - **sort by**: - *valinnainen*&nbsp;- \`sort by\`-saraketta käytetään pisteiden lajitteluun; jos ei ole määritetty, pisteet lajitellaan rivin indeksin mukaan.
+`,
+      exampleTable: 'Example CSV'
     },
     storageMapViewer: {
       lastModified: 'Viimeksi muokattu {lastUpdated} sitten',
@@ -377,7 +522,9 @@ export default {
       back: 'Takaisin',
       goToPage: 'Mene Kepler.gl {displayName} sivullesi',
       storageMaps: 'Tallennus / Kartat',
-      noSavedMaps: 'Ei tallennettuja karttoja vielä'
+      noSavedMaps: 'Ei tallennettuja karttoja vielä',
+      foursquareStorageMessage:
+        'Tässä näytetään vain kartat, jotka on tallennettu Kepler.gl > Tallenna > Foursquare-tallennus -vaihtoehdon avulla'
     }
   },
   header: {
@@ -387,7 +534,8 @@ export default {
   interactions: {
     tooltip: 'Vihje',
     brush: 'Harja',
-    coordinate: 'Koordinaatit'
+    coordinate: 'Koordinaatit',
+    geocoder: 'Geocoder'
   },
   layerBlending: {
     title: 'Tasojen sekoittuvuus',
@@ -395,13 +543,29 @@ export default {
     normal: 'normaali',
     subtractive: 'vähentävä'
   },
+  overlayBlending: {
+    title: 'Kartan päällekkäissekoitus',
+    description: 'Sekoita tasot taustakartan kanssa niin, että molemmat näkyvät.',
+    screen: 'tumma taustakartta',
+    normal: 'normaali',
+    darken: 'vaalea taustakartta'
+  },
   columns: {
     title: 'Sarakkeet',
     lat: 'lat',
     lng: 'lng',
     altitude: 'korkeus',
+    alt: 'korkeus',
+    id: 'id',
+    timestamp: 'aika',
     icon: 'kuva',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow lähde',
+    geoarrow1: 'geoarrow kohde',
+    token: 'token',
+    sortBy: 'lajittele',
+    neighbors: 'naapurit',
     arc: {
       lat0: 'lähdön lat',
       lng0: 'lähdön lng',
@@ -417,18 +581,24 @@ export default {
     },
     hexagon: {
       worldUnitSize: 'Hexagonien säde (km)'
-    }
+    },
+    hex_id: 'hex id'
   },
   color: {
     customPalette: 'Mukautettu paletti',
     steps: 'askeleet',
     type: 'tyyppi',
-    reversed: 'käänteinen'
+    colorBlindSafe: 'Värisokeusturvallinen',
+    reversed: 'käänteinen',
+    disableStepReason: "Askeleiden määrää ei voi muuttaa mukautetuilla värikatkaisuilla, käytä mukautettua palettia muokataksesi askeleita",
+    preset: 'Esimääritetyt värit',
+    picker: 'Värivalitsin'
   },
   scale: {
     colorScale: 'Värin skaala',
     sizeScale: 'Koon skaala',
     strokeScale: 'Viivan paksuuden skaala',
+    strokeColorScale: 'Viivan värin skaala',
     scale: 'Skaala'
   },
   fileUploader: {
@@ -449,5 +619,50 @@ export default {
   'Bug Report': 'Bugiraportointi',
   'User Guide': 'Opas',
   Save: 'Tallenna',
-  Share: 'Jaa'
+  Share: 'Jaa',
+  tilesetSetup: {
+    header: 'Vektoritiilien asetukset',
+    rasterTileHeader: 'Rasteritiilien asetukset',
+    addTilesetText: 'Lisää tiilijoukko'
+  },
+  geocoder: {
+    title: 'Syötä osoite tai koordinaatit, esim. 37.79,-122.40'
+  },
+  fieldSelector: {
+    clearAll: 'Tyhjennä kaikki',
+    formatting: 'Muotoilu'
+  },
+  compare: {
+    modeLabel: 'Vertailutila',
+    typeLabel: 'Vertailutyyppi',
+    types: {
+      absolute: 'Absoluuttinen',
+      relative: 'Suhteellinen'
+    }
+  },
+  mapPopover: {
+    primary: 'Ensisijainen'
+  },
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/ja.ts
+++ b/src/localization/src/translations/ja.ts
@@ -646,20 +646,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: '始点',
+          targetColor: '終点'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: '始点',
+          targetColor: '終点'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: '塗りつぶしの色',
+          strokeColor: '輪郭線'
         }
       }
     }

--- a/src/localization/src/translations/ja.ts
+++ b/src/localization/src/translations/ja.ts
@@ -26,7 +26,8 @@ export default {
     selectType: 'タイプを選択',
     selectValue: '値を選択',
     enterValue: '値を入力',
-    empty: '未選択'
+    empty: '未選択',
+    selectLayer: 'レイヤを選択'
   },
   misc: {
     by: '',
@@ -55,7 +56,10 @@ export default {
       fontColor: '文字色',
       textAnchor: '文字左右',
       alignment: '文字上下',
-      addMoreLabel: 'ラベルを追加'
+      addMoreLabel: 'ラベルを追加',
+      backgroundColor: '背景色',
+      outlineWidth: '輪郭線の幅',
+      outlineColor: '輪郭線の色'
     }
   },
   sidebar: {
@@ -64,6 +68,10 @@ export default {
       filter: 'フィルター',
       interaction: 'インタラクション',
       basemap: 'ベースマップ'
+    },
+    panelViewToggle: {
+      list: 'リスト表示',
+      byDataset: 'データセット別表示'
     }
   },
   layer: {
@@ -87,6 +95,11 @@ export default {
     aggregateBy: '{field}を以下で集計: ',
     '3DModel': '3Dモデル',
     '3DModelOptions': '3Dモデルのオプション',
+    columnModesSeparator: 'または',
+    service: 'サービス',
+    layer: 'レイヤ',
+    appearance: '外観',
+    uniqueIdField: '一意IDフィールド',
     type: {
       point: 'point',
       arc: 'arc',
@@ -102,8 +115,18 @@ export default {
       hexagonid: 'H3',
       trip: 'trip',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'vector tile',
+      rastertile: 'raster tile',
+      wms: 'WMS',
+      tile3d: '3D tile'
     },
+    wms: {
+      hover: 'Value:'
+    },
+    layerUpdateError:
+      'レイヤ更新中にエラーが発生しました: {errorMessage}。入力データの形式が正しいことを確認してください。',
+    interaction: 'インタラクション',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
@@ -156,12 +179,18 @@ export default {
     fixedHeight: '固定高さ',
     fixedHeightDescription: '高さを変更せずに使用する',
     allowHover: 'ツールチップを表示',
-    allowHoverDescription: 'レイヤー要素にホバーしたときにツールチップを表示または非表示にする'
+    allowHoverDescription: 'レイヤー要素にホバーしたときにツールチップを表示または非表示にする',
+    showNeighborOnHover: 'ホバー時に隣接要素をハイライト',
+    showHighlightColor: 'ハイライトカラーを表示',
+    darkModeEnabled: 'ダークベースマップ',
+    transparentBackground: '透明な背景',
+    pointSize: 'ポイントサイズ'
   },
   layerManager: {
     addData: 'データ追加',
     addLayer: 'レイヤ追加',
-    layerBlending: 'レイヤのブレンド'
+    layerBlending: 'レイヤのブレンド',
+    overlayBlending: 'オーバーレイブレンド'
   },
   mapManager: {
     mapStyle: 'マップスタイル',
@@ -169,19 +198,76 @@ export default {
     '3dBuildingColor': '3D建物の色',
     backgroundColor: '背景色'
   },
+  effectManager: {
+    effects: 'エフェクト',
+    addEffect: 'エフェクトを追加',
+    pickDateTime: '日時を選択',
+    currentTime: '現在時刻',
+    pickCurrrentTime: '現在時刻を選択',
+    date: '日付',
+    time: '時刻',
+    timezone: 'タイムゾーン'
+  },
+  effectDescription: {
+    lightAndShadow:
+      '時刻と地理的位置に基づいてリアルな太陽光と影の投影をシミュレートします。影の強さ、太陽光と環境光の色を調整できます。',
+    ink: '縁を暗くして手描きの外観を作成する水墨画風のアートスタイルを適用します。強度を調整して効果の程度を制御します。',
+    brightnessContrast:
+      'マップ全体の明るさとコントラストを調整します。正の値で明るさやコントラストを上げ、負の値で暗くしたり平坦化します。',
+    hueSaturation:
+      '色相を変更し、マップ全体の彩度を調整します。カラーテーマの作成やビューの彩度を下げるのに便利です。',
+    vibrance:
+      '既に鮮やかな色を過度に飽和させることなく、くすんだ色の強度を選択的に高めます。彩度よりも自然な色の向上を生み出します。',
+    sepia:
+      '古い写真を思わせる温かみのある茶色のトーンを適用します。元の色とセピア調の間のブレンド量を制御します。',
+    dotScreen:
+      '画像をモノクロのドットパターンに変換し、新聞のハーフトーン印刷に似た効果を出します。角度、ドットサイズ、中心位置を調整します。',
+    colorHalftone:
+      '各カラーチャンネルに個別のドットパターンを使用してCMYKカラーハーフトーン印刷をシミュレートします。角度、ドットサイズ、中心位置を制御します。',
+    noise:
+      'マップ全体にフィルムグレインスタイルのランダムノイズを追加します。テクスチャのあるアナログ的な美観の作成やカラーバンディングの軽減に便利です。',
+    triangleBlur:
+      'マップ全体に滑らかなガウシアン風のブラーを均一に適用します。ブラー半径を制御してソフトさのレベルを調整します。',
+    zoomBlur:
+      '中心点から放射状に広がるモーションブラーを作成し、カメラズームをシミュレートします。強度と中心位置を調整します。',
+    tiltShift:
+      'フォーカルバンドの外側の領域をぼかすティルトシフトレンズ効果をシミュレートし、ミニチュアモデルのような外観を作成します。開始/終了位置でフォーカルバンドを設定します。',
+    edgeWork:
+      '芸術的な木炭スケッチスタイルを使用して画像の構造的なエッジをハイライトします。検出半径を調整して線の太さを制御します。',
+    vignette:
+      'マップの角と縁を暗くし、中心に注目を集めます。暗くする量とクリアエリアの半径を制御します。',
+    magnify:
+      '設定可能な位置に円形の拡大鏡オーバーレイを作成します。サイズ、ズームレベル、ボーダー幅を調整します。',
+    hexagonalPixelate:
+      '画像を六角形タイルのグリッドに置き換え、各タイルがカバーする領域の平均色で塗りつぶします。タイルのスケールを調整します。',
+    distanceFog:
+      'カメラからの深度に基づいて遠くのオブジェクトをフォグカラーにフェードさせ、奥行き感を高めます。密度、開始距離、範囲、フォグカラーを制御します。',
+    surfaceFog:
+      '地形表面の上の特定の高度にフォグレイヤをレンダリングします。高度、遷移の厚さ、密度、色、オプションのノイズパターンを調整します。'
+  },
   layerConfiguration: {
     defaultDescription: '選択されたフィールドに基づいて{property}を計算します',
-    howTo: '使い方'
+    howTo: '使い方',
+    showColorChart: 'カラーチャートを表示',
+    hideColorChart: 'カラーチャートを非表示'
   },
   filterManager: {
-    addFilter: 'フィルター追加'
+    addFilter: 'フィルター追加',
+    timeFilterSync: '同期データセット',
+    timeLayerSync: 'レイヤタイムラインにリンク',
+    timeLayerUnsync: 'レイヤタイムラインのリンクを解除',
+    column: '列'
   },
   datasetTitle: {
     showDataTable: 'データ表を表示',
     removeDataset: 'データセットを削除'
   },
   datasetInfo: {
-    rowCount: '{rowCount}行'
+    rowCount: '{rowCount}行',
+    vectorTile: 'ベクタータイル',
+    rasterTile: 'ラスタータイル',
+    wmsTile: 'WMSタイル',
+    tile3d: '3Dタイル'
   },
   tooltip: {
     hideLayer: 'レイヤを非表示',
@@ -215,12 +301,25 @@ export default {
     play: '再生',
     pause: '一時停止',
     reset: 'リセット',
-    export: 'エクスポート'
+    export: 'エクスポート',
+    resetAfterError: 'エラー後にレイヤを有効にしてみる',
+    removeBaseMapStyle: 'ベースマップスタイルを削除',
+    timeFilterSync: '別のデータセットの列と同期',
+    syncTimelineStart: '現在のフィルタ期間の開始',
+    syncTimelineEnd: '現在のフィルタ期間の終了',
+    showEffectPanel: 'エフェクトパネルを表示',
+    hideEffectPanel: 'エフェクトパネルを非表示',
+    removeEffect: 'エフェクトを削除',
+    disableEffect: 'エフェクトを無効化',
+    effectSettings: 'エフェクト設定',
+    timeLayerSync: 'レイヤタイムラインにリンク',
+    timeLayerUnsync: 'レイヤタイムラインのリンクを解除'
   },
   toolbar: {
     exportImage: '画像を出力',
     exportData: 'データを出力',
     exportMap: '地図を出力',
+    exportVideo: 'ビデオをエクスポート',
     shareMapURL: '地図のURLを共有',
     saveMap: '地図を保存',
     select: '選択',
@@ -229,6 +328,16 @@ export default {
     hide: '非表示',
     show: '表示',
     ...LOCALES
+  },
+  editor: {
+    filterLayer: 'レイヤをフィルタ',
+    filterLayerDisabled: 'ポリゴン以外のジオメトリはフィルタリングに使用できません',
+    copyGeometry: 'ジオメトリをコピー',
+    noLayersToFilter: 'フィルタするレイヤがありません'
+  },
+  exportVideoModal: {
+    animation: 'アニメーション',
+    settings: '設定'
   },
   modal: {
     title: {
@@ -239,7 +348,8 @@ export default {
       exportMap: '地図を出力',
       addCustomMapboxStyle: 'カスタムマップスタイルを追加',
       saveMap: '地図を保存',
-      shareURL: 'URLを共有'
+      shareURL: 'URLを共有',
+      exportVideo: 'ビデオをエクスポート'
     },
     button: {
       delete: '削除',
@@ -263,6 +373,10 @@ export default {
       mapLegendTitle: '地図の凡例',
       mapLegendAdd: '地図に判例を追加'
     },
+    exportVideo: {
+      animation: 'アニメーション',
+      settings: '設定'
+    },
     exportData: {
       datasetTitle: 'データセット',
       datasetSubtitle: 'エクスポートしたいデータセットを選択します',
@@ -275,7 +389,8 @@ export default {
       filteredData: 'フィルタ済データ',
       unfilteredData: '元データ',
       fileCount: '{fileCount}個のファイル',
-      rowCount: '{rowCount}行'
+      rowCount: '{rowCount}行',
+      tiledDatasetWarning: "* タイルデータセットのデータエクスポートはサポートされていません"
     },
     deleteData: {
       warning: 'このデータセットを削除します。{length}個のレイヤに影響します。'
@@ -301,6 +416,7 @@ export default {
       namingTitle: '3. スタイルの名称を設定'
     },
     shareMap: {
+      title: '地図を共有',
       shareUriTitle: '地図のURLを共有',
       shareUriSubtitle: '共有用に地図のURLを生成',
       cloudTitle: 'クラウドストレージ',
@@ -328,6 +444,8 @@ export default {
         tokenPlaceholder: '自分のMapboxアクセストークンをここに貼り付け',
         tokenMisuseWarning:
           '* 自分のトークンを使用しない場合は、デフォルトのトークンが悪用防止のために更新され、地図が表示されなくなる可能性があります。  ',
+        tokenSecurityWarning:
+          '* 警告：MapboxトークンはエクスポートされたHTMLファイルに埋め込まれます。このファイルにアクセスできる人は誰でもトークンを確認・使用できます。可能な場合はURL制限付きのスコープトークンを使用してください。',
         tokenDisclaimer: 'Mapboxのトークンは下記の方法に従って後から変更することも可能です：',
         tokenUpdate: '既存の地図のトークンを更新する方法',
         modeTitle: '地図のモード',
@@ -353,6 +471,7 @@ export default {
     },
     loadData: {
       upload: 'ファイルをロード',
+      tileset: 'タイルセット',
       storage: 'ストレージからロード'
     },
     tripInfo: {
@@ -362,7 +481,10 @@ export default {
       code: ' [経度, 緯度, 標高, timestamp] ',
       description2:
         'という形式（最後にタイムスタンプを含む）で保持する必要があります。タイムスタンプの形式は、 UNIX時間の秒単位（例: `1564184363`）またはミリ秒単位（例: `1564184363000`）が有効です。',
-      example: '例：'
+      example: '例：',
+      titleTable: 'ポイントリストからトリップを作成',
+      descriptionTable1:
+        'トリップは緯度と経度のポイントリストを結合し、タイムスタンプで並べ替え、一意のIDでグループ化して作成できます。'
     },
     iconInfo: {
       title: 'アイコンの描画方法',
@@ -372,6 +494,20 @@ export default {
       description2: 'の場合、kepler.glは自動的にアイコンレイヤを作成します。',
       example: '例:',
       icons: 'アイコン一覧'
+    },
+    polygonInfo: {
+      title: 'GeoJSON機能からポリゴンレイヤを作成',
+      titleTable: 'ポイントからパスを作成',
+      descriptionTable: `パスは緯度と経度のポイントリストを結合し、インデックスフィールド（例：タイムスタンプ）で並べ替え、一意のIDでグループ化して作成できます。
+
+  ### レイヤ列：
+  - **id**: - *必須*&nbsp;- \`id\` 列はポイントのグループ化に使用されます。同じidを持つポイントは1つのパスに結合されます。
+  - **lat**: - *必須*&nbsp;- ポイントの緯度
+  - **lon**: - *必須*&nbsp;- ポイントの経度
+  - **alt**: - *任意*&nbsp;- ポイントの高度
+  - **sort by**: - *任意*&nbsp;- \`sort by\` 列はポイントの並べ替えに使用されます。指定しない場合、ポイントは行インデックス順に並べ替えられます。
+`,
+      exampleTable: 'Example CSV'
     },
     storageMapViewer: {
       lastModified: '最終編集：{lastUpdated} 前',
@@ -385,7 +521,9 @@ export default {
       back: '戻る',
       goToPage: 'Kepler.glの{displayName}ページに移動',
       storageMaps: 'ストレージ / 地図',
-      noSavedMaps: '保存済の地図はまだありません'
+      noSavedMaps: '保存済の地図はまだありません',
+      foursquareStorageMessage:
+        'Kepler.gl > 保存 > Foursquareストレージ オプションで保存されたマップのみがここに表示されます'
     }
   },
   header: {
@@ -404,19 +542,38 @@ export default {
     normal: 'normal',
     subtractive: 'subtractive'
   },
+  overlayBlending: {
+    title: 'マップオーバーレイブレンド',
+    description: 'レイヤとベースマップをブレンドして両方を表示します。',
+    screen: 'ダークベースマップ',
+    normal: 'ノーマル',
+    darken: 'ライトベースマップ'
+  },
   columns: {
     title: '列',
     lat: '緯度',
     lng: '経度',
     altitude: '標高',
+    alt: '高度',
+    id: 'id',
+    timestamp: '時間',
     icon: 'アイコン',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow ソース',
+    geoarrow1: 'geoarrow ターゲット',
     token: 'トークン',
+    sortBy: '並べ替え',
+    neighbors: '隣接',
     arc: {
       lat0: '出発 緯度',
       lng0: '出発 経度',
       lat1: '到着 緯度',
       lng1: '到着 経度'
+    },
+    line: {
+      alt0: '出発 標高',
+      alt1: '到着 標高'
     },
     grid: {
       worldUnitSize: 'グリッドサイズ (km)'
@@ -430,12 +587,17 @@ export default {
     customPalette: 'カスタムパレット',
     steps: '段階数',
     type: 'タイプ',
-    reversed: '反転'
+    reversed: '反転',
+    colorBlindSafe: '色覚安全',
+    disableStepReason: "カスタムカラーブレークでは段階数を変更できません。段階を編集するにはカスタムパレットを使用してください",
+    preset: 'プリセットカラー',
+    picker: 'カラーピッカー'
   },
   scale: {
     colorScale: 'カラースケール',
     sizeScale: 'サイズのスケール',
     strokeScale: '線のスケール',
+    strokeColorScale: '線の色のスケール',
     scale: 'スケール'
   },
   fileUploader: {
@@ -450,7 +612,7 @@ export default {
     browseFiles: 'デバイスのファイルを選択',
     uploading: 'アップロード中',
     fileNotSupported: '{errorFiles} はサポートされていないファイルです。',
-    or: 'or'
+    or: 'または'
   },
   geocoder: {
     title: '住所または座標を入力（例： 37.79,-122.40）'
@@ -470,9 +632,36 @@ export default {
   mapPopover: {
     primary: 'プライマリ'
   },
-  density: 'density',
+  density: '密度',
   'Bug Report': 'バグを報告',
   'User Guide': 'ユーザーガイド',
   Save: '保存',
-  Share: '共有'
+  Share: '共有',
+  tilesetSetup: {
+    header: 'ベクタータイルの設定',
+    rasterTileHeader: 'ラスタータイルの設定',
+    addTilesetText: 'タイルセットを追加'
+  },
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/pt.ts
+++ b/src/localization/src/translations/pt.ts
@@ -122,7 +122,7 @@ export default {
       tile3d: 'mosaico 3D'
     },
     wms: {
-      hover: 'Value:'
+      hover: 'Valor:'
     },
     layerUpdateError:
       'Ocorreu um erro ao atualizar a camada: {errorMessage}. Certifique-se de que o formato dos dados de entrada seja válido.',
@@ -299,11 +299,11 @@ export default {
     removeBaseMapStyle: 'Remover estilo de mapa base',
     delete: 'Deletar',
     timePlayback: 'Tempo de reprodução',
-    timeFilterSync: 'Sync with a column from another dataset',
+    timeFilterSync: 'Sincronizar com uma coluna de outro conjunto de dados',
     cloudStorage: 'Armazenamento Cloud',
     '3DMap': ' Mapa 3D',
-    animationByWindow: 'Moving Time Window',
-    animationByIncremental: 'Incremental Time Window',
+    animationByWindow: 'Janela de tempo móvel',
+    animationByIncremental: 'Janela de tempo incremental',
     speed: 'velocidade',
     play: 'reproduzir',
     pause: 'pausar',
@@ -410,11 +410,11 @@ export default {
         'aqui. *kepler.gl é uma aplicação client-side, os dados permanecem no seu browser..',
       exampleToken: 'e.g. pk.abcdefg.xxxxxx',
       pasteTitle: '2. Cole a url do seu estilo',
-      pasteSubtitle0: 'Style url can be a mapbox',
+      pasteSubtitle0: 'A URL do estilo pode ser um estilo do Mapbox',
       pasteSubtitle1: 'O que é uma',
       pasteSubtitle2: 'URL de estilo',
-      pasteSubtitle3: 'or a style.json using the',
-      pasteSubtitle4: 'Mapbox GL Style Spec',
+      pasteSubtitle3: 'ou um style.json usando a',
+      pasteSubtitle4: 'especificação Mapbox GL Style Spec',
       namingTitle: '3. Nomeie o seu estilo'
     },
     shareMap: {
@@ -650,20 +650,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Origem',
+          targetColor: 'Destino'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Origem',
+          targetColor: 'Destino'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: 'Cor do preenchimento',
+          strokeColor: 'Contorno'
         }
       }
     }

--- a/src/localization/src/translations/pt.ts
+++ b/src/localization/src/translations/pt.ts
@@ -15,6 +15,7 @@ export default {
     stroke: 'Traçado',
     density: 'Densidade',
     height: 'Altura',
+    coverage: 'Cobertura',
     sum: 'Soma',
     pointCount: 'Contagem de Pontos'
   },
@@ -25,7 +26,8 @@ export default {
     selectType: 'Selecione um Tipo',
     selectValue: 'Selecione um valor',
     enterValue: 'Insira um valor',
-    empty: 'Vazio'
+    empty: 'Vazio',
+    selectLayer: 'Selecione uma camada'
   },
   misc: {
     by: '',
@@ -54,7 +56,10 @@ export default {
       fontColor: 'Cor da fonte',
       textAnchor: 'Âncora do texto',
       alignment: 'Alinhamento',
-      addMoreLabel: 'Adicionar mais Rótulos'
+      addMoreLabel: 'Adicionar mais Rótulos',
+      backgroundColor: 'Cor de fundo',
+      outlineWidth: 'Largura do contorno',
+      outlineColor: 'Cor do contorno'
     }
   },
   sidebar: {
@@ -63,10 +68,15 @@ export default {
       filter: 'Filtros',
       interaction: 'Interações',
       basemap: 'Mapa base'
+    },
+    panelViewToggle: {
+      list: 'Ver Lista',
+      byDataset: 'Ver por Conjunto de dados'
     }
   },
   layer: {
     required: 'Obrigatório*',
+    columnModesSeparator: 'Ou',
     radius: 'Raio',
     color: 'Cor',
     fillColor: 'Cor de preenchimento',
@@ -86,6 +96,10 @@ export default {
     aggregateBy: '{field} agregado por',
     '3DModel': 'Modelo 3D',
     '3DModelOptions': 'Opções do Modelo 3D',
+    service: 'Serviço',
+    layer: 'Camada',
+    appearance: 'Aparência',
+    uniqueIdField: 'Campo ID único',
     type: {
       point: 'ponto',
       arc: 'arco',
@@ -101,14 +115,23 @@ export default {
       hexagonid: 'H3',
       trip: 'viagem',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'mosaico vetorial',
+      rastertile: 'mosaico raster',
+      wms: 'WMS',
+      tile3d: 'mosaico 3D'
+    },
+    wms: {
+      hover: 'Value:'
     },
     layerUpdateError:
       'Ocorreu um erro ao atualizar a camada: {errorMessage}. Certifique-se de que o formato dos dados de entrada seja válido.',
+    interaction: 'Interação',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
   layerVisConfigs: {
+    angle: 'Ângulo',
     strokeWidth: 'Largura do Traço',
     strokeWidthRange: 'Alcance da Largura do Traço',
     radius: 'Raio',
@@ -121,6 +144,7 @@ export default {
     billboardDescription: 'Oriente a geometria em direção à câmera',
     fadeTrail: 'Fade trilha',
     opacity: 'Opacidade',
+    pointSize: 'Tamanho do ponto',
     coverage: 'Cobertura',
     outline: 'Contorno',
     colorRange: 'Alcance da Cor',
@@ -159,12 +183,17 @@ export default {
     fixedHeightDescription: 'Use a altura sem modificações',
     allowHover: 'Mostrar dica de ferramenta',
     allowHoverDescription:
-      'Mostrar ou ocultar dica de ferramenta ao passar o cursor sobre os recursos da camada'
+      'Mostrar ou ocultar dica de ferramenta ao passar o cursor sobre os recursos da camada',
+    showNeighborOnHover: 'Destacar vizinhos ao passar o cursor',
+    showHighlightColor: 'Mostrar cor de destaque',
+    darkModeEnabled: 'Mapa base escuro',
+    transparentBackground: 'Fundo transparente'
   },
   layerManager: {
     addData: 'Adicionar Dados',
     addLayer: 'Adicionar Camada',
-    layerBlending: 'Mistura de Camada'
+    layerBlending: 'Mistura de Camada',
+    overlayBlending: 'Mistura de sobreposição'
   },
   mapManager: {
     mapStyle: 'Estilo do Mapa',
@@ -172,19 +201,76 @@ export default {
     '3dBuildingColor': 'Cor do Edifício 3D',
     backgroundColor: 'Cor de Fundo'
   },
+  effectManager: {
+    effects: 'Efeitos',
+    addEffect: 'Adicionar efeito',
+    pickDateTime: 'Selecionar data/hora',
+    currentTime: 'Hora atual',
+    pickCurrrentTime: 'Selecionar hora atual',
+    date: 'Data',
+    time: 'Hora',
+    timezone: 'Fuso horário'
+  },
+  effectDescription: {
+    lightAndShadow:
+      'Simula iluminação solar realista e projeção de sombras com base na hora do dia e localização geográfica. Intensidade de sombra, cores de luz solar e ambiente ajustáveis.',
+    ink: 'Aplica um estilo artístico de tinta que escurece as bordas e cria uma aparência desenhada à mão. Ajuste a intensidade para controlar o efeito.',
+    brightnessContrast:
+      'Ajusta o brilho e o contraste gerais do mapa. Use valores positivos para aumentar o brilho ou contraste, valores negativos para escurecer ou achatar a imagem.',
+    hueSaturation:
+      'Altera o tom de cor e ajusta a saturação em todo o mapa. Útil para criar temas de cor ou dessaturar a vista.',
+    vibrance:
+      'Aumenta seletivamente a intensidade de cores suaves sem sobressaturar as já vivas. Produz um realce de cor mais natural que a saturação.',
+    sepia:
+      'Aplica um tom acastanhado quente que lembra fotografias envelhecidas. Controle a quantidade para misturar entre as cores originais e o aspecto sépia.',
+    dotScreen:
+      'Converte a imagem em um padrão de pontos monocromáticos, semelhante à impressão de meios-tons de jornal. Ajuste o ângulo, tamanho dos pontos e posição central.',
+    colorHalftone:
+      'Simula a impressão de meios-tons de cor CMYK com padrões de pontos separados para cada canal de cor. Controle o ângulo, tamanho dos pontos e posição central.',
+    noise:
+      'Adiciona ruído aleatório estilo grão de filme ao mapa. Útil para uma estética texturizada e analógica ou para reduzir banding de cor.',
+    triangleBlur:
+      'Aplica um desfoque suave do tipo gaussiano uniformemente no mapa. Controle o raio do desfoque para ajustar o nível de suavidade.',
+    zoomBlur:
+      'Cria um desfoque de movimento radial que emana de um ponto central, simulando um zoom de câmera. Ajuste a intensidade e a posição central.',
+    tiltShift:
+      'Simula um efeito de lente tilt-shift que desfoca áreas fora de uma faixa focal, criando uma aparência de maquete em miniatura. Defina a faixa focal com posições de início/fim.',
+    edgeWork:
+      'Destaca as bordas estruturais da imagem usando um estilo artístico de desenho a carvão. Ajuste o raio de detecção para controlar a espessura da linha.',
+    vignette:
+      'Escurece os cantos e bordas do mapa, direcionando o foco para o centro. Controle a quantidade de escurecimento e o raio da área clara.',
+    magnify:
+      'Cria uma sobreposição de lupa circular em uma posição configurável. Ajuste o tamanho, o nível de zoom e a largura da borda.',
+    hexagonalPixelate:
+      'Substitui a imagem por uma grade de mosaicos hexagonais, cada um preenchido com a cor média da área que cobre. Ajuste a escala do mosaico.',
+    distanceFog:
+      'Desvanece objetos distantes em uma cor de neblina com base na profundidade em relação à câmera, realçando a sensação de profundidade. Controle a densidade, distância inicial, alcance e cor da neblina.',
+    surfaceFog:
+      'Renderiza uma camada de neblina em uma elevação específica acima da superfície do terreno. Ajuste a elevação, espessura de transição, densidade, cor e um padrão de ruído opcional.'
+  },
   layerConfiguration: {
     defaultDescription: 'Calcular {property} baseada no campo selecionado',
-    howTo: 'Como'
+    howTo: 'Como',
+    showColorChart: 'Mostrar gráfico de cores',
+    hideColorChart: 'Ocultar gráfico de cores'
   },
   filterManager: {
-    addFilter: 'Adicionar Filtro'
+    addFilter: 'Adicionar Filtro',
+    timeFilterSync: 'Conjuntos sincronizados',
+    timeLayerSync: 'Vincular à linha do tempo da camada',
+    timeLayerUnsync: 'Desvincular da linha do tempo da camada',
+    column: 'Coluna'
   },
   datasetTitle: {
     showDataTable: 'Mostrar tabela de dados',
     removeDataset: 'Remover tabela de dados'
   },
   datasetInfo: {
-    rowCount: '{rowCount} linhas'
+    rowCount: '{rowCount} linhas',
+    vectorTile: 'Mosaico vetorial',
+    rasterTile: 'Mosaico raster',
+    wmsTile: 'Mosaico WMS',
+    tile3d: 'Mosaico 3D'
   },
   tooltip: {
     hideLayer: 'esconder camada',
@@ -194,6 +280,8 @@ export default {
     hide: 'esconder',
     show: 'mostrar',
     removeLayer: 'Remover Camada',
+    duplicateLayer: 'Duplicar camada',
+    zoomToLayer: 'Zoom para a camada',
     resetAfterError: 'Tente habilitar a camada após um erro',
     layerSettings: 'Configurações de Camada',
     closePanel: 'Fechar painel atual',
@@ -208,16 +296,34 @@ export default {
     showLayerPanel: 'Mostrar painel de camada',
     moveToTop: 'Mover para o topo das camadas',
     selectBaseMapStyle: 'Selecionar o Estilo do Mapa Base',
+    removeBaseMapStyle: 'Remover estilo de mapa base',
     delete: 'Deletar',
     timePlayback: 'Tempo de reprodução',
+    timeFilterSync: 'Sync with a column from another dataset',
     cloudStorage: 'Armazenamento Cloud',
     '3DMap': ' Mapa 3D',
-    export: 'exportar'
+    animationByWindow: 'Moving Time Window',
+    animationByIncremental: 'Incremental Time Window',
+    speed: 'velocidade',
+    play: 'reproduzir',
+    pause: 'pausar',
+    reset: 'redefinir',
+    export: 'exportar',
+    timeLayerSync: 'Vincular com a linha do tempo da camada',
+    timeLayerUnsync: 'Desvincular da linha do tempo da camada',
+    syncTimelineStart: 'Início do período de tempo do filtro atual',
+    syncTimelineEnd: 'Fim do período de tempo do filtro atual',
+    showEffectPanel: 'Mostrar painel de efeitos',
+    hideEffectPanel: 'Ocultar painel de efeitos',
+    removeEffect: 'Remover efeito',
+    disableEffect: 'Desativar efeito',
+    effectSettings: 'Configurações de efeito'
   },
   toolbar: {
     exportImage: 'Exportar Imagem',
     exportData: 'Exportar Dados',
     exportMap: 'Exportar Mapa',
+    exportVideo: 'Exportar Vídeo',
     shareMapURL: 'Compartilhar URL do Mapa',
     saveMap: 'Salvar Mapa',
     select: 'selecionar',
@@ -227,6 +333,16 @@ export default {
     show: 'mostrar',
     ...LOCALES
   },
+  editor: {
+    filterLayer: 'Filtrar camadas',
+    filterLayerDisabled: 'Geometrias não poligonais não podem ser usadas para filtragem',
+    copyGeometry: 'Copiar geometria',
+    noLayersToFilter: 'Sem camadas para filtrar'
+  },
+  exportVideoModal: {
+    animation: 'Animação',
+    settings: 'Configurações'
+  },
   modal: {
     title: {
       deleteDataset: 'Deletar Conjunto de Dados',
@@ -234,6 +350,7 @@ export default {
       exportImage: 'Exportar Imagem',
       exportData: 'Exportar Dados',
       exportMap: 'Exportar Mapa',
+      exportVideo: 'Exportar Vídeo',
       addCustomMapboxStyle: 'Adicionar Estilo Mapbox Customizado',
       saveMap: 'Salvar Mapa',
       shareURL: 'Compartilhar URL'
@@ -260,6 +377,10 @@ export default {
       mapLegendTitle: 'Legenda do Mapa',
       mapLegendAdd: 'Adicionar Legenda no mapa'
     },
+    exportVideo: {
+      animation: 'Animação',
+      settings: 'Configurações'
+    },
     exportData: {
       datasetTitle: 'Conjunto de dados',
       datasetSubtitle: 'Escolha o conjunto de dados que você quer exportar',
@@ -271,7 +392,8 @@ export default {
       filteredData: 'Dados Filtrados',
       unfilteredData: 'Dados não filtrados',
       fileCount: '{fileCount} Arquivos',
-      rowCount: '{rowCount} Linhas'
+      rowCount: '{rowCount} Linhas',
+      tiledDatasetWarning: "* A exportação de dados para conjuntos de dados em mosaico não é suportada"
     },
     deleteData: {
       warning: 'você irá deletar esse conjunto de dados. Isso irá afetar {length} camadas'
@@ -288,11 +410,15 @@ export default {
         'aqui. *kepler.gl é uma aplicação client-side, os dados permanecem no seu browser..',
       exampleToken: 'e.g. pk.abcdefg.xxxxxx',
       pasteTitle: '2. Cole a url do seu estilo',
+      pasteSubtitle0: 'Style url can be a mapbox',
       pasteSubtitle1: 'O que é uma',
       pasteSubtitle2: 'URL de estilo',
+      pasteSubtitle3: 'or a style.json using the',
+      pasteSubtitle4: 'Mapbox GL Style Spec',
       namingTitle: '3. Nomeie o seu estilo'
     },
     shareMap: {
+      title: 'Compartilhar Mapa',
       shareUriTitle: 'Compartilhar a URL do Mapa',
       shareUriSubtitle: 'Gerar a url do mapa e compartilhar com outros',
       cloudTitle: 'Armazenamento Cloud',
@@ -320,6 +446,8 @@ export default {
         tokenPlaceholder: 'Cole a sua chave de acesso Mapbox',
         tokenMisuseWarning:
           '* Se você não fornecer a sua própria chave de acesso, o mapa pode falhar em exibir a qualquer momento quando nós substituirmos a nossa para evitar mau uso. ',
+        tokenSecurityWarning:
+          '* Aviso: seu token Mapbox será incorporado no arquivo HTML exportado. Qualquer pessoa com acesso a este arquivo poderá ver e usar seu token. Use um token com restrições de URL quando possível. ',
         tokenDisclaimer:
           'Você pode trocar a sua chave de acesso Mapbox mais tarde utizando as instruções seguintes: ',
         tokenUpdate: 'Como atualizar a chave de acesso de um mapa existente.',
@@ -346,16 +474,35 @@ export default {
     },
     loadData: {
       upload: 'Carregar arquivo',
+      tileset: 'Conjunto de mosaico',
       storage: 'Carregar do armazenamento'
     },
     tripInfo: {
       title: 'Como habilitar animação de viagem',
+      titleTable: 'Criar viagens a partir de uma lista de pontos',
       description1:
         'Para animar o caminho, o dado geoJSON deve conter `LineString` na sua propriedade geometry, e as coordenadas na LineString devem ter 4 elementos no seguinte formato',
+      descriptionTable1:
+        'As viagens podem ser criadas unindo uma lista de pontos de latitude e longitude, ordenando por marcas de tempo e agrupando por identificadores únicos.',
       code: ' [longitude, latitude, altitude, data] ',
       description2:
         'com um ultimo elemento sendo uma data. Um formato de data válida inclui segundos unix como `1564184363` ou em milisegundos como `1564184363000`.',
-      example: 'Exemplo:'
+      example: 'Exemplo:',
+      exampleTable: 'Example Csv'
+    },
+    polygonInfo: {
+      title: 'Criar camada de polígonos a partir de recursos GeoJSON',
+      titleTable: 'Criar caminho a partir de pontos',
+      descriptionTable: `Os caminhos podem ser criados unindo uma lista de pontos de latitude e longitude, ordenando por um campo de índice (ex. marca de tempo) e agrupando por identificadores únicos.
+
+  ### Colunas da camada:
+  - **id**: - *obrigatório*&nbsp;- Uma coluna \`id\` é usada para agrupar pontos. Pontos com o mesmo id serão unidos em um único caminho.
+  - **lat**: - *obrigatório*&nbsp;- A latitude do ponto
+  - **lon**: - *obrigatório*&nbsp;- A longitude do ponto
+  - **alt**: - *opcional*&nbsp;- A altitude do ponto
+  - **sort by**: - *opcional*&nbsp;- Uma coluna \`sort by\` é usada para ordenar os pontos; se não especificada, os pontos serão ordenados por índice de linha.
+`,
+      exampleTable: 'Example CSV'
     },
     iconInfo: {
       title: 'Como desenhar ícones',
@@ -378,7 +525,9 @@ export default {
       back: 'Voltar',
       goToPage: 'Vá para a sua página {displayName} do Kepler.gl',
       storageMaps: 'Armazenamento / Mapas',
-      noSavedMaps: 'Nenhum mapa salvo'
+      noSavedMaps: 'Nenhum mapa salvo',
+      foursquareStorageMessage:
+        'Apenas mapas salvos com a opção Kepler.gl > Salvar > Armazenamento Foursquare são mostrados aqui'
     }
   },
   header: {
@@ -388,7 +537,8 @@ export default {
   interactions: {
     tooltip: 'Dica de contexto',
     brush: 'Pincel',
-    coordinate: 'Coordenadas'
+    coordinate: 'Coordenadas',
+    geocoder: 'Geocoder'
   },
   layerBlending: {
     title: 'Mistura de Camadas',
@@ -396,13 +546,29 @@ export default {
     normal: 'normal',
     subtractive: 'subtrativo'
   },
+  overlayBlending: {
+    title: 'Mistura de sobreposição do mapa',
+    description: 'Misturar camadas com o mapa base para que ambos sejam visíveis.',
+    screen: 'mapa base escuro',
+    normal: 'normal',
+    darken: 'mapa base claro'
+  },
   columns: {
     title: 'Colunas',
     lat: 'lat',
     lng: 'lon',
     altitude: 'altitude',
+    alt: 'altitude',
+    id: 'id',
+    timestamp: 'tempo',
     icon: 'ícone',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow origem',
+    geoarrow1: 'geoarrow destino',
+    token: 'token',
+    sortBy: 'ordenar por',
+    neighbors: 'vizinhos',
     arc: {
       lat0: 'origem lat',
       lng0: 'origem lng',
@@ -418,18 +584,24 @@ export default {
     },
     hexagon: {
       worldUnitSize: 'Raio do Hexágono (km)'
-    }
+    },
+    hex_id: 'hex id'
   },
   color: {
     customPalette: 'Paletas customizadas',
     steps: 'caminhos',
     type: 'tipo',
-    reversed: 'reverso'
+    colorBlindSafe: 'Seguro para daltônicos',
+    reversed: 'reverso',
+    disableStepReason: "Não é possível alterar o número de passos com quebras de cor personalizadas, use a paleta personalizada para editar os passos",
+    preset: 'Cores predefinidas',
+    picker: 'Seletor de cor'
   },
   scale: {
     colorScale: 'Escala da Cor',
     sizeScale: 'Tamanho da Escala',
     strokeScale: 'Escala do Traço',
+    strokeColorScale: 'Escala de cor do traço',
     scale: 'Escala'
   },
   fileUploader: {
@@ -446,9 +618,54 @@ export default {
     fileNotSupported: 'Arquivo {errorFiles} não é suportado.',
     or: 'ou'
   },
+  tilesetSetup: {
+    header: 'Configurar mosaicos vetoriais',
+    rasterTileHeader: 'Configurar mosaicos raster',
+    addTilesetText: 'Adicionar conjunto de mosaico'
+  },
+  geocoder: {
+    title: 'Insira um endereço ou coordenadas, ex 37.79,-122.40'
+  },
+  fieldSelector: {
+    clearAll: 'Limpar tudo',
+    formatting: 'Formatação'
+  },
+  compare: {
+    modeLabel: 'Modo de comparação',
+    typeLabel: 'Tipo de comparação',
+    types: {
+      absolute: 'Absoluto',
+      relative: 'Relativo'
+    }
+  },
+  mapPopover: {
+    primary: 'Primário'
+  },
   density: 'densidade',
   'Bug Report': 'Reportar Bug',
   'User Guide': 'Guia do Usuário',
   Save: 'Salvar',
-  Share: 'Compartilhar'
+  Share: 'Compartilhar',
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/ru.ts
+++ b/src/localization/src/translations/ru.ts
@@ -26,7 +26,8 @@ export default {
     selectType: 'Выберите A тип',
     selectValue: 'Выберите A значение',
     enterValue: 'Введите значение',
-    empty: 'пустой'
+    empty: 'пустой',
+    selectLayer: 'Выберите слой'
   },
   misc: {
     by: '',
@@ -44,7 +45,8 @@ export default {
     building: 'Здания',
     water: 'Вода',
     land: 'Земля',
-    '3dBuilding': '3d здания'
+    '3dBuilding': '3d здания',
+    background: 'Фон'
   },
   panel: {
     text: {
@@ -52,9 +54,12 @@ export default {
       labelWithId: 'Ярлык {labelId}',
       fontSize: 'Размер шрифта',
       fontColor: 'Цвет шрифта',
+      backgroundColor: 'Цвет фона',
       textAnchor: 'Анкор текста',
       alignment: 'Положение',
-      addMoreLabel: 'Добавить еще ярлык'
+      addMoreLabel: 'Добавить еще ярлык',
+      outlineWidth: 'Ширина контура',
+      outlineColor: 'Цвет контура'
     }
   },
   sidebar: {
@@ -63,10 +68,15 @@ export default {
       filter: 'Фильтры',
       interaction: 'Взаимодействия',
       basemap: 'Базовая карта'
+    },
+    panelViewToggle: {
+      list: 'Просмотр списком',
+      byDataset: 'Просмотр по набору данных'
     }
   },
   layer: {
     required: 'Требования*',
+    columnModesSeparator: 'Или',
     radius: 'Радиус',
     color: 'Цвет',
     fillColor: 'Цвет заливки',
@@ -77,15 +87,19 @@ export default {
     stroke: 'Обводка',
     strokeWidth: 'Ширина обводки',
     strokeColor: 'Цвет обводки',
-    basic: 'Basic',
-    trailLength: 'Trail Length',
-    trailLengthDescription: 'Number of seconds for a path to completely fade out',
-    newLayer: 'new layer',
-    elevationByDescription: 'When off, height is based on count of points',
-    colorByDescription: 'When off, color is based on count of points',
-    aggregateBy: 'Aggregate {field} by',
-    '3DModel': '3D Model',
-    '3DModelOptions': '3D Model Options',
+    basic: 'Базовый',
+    trailLength: 'Длина следа',
+    trailLengthDescription: 'Количество секунд для полного затухания пути',
+    newLayer: 'новый слой',
+    elevationByDescription: 'При выключении высота основана на количестве точек',
+    colorByDescription: 'При выключении цвет основан на количестве точек',
+    aggregateBy: 'Агрегировать {field} по',
+    '3DModel': '3D Модель',
+    '3DModelOptions': 'Настройки 3D модели',
+    service: 'Сервис',
+    layer: 'Слой',
+    appearance: 'Внешний вид',
+    uniqueIdField: 'Поле уникального ID',
     type: {
       point: 'точки',
       arc: 'дуги',
@@ -101,12 +115,23 @@ export default {
       hexagonid: 'H3',
       trip: 'пути',
       s2: 'S2',
-      '3d': '3D'
+      '3d': '3D',
+      vectortile: 'векторный тайл',
+      rastertile: 'растровый тайл',
+      wms: 'WMS',
+      tile3d: '3D тайл'
     },
+    wms: {
+      hover: 'Значение:'
+    },
+    layerUpdateError:
+      'Произошла ошибка при обновлении слоя: {errorMessage}. Убедитесь, что формат входных данных корректен.',
+    interaction: 'Взаимодействие',
     heatmap: 'Heatmap',
     aggregation: 'Aggregation'
   },
   layerVisConfigs: {
+    angle: 'Угол',
     strokeWidth: 'Ширина штриха (в пикселях)',
     strokeWidthRange: 'Диапазон ширины штриха',
     radius: 'Радиус',
@@ -116,7 +141,11 @@ export default {
     radiusRange: 'Диапазон радиуса',
     clusterRadius: 'Радиус кластера в пикселях',
     radiusRangePixels: 'Диапазон радиуса в пикселях',
+    billboard: 'Режим билборда',
+    billboardDescription: 'Ориентировать геометрию на камеру',
+    fadeTrail: 'Затухающий след',
     opacity: 'Непрозрачность',
+    pointSize: 'Размер точки',
     coverage: 'Покрытие',
     outline: 'Контур',
     colorRange: 'Цветовая гамма',
@@ -134,7 +163,7 @@ export default {
     enableElevationZoomFactor: 'Использовать коэффициент увеличения по высоте',
     enableElevationZoomFactorDescription:
       'Отрегулируйте высоту / возвышение на основе текущего коэффициента масштабирования',
-    enableHeightZoomFactor: 'вкл. коэффициент масштабирования по высоте',
+    enableHeightZoomFactor: 'Использовать коэффициент масштабирования по высоте',
     heightScale: 'Масштаб высоты',
     coverageRange: 'Диапазон покрытия',
     highPrecisionRendering: 'Высокая точность рендеринга',
@@ -150,32 +179,97 @@ export default {
     zoomScale: 'Масштаб увеличения',
     heightRange: 'Диапазон высоты',
     heightMultiplier: 'Множитель высоты',
+    fixedHeight: 'Фиксированная высота',
+    fixedHeightDescription: 'Использовать высоту без изменений',
     allowHover: 'Показать подсказку',
-    allowHoverDescription: 'Показать или скрыть подсказку при наведении на элементы слоя'
+    allowHoverDescription: 'Показать или скрыть подсказку при наведении на элементы слоя',
+    showNeighborOnHover: 'Выделять соседей при наведении',
+    showHighlightColor: 'Показать цвет выделения',
+    darkModeEnabled: 'Темная базовая карта',
+    transparentBackground: 'Прозрачный фон'
   },
   layerManager: {
     addData: 'Добавить данные',
     addLayer: 'Добавить слой',
-    layerBlending: 'Смешивание слоев'
+    layerBlending: 'Смешивание слоев',
+    overlayBlending: 'Наложение слоев'
   },
   mapManager: {
     mapStyle: 'Стиль карты',
     addMapStyle: 'Добавить стиль карты',
-    '3dBuildingColor': '3D Цвет здания'
+    '3dBuildingColor': '3D Цвет здания',
+    backgroundColor: 'Цвет фона'
+  },
+  effectManager: {
+    effects: 'Эффекты',
+    addEffect: 'Добавить эффект',
+    pickDateTime: 'Выбрать дату/время',
+    currentTime: 'Текущее время',
+    pickCurrrentTime: 'Выбрать текущее время',
+    date: 'Дата',
+    time: 'Время',
+    timezone: 'Часовой пояс'
+  },
+  effectDescription: {
+    lightAndShadow:
+      'Имитирует реалистичное солнечное освещение и отбрасывание теней на основе времени суток и географического положения. Регулируемая интенсивность теней, цвета солнечного и рассеянного света.',
+    ink: 'Применяет художественный стиль тушевой заливки, затемняющий края и создающий рукописный вид. Регулируйте силу для управления интенсивностью эффекта.',
+    brightnessContrast:
+      'Регулирует общую яркость и контрастность карты. Используйте положительные значения для увеличения яркости или контраста, отрицательные — для затемнения или выравнивания изображения.',
+    hueSaturation:
+      'Сдвигает цветовой тон и регулирует насыщенность по всей карте. Полезно для создания цветовых тем или обесцвечивания вида.',
+    vibrance:
+      'Избирательно усиливает интенсивность приглушённых цветов, не перенасыщая уже яркие. Создаёт более естественное улучшение цвета, чем насыщенность.',
+    sepia:
+      'Применяет тёплый коричневатый тон, напоминающий старые фотографии. Регулируйте степень смешивания между исходными цветами и эффектом сепии.',
+    dotScreen:
+      'Преобразует изображение в узор из монохромных точек, напоминающий газетную полутоновую печать. Регулируйте угол, размер точек и положение центра.',
+    colorHalftone:
+      'Имитирует цветную полутоновую печать CMYK с отдельными точечными узорами для каждого цветового канала. Управляйте углом, размером точек и положением центра.',
+    noise:
+      'Добавляет случайный шум в стиле плёночного зерна по всей карте. Полезно для текстурированной аналоговой эстетики или уменьшения цветовых полос.',
+    triangleBlur:
+      'Равномерно применяет плавное размытие по Гауссу по всей карте. Управляйте радиусом размытия для настройки уровня мягкости.',
+    zoomBlur:
+      'Создаёт радиальное размытие движения из центральной точки, имитируя зум камеры. Регулируйте силу и положение центра.',
+    tiltShift:
+      'Имитирует эффект объектива тилт-шифт, размывающий области за пределами фокусной полосы и создающий вид миниатюрной модели. Задайте фокусную полосу начальной и конечной позициями.',
+    edgeWork:
+      'Выделяет структурные края изображения в художественном стиле угольного эскиза. Регулируйте радиус обнаружения для управления толщиной линий.',
+    vignette:
+      'Затемняет углы и края карты, направляя внимание к центру. Управляйте степенью затемнения и радиусом чистой области.',
+    magnify:
+      'Создаёт круглое наложение увеличительного стекла в настраиваемом положении. Регулируйте размер, уровень масштабирования и ширину рамки.',
+    hexagonalPixelate:
+      'Заменяет изображение сеткой шестиугольных плиток, каждая из которых заполнена средним цветом покрываемой области. Регулируйте масштаб плиток.',
+    distanceFog:
+      'Затуманивает удалённые объекты на основе их глубины от камеры, усиливая ощущение глубины. Управляйте плотностью, начальным расстоянием, диапазоном и цветом тумана.',
+    surfaceFog:
+      'Отрисовывает слой тумана на определённой высоте над поверхностью рельефа. Настройте высоту, толщину перехода, плотность, цвет и необязательный шумовой паттерн.'
   },
   layerConfiguration: {
     defaultDescription: 'Рассчитать {property} на основе выбранного поля',
-    howTo: 'How to'
+    howTo: 'Как использовать',
+    showColorChart: 'Показать цветовую диаграмму',
+    hideColorChart: 'Скрыть цветовую диаграмму'
   },
   filterManager: {
-    addFilter: 'Добавить фильтр'
+    addFilter: 'Добавить фильтр',
+    timeFilterSync: 'Синхронизированные наборы данных',
+    timeLayerSync: 'Привязать к временной шкале слоя',
+    timeLayerUnsync: 'Отвязать от временной шкалы слоя',
+    column: 'Столбец'
   },
   datasetTitle: {
     showDataTable: 'Показать таблицу данных ',
     removeDataset: 'Удалить набор данных'
   },
   datasetInfo: {
-    rowCount: '{rowCount} строк'
+    rowCount: '{rowCount} строк',
+    vectorTile: 'Векторный тайл',
+    rasterTile: 'Растровый тайл',
+    wmsTile: 'WMS тайл',
+    tile3d: '3D тайл'
   },
   tooltip: {
     hideLayer: 'скрыть слой',
@@ -209,13 +303,27 @@ export default {
     play: 'проиграть',
     pause: 'пауза',
     reset: 'перезапустить',
-    export: 'экспорт'
+    export: 'экспорт',
+    resetAfterError: 'Попытаться включить слой после ошибки',
+    zoomToLayer: 'Приблизить к слою',
+    removeBaseMapStyle: 'Удалить стиль базовой карты',
+    timeFilterSync: 'Синхронизировать со столбцом из другого набора данных',
+    syncTimelineStart: 'Начало текущего периода фильтра',
+    syncTimelineEnd: 'Конец текущего периода фильтра',
+    showEffectPanel: 'Показать панель эффектов',
+    hideEffectPanel: 'Скрыть панель эффектов',
+    removeEffect: 'Удалить эффект',
+    disableEffect: 'Отключить эффект',
+    effectSettings: 'Настройки эффекта',
+    timeLayerSync: 'Привязать к временной шкале слоя',
+    timeLayerUnsync: 'Отвязать от временной шкалы слоя'
   },
   toolbar: {
     exportImage: 'Экспорт изображения',
     exportData: 'Экспорт данных',
     exportMap: 'Экспорт карты',
-    shareMapURL: 'Share Map URL',
+    shareMapURL: 'Поделиться URL карты',
+    exportVideo: 'Экспорт видео',
     saveMap: 'Сохарнить Карту',
     select: 'Выбрать',
     polygon: 'Многоугольник',
@@ -226,7 +334,13 @@ export default {
   },
   editor: {
     filterLayer: 'Слои фильтров',
-    copyGeometry: 'Копировать геометрию'
+    filterLayerDisabled: 'Неполигональные геометрии нельзя использовать для фильтрации',
+    copyGeometry: 'Копировать геометрию',
+    noLayersToFilter: 'Нет слоев для фильтрации'
+  },
+  exportVideoModal: {
+    animation: 'Анимация',
+    settings: 'Настройки'
   },
 
   modal: {
@@ -236,6 +350,7 @@ export default {
       exportImage: 'Экспорт изображения',
       exportData: 'Экспорт данных',
       exportMap: 'Экспорт карты',
+      exportVideo: 'Экспорт видео',
       addCustomMapboxStyle: 'Добавить собственный стиль карты',
       saveMap: 'Поделиться Картой',
       shareURL: 'Поделиться URL'
@@ -262,6 +377,10 @@ export default {
       mapLegendTitle: 'Легенда карты',
       mapLegendAdd: 'Добавить легенду на карту'
     },
+    exportVideo: {
+      animation: 'Анимация',
+      settings: 'Настройки'
+    },
     exportData: {
       datasetTitle: 'Набор данных',
       datasetSubtitle: 'Выберите наборы данных, которые хотите экспортировать',
@@ -273,7 +392,8 @@ export default {
       filteredData: 'Отфильтрованные данные',
       unfilteredData: 'Нефильтрованные данные',
       fileCount: '{fileCount} Файлов',
-      rowCount: '{rowCount} Строк'
+      rowCount: '{rowCount} Строк',
+      tiledDatasetWarning: "* Экспорт данных для тайловых наборов данных не поддерживается"
     },
     deleteData: {
       warning: 'вы собираетесь удалить этот набор данных. Это повлияет на {length} слой'
@@ -299,6 +419,7 @@ export default {
       namingTitle: '3. Назови свой стиль'
     },
     shareMap: {
+      title: 'Поделиться картой',
       shareUriTitle: 'Поделиться URL карты',
       shareUriSubtitle: 'Создать URL карты, чтобы поделиться с другими',
       cloudTitle: 'Облачное хранилище',
@@ -326,6 +447,8 @@ export default {
         tokenPlaceholder: 'Вставьте токен доступа Mapbox',
         tokenMisuseWarning:
           '* If you do not provide your own token, the map may fail to display at any time when we replace ours to avoid misuse. ',
+        tokenSecurityWarning:
+          '* Предупреждение: ваш токен Mapbox будет встроен в экспортированный HTML-файл. Любой, кто имеет доступ к этому файлу, сможет увидеть и использовать ваш токен. По возможности используйте токен с ограничением по URL. ',
         tokenDisclaimer:
           'Если вы не предоставите свой собственный токен, карта может не отображаться в любое время, когда мы заменяем наш, чтобы избежать неправильного использования.',
         tokenUpdate: 'Как обновить существующий токен карты.',
@@ -352,16 +475,35 @@ export default {
     },
     loadData: {
       upload: 'Загрузить файлы',
+      tileset: 'Набор тайлов',
       storage: 'Загрузить из хранилища'
     },
     tripInfo: {
       title: 'Как включить анимацию поездки',
+      titleTable: 'Создать поездки из списка точек',
       description1:
         'Чтобы анимировать путь, данные geoJSON должны содержать LineString в своей геометрии объекта, а координаты в LineString должны иметь 4 элемента в форматах',
       code: ' [longitude, latitude, altitude, timestamp] ',
       description2:
         'с последним элементом, являющимся отметкой времени. Допустимые форматы меток времени включают unix в секундах, например 1564184363, или в миллисекундах, например 1564184363000',
-      example: ',Пример:'
+      descriptionTable1:
+        'Поездки можно создать, соединив список точек по широте и долготе, отсортировав по временным меткам и сгруппировав по уникальным идентификаторам.',
+      example: ',Пример:',
+      exampleTable: 'Example Csv'
+    },
+    polygonInfo: {
+      title: 'Создать слой полигонов из объекта GeoJSON',
+      titleTable: 'Создать путь из точек',
+      descriptionTable: `Пути можно создать, соединив список точек по широте и долготе, отсортировав по индексному полю (например, временная метка) и сгруппировав по уникальным идентификаторам.
+
+  ### Столбцы слоя:
+  - **id**: - *обязательный*&nbsp;- Столбец \`id\` используется для группировки точек. Точки с одинаковым id будут объединены в один путь.
+  - **lat**: - *обязательный*&nbsp;- Широта точки
+  - **lon**: - *обязательный*&nbsp;- Долгота точки
+  - **alt**: - *необязательный*&nbsp;- Высота точки
+  - **sort by**: - *необязательный*&nbsp;- Столбец \`sort by\` используется для сортировки точек; если не указан, точки будут отсортированы по индексу строки.
+`,
+      exampleTable: 'Example CSV'
     },
     iconInfo: {
       title: 'Как рисовать значки',
@@ -384,7 +526,9 @@ export default {
       back: 'Назад',
       goToPage: 'Перейти на страницу Kepler.gl {displayName}',
       storageMaps: 'Хранилище / Карты',
-      noSavedMaps: 'Нет сохраненных карт'
+      noSavedMaps: 'Нет сохраненных карт',
+      foursquareStorageMessage:
+        'Здесь отображаются только карты, сохраненные с помощью опции Kepler.gl > Сохранить > Хранилище Foursquare'
     }
   },
   header: {
@@ -403,14 +547,29 @@ export default {
     normal: 'нормальное',
     subtractive: 'вычитание'
   },
+  overlayBlending: {
+    title: 'Наложение слоев карты',
+    description: 'Смешивание слоев с базовой картой, чтобы оба были видны.',
+    screen: 'темная базовая карта',
+    normal: 'обычный',
+    darken: 'светлая базовая карта'
+  },
   columns: {
     title: 'Столбцы',
     lat: 'lat',
     lng: 'lon',
     altitude: 'высота',
+    alt: 'высота',
+    id: 'id',
+    timestamp: 'время',
     icon: 'значек',
     geojson: 'geojson',
+    geoarrow: 'geoarrow',
+    geoarrow0: 'geoarrow источник',
+    geoarrow1: 'geoarrow назначение',
     token: 'token',
+    sortBy: 'сортировать по',
+    neighbors: 'соседи',
     arc: {
       lat0: 'lat источника',
       lng0: 'lng источника',
@@ -433,12 +592,17 @@ export default {
     customPalette: 'Ваша палитра',
     steps: 'шагов',
     type: 'тип',
-    reversed: 'перевернуть'
+    colorBlindSafe: 'Для дальтоников',
+    reversed: 'перевернуть',
+    disableStepReason: "Невозможно изменить количество шагов с пользовательскими цветовыми переходами, используйте пользовательскую палитру для редактирования шагов",
+    preset: 'Предустановленные цвета',
+    picker: 'Выбор цвета'
   },
   scale: {
     colorScale: 'Цветовая шкала',
     sizeScale: 'Масштаб размера',
     strokeScale: 'Масштаб штриха',
+    strokeColorScale: 'Шкала цвета обводки',
     scale: 'Масштаб'
   },
   fileUploader: {
@@ -452,8 +616,13 @@ export default {
       'Загрузите {fileFormatNames} или сохраненную карту **Json**. Подробнее [**supported file formats**]',
     browseFiles: 'Просматреть файлы',
     uploading: 'Загрузка',
-    fileNotSupported: 'File {errorFiles} is not supported.',
-    or: 'or'
+    fileNotSupported: 'Файл {errorFiles} не поддерживается.',
+    or: 'или'
+  },
+  tilesetSetup: {
+    header: 'Настройка векторных тайлов',
+    rasterTileHeader: 'Настройка растровых тайлов',
+    addTilesetText: 'Добавить набор тайлов'
   },
   geocoder: {
     title: 'Введите адрес или координаты, например 37.79, -122.40'
@@ -473,9 +642,31 @@ export default {
   mapPopover: {
     primary: 'Первичный'
   },
-  density: 'density',
+  density: 'плотность',
   'Bug Report': 'Отчет об ошибках',
   'User Guide': 'Инструкции',
   Save: 'Сохранить',
-  Share: 'Поделиться'
+  Share: 'Поделиться',
+  mapLegend: {
+    layers: {
+      line: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      arc: {
+        singleColor: {
+          sourceColor: 'Source',
+          targetColor: 'Target'
+        }
+      },
+      default: {
+        singleColor: {
+          color: 'Fill color',
+          strokeColor: 'Outline'
+        }
+      }
+    }
+  }
 };

--- a/src/localization/src/translations/ru.ts
+++ b/src/localization/src/translations/ru.ts
@@ -446,7 +446,7 @@ export default {
         tokenSubtitle: 'Используйте свой токен доступа Mapbox в html(необязательно)',
         tokenPlaceholder: 'Вставьте токен доступа Mapbox',
         tokenMisuseWarning:
-          '* If you do not provide your own token, the map may fail to display at any time when we replace ours to avoid misuse. ',
+          '* Если вы не предоставите свой собственный токен, карта может перестать отображаться в любой момент, когда мы заменим наш токен во избежание неправильного использования. ',
         tokenSecurityWarning:
           '* Предупреждение: ваш токен Mapbox будет встроен в экспортированный HTML-файл. Любой, кто имеет доступ к этому файлу, сможет увидеть и использовать ваш токен. По возможности используйте токен с ограничением по URL. ',
         tokenDisclaimer:
@@ -651,20 +651,20 @@ export default {
     layers: {
       line: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Источник',
+          targetColor: 'Цель'
         }
       },
       arc: {
         singleColor: {
-          sourceColor: 'Source',
-          targetColor: 'Target'
+          sourceColor: 'Источник',
+          targetColor: 'Цель'
         }
       },
       default: {
         singleColor: {
-          color: 'Fill color',
-          strokeColor: 'Outline'
+          color: 'Цвет заливки',
+          strokeColor: 'Контур'
         }
       }
     }


### PR DESCRIPTION
- Added missing translation keys to all 7 locale files (ca, cn, es, fi, ja, pt, ru) to match en.ts
- Translated English strings that were left untranslated within otherwise-translated sections
