### PR TITLE
fix: fix regressions after deck.gl 9.3.1 upgrade

### DIFF
--- a/src/components/src/effects/surface-fog-section.tsx
+++ b/src/components/src/effects/surface-fog-section.tsx
@@ -196,7 +196,7 @@ export default function SurfaceFogElevationSectionFactory(
       if (!heightDesc || !heightEndDesc) return null;
 
       const rangeMin = heightDesc.min ?? -200;
-      const rangeMax = heightDesc.max ?? 3000;
+      const rangeMax = heightDesc.max ?? 6000;
       const rangeSpan = rangeMax - rangeMin;
       const step = rangeSpan > 10 ? 1 : 0.001;
 

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -965,11 +965,7 @@ export default function MapContainerFactory(
 
       const views = deckGlProps?.views
         ? deckGlProps?.views()
-        : new MapView({legacyMeterSizes: true, farZMultiplier: 1.2} as ConstructorParameters<
-            typeof MapView
-          >[0] & {
-            legacyMeterSizes: boolean;
-          });
+        : new MapView({farZMultiplier: 1.2});
 
       let allDeckGlProps = {
         ...deckGlProps,

--- a/src/components/src/modals/export-video-modal.tsx
+++ b/src/components/src/modals/export-video-modal.tsx
@@ -257,8 +257,23 @@ const ExportVideoModalFactory = () => {
       if (mapStyle?.styleType === NO_MAP_ID) {
         const noMapEntry = mapStyle.mapStyles?.[NO_MAP_ID];
         if (noMapEntry && !noMapEntry.url) {
+          const bg = mapStyle.backgroundColor;
+          const bgStyle = {
+            ...EMPTY_MAPBOX_STYLE,
+            layers: bg
+              ? [
+                  {
+                    id: 'background',
+                    type: 'background',
+                    paint: {
+                      'background-color': `rgb(${bg[0]},${bg[1]},${bg[2]})`
+                    }
+                  }
+                ]
+              : []
+          };
           const emptyStyleUrl = `data:application/json,${encodeURIComponent(
-            JSON.stringify(EMPTY_MAPBOX_STYLE)
+            JSON.stringify(bgStyle)
           )}`;
           return {
             visState,

--- a/src/components/src/modals/hubble-utils.ts
+++ b/src/components/src/modals/hubble-utils.ts
@@ -181,7 +181,10 @@ export function getHubbleDeckGlProps(
   return {
     parameters: getHubbleParameters(keplerState),
     controller: true,
-    views: new MapView({farZMultiplier: 1.2})
+    views: new MapView({
+      id: 'mapbox',
+      farZMultiplier: 1.2
+    })
   };
 }
 

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1649,7 +1649,7 @@ export const POSTPROCESSING_EFFECTS: {[key: string]: EffectDescription} = {
     description: 'effectDescription.surfaceFog',
     parameters: [
       {name: 'density', defaultValue: 0.6, min: 0, max: 1},
-      {name: 'height', label: 'Elevation (m)', defaultValue: 50, min: -200, max: 3000},
+      {name: 'height', label: 'Elevation (m)', defaultValue: 50, min: -200, max: 6000},
       {
         name: 'animateHeight',
         type: 'checkbox',
@@ -1660,7 +1660,7 @@ export const POSTPROCESSING_EFFECTS: {[key: string]: EffectDescription} = {
         min: 0,
         max: 1
       },
-      {name: 'heightEnd', label: 'End Elevation (m)', defaultValue: 100, min: -200, max: 3000},
+      {name: 'heightEnd', label: 'End Elevation (m)', defaultValue: 100, min: -200, max: 6000},
       {
         name: 'linearEasing',
         type: 'checkbox',

--- a/src/effects/src/shader-passes/distance-fog.ts
+++ b/src/effects/src/shader-passes/distance-fog.ts
@@ -86,10 +86,9 @@ void main() {
 
   // Porter-Duff source-over for correct compositing over transparent basemap pixels.
   vec3 baseRgb = color.a > 0.001 ? color.rgb / color.a : fogColor;
-  vec3 blended = mix(baseRgb, fogColor, fogFactor);
-  vec3 outRgb = blended * fogFactor + color.rgb * (1.0 - fogFactor);
+  vec3 straightRgb = mix(baseRgb, fogColor, fogFactor);
   float outAlpha = fogFactor + color.a * (1.0 - fogFactor);
-  fragColor = vec4(outRgb, outAlpha);
+  fragColor = vec4(straightRgb * outAlpha, outAlpha);
 }
 `;
 
@@ -205,6 +204,12 @@ export class DeckDistanceFogEffect {
   preRender(opts?: any): void {
     if (this.isExportMode && opts) {
       this._unpatchViewports = patchTileViewportIds(opts);
+    }
+    if (this.model) {
+      const gl = (this.model.device as any).gl as WebGL2RenderingContext | undefined;
+      if (gl) {
+        gl.depthRange(0, 1);
+      }
     }
   }
 

--- a/src/effects/src/shader-passes/distance-fog.ts
+++ b/src/effects/src/shader-passes/distance-fog.ts
@@ -84,7 +84,9 @@ void main() {
     return;
   }
 
-  // Porter-Duff source-over for correct compositing over transparent basemap pixels.
+  // Composite fog over the scene. Transparent pixels (basemap gaps) are treated
+  // as if they already contain the fog color, so we un-premultiply, blend in
+  // straight RGB space, then re-premultiply for the framebuffer.
   vec3 baseRgb = color.a > 0.001 ? color.rgb / color.a : fogColor;
   vec3 straightRgb = mix(baseRgb, fogColor, fogFactor);
   float outAlpha = fogFactor + color.a * (1.0 - fogFactor);

--- a/src/effects/src/shader-passes/distance-fog.ts
+++ b/src/effects/src/shader-passes/distance-fog.ts
@@ -3,7 +3,7 @@
 
 import {ClipSpace} from '@luma.gl/engine';
 import type {ShaderModule} from '@luma.gl/shadertools';
-import {patchTileViewportIds} from '../tile-viewport-fix';
+import {patchTileViewportIds, resetDepthRange} from '../tile-viewport-fix';
 
 export type DistanceFogProps = {
   density: number;
@@ -207,12 +207,7 @@ export class DeckDistanceFogEffect {
     if (this.isExportMode && opts) {
       this._unpatchViewports = patchTileViewportIds(opts);
     }
-    if (this.model) {
-      const gl = (this.model.device as any).gl as WebGL2RenderingContext | undefined;
-      if (gl) {
-        gl.depthRange(0, 1);
-      }
-    }
+    resetDepthRange(this.model);
   }
 
   postRender(params: any): any {

--- a/src/effects/src/shader-passes/surface-fog.ts
+++ b/src/effects/src/shader-passes/surface-fog.ts
@@ -194,13 +194,11 @@ void main() {
   vec3 fogColorNorm = surfaceFog.fogColor / 255.0;
 
   if (!usePattern) {
-    // Plain fog — Porter-Duff source-over for basemap coverage.
     float ff = clamp(fogFactor, 0.0, 1.0);
     vec3 baseRgb = color.a > 0.001 ? color.rgb / color.a : fogColorNorm;
-    vec3 blended = mix(baseRgb, fogColorNorm, ff);
-    vec3 outRgb = blended * ff + color.rgb * (1.0 - ff);
+    vec3 straightRgb = mix(baseRgb, fogColorNorm, ff);
     float outAlpha = ff + color.a * (1.0 - ff);
-    fragColor = vec4(outRgb, outAlpha);
+    fragColor = vec4(straightRgb * outAlpha, outAlpha);
     return;
   }
 
@@ -216,12 +214,10 @@ void main() {
   vec3 tinted = mix(baseRgb, fogColorNorm, submersion);
   vec3 waterSurface = clamp(tinted * (diffuse + vec3(0.1)) + specular, 0.0, 1.0);
 
-  // Porter-Duff source-over so the effect is visible on transparent basemap areas.
   float wf = clamp(fogFactor, 0.0, 1.0);
-  vec3 outRgb = waterSurface * wf + color.rgb * (1.0 - wf);
+  vec3 straightRgb = mix(baseRgb, waterSurface, wf);
   float outAlpha = wf + color.a * (1.0 - wf);
-
-  fragColor = vec4(outRgb, outAlpha);
+  fragColor = vec4(straightRgb * outAlpha, outAlpha);
 }
 `;
 
@@ -338,6 +334,17 @@ export class DeckSurfaceFogEffect {
   preRender(opts?: any): void {
     if (this.isExportMode && opts) {
       this._unpatchViewports = patchTileViewportIds(opts);
+    }
+    // Reset depthRange to [0,1]. Maplibre/mapbox basemap rendering sets a
+    // compressed depthRange (e.g. [0, 0.979]) and doesn't restore it.  When
+    // deck.gl layers render to the offscreen FBO their depth values get
+    // compressed into that range, causing the fog shader's depth
+    // reconstruction (depth * 2 − 1) to return incorrect z values.
+    if (this.model) {
+      const gl = (this.model.device as any).gl as WebGL2RenderingContext | undefined;
+      if (gl) {
+        gl.depthRange(0, 1);
+      }
     }
   }
 

--- a/src/effects/src/shader-passes/surface-fog.ts
+++ b/src/effects/src/shader-passes/surface-fog.ts
@@ -286,7 +286,7 @@ const surfaceFogModule = {
  * When `pattern` is false the effect behaves as a classic flat-colour fog layer.
  * When `pattern` is true a static wave pattern (layered sine trains + FBM noise,
  * lit with diffuse+specular sun shading) replaces the flat tint and the
- * effect also renders over basemap areas via Porter-Duff compositing.
+ * effect also renders over basemap areas via straight-alpha compositing.
  */
 export class DeckSurfaceFogEffect {
   id = 'surface-fog-effect';

--- a/src/effects/src/shader-passes/surface-fog.ts
+++ b/src/effects/src/shader-passes/surface-fog.ts
@@ -3,7 +3,7 @@
 
 import {ClipSpace} from '@luma.gl/engine';
 import type {ShaderModule} from '@luma.gl/shadertools';
-import {patchTileViewportIds} from '../tile-viewport-fix';
+import {patchTileViewportIds, resetDepthRange} from '../tile-viewport-fix';
 
 export type SurfaceFogProps = {
   density: number;
@@ -335,17 +335,7 @@ export class DeckSurfaceFogEffect {
     if (this.isExportMode && opts) {
       this._unpatchViewports = patchTileViewportIds(opts);
     }
-    // Reset depthRange to [0,1]. Maplibre/mapbox basemap rendering sets a
-    // compressed depthRange (e.g. [0, 0.979]) and doesn't restore it.  When
-    // deck.gl layers render to the offscreen FBO their depth values get
-    // compressed into that range, causing the fog shader's depth
-    // reconstruction (depth * 2 − 1) to return incorrect z values.
-    if (this.model) {
-      const gl = (this.model.device as any).gl as WebGL2RenderingContext | undefined;
-      if (gl) {
-        gl.depthRange(0, 1);
-      }
-    }
+    resetDepthRange(this.model);
   }
 
   postRender(params: any): any {

--- a/src/effects/src/tile-viewport-fix.ts
+++ b/src/effects/src/tile-viewport-fix.ts
@@ -45,3 +45,19 @@ export function patchTileViewportIds(opts: {
     }
   };
 }
+
+/**
+ * Reset WebGL depthRange to [0, 1].
+ *
+ * Maplibre/Mapbox basemap rendering compresses the depth range (e.g. [0, 0.979])
+ * and doesn't restore it. When deck.gl layers subsequently render to the offscreen
+ * FBO, their depth values inherit that compressed range, causing the fog shader's
+ * depth reconstruction (depth * 2 − 1) to produce incorrect z values.
+ */
+export function resetDepthRange(model: {device: any} | null): void {
+  if (!model) return;
+  const gl = (model.device as any).gl as WebGL2RenderingContext | undefined;
+  if (gl) {
+    gl.depthRange(0, 1);
+  }
+}


### PR DESCRIPTION
- [x] remove legacyMeterSizes. Causes artifacts after the upgrade. Not sure why it's needed. Can be restored later if needed.
- [x] clear depth after basemaps in interleaved mode (video export).
- [x] fix fog shaders output color logic
- [x] increase surface fog max level to 6000