### PR TITLE
fix: Fix incorrect highlight position in point/arc layers when CPU-side filter is active

### DIFF
--- a/src/layers/src/arc-layer/arc-layer.ts
+++ b/src/layers/src/arc-layer/arc-layer.ts
@@ -564,6 +564,7 @@ export default class ArcLayer extends Layer {
 
   hasHoveredObject(objectInfo: {index: number}) {
     if (
+      this.geoArrowVector0 &&
       isLayerHoveredFromArrow(objectInfo, this.id) &&
       objectInfo.index >= 0 &&
       this.dataContainer

--- a/src/layers/src/point-layer/point-layer.ts
+++ b/src/layers/src/point-layer/point-layer.ts
@@ -643,6 +643,7 @@ export default class PointLayer extends Layer {
 
   hasHoveredObject(objectInfo: {index: number}) {
     if (
+      this.geoArrowVector &&
       isLayerHoveredFromArrow(objectInfo, this.id) &&
       objectInfo.index >= 0 &&
       this.dataContainer


### PR DESCRIPTION
When a CPU-side filter (e.g. string filter) is applied to a scatterplot or arc layer using non-Arrow data, hovering a point highlights the wrong object. The hasHoveredObject override in PointLayer and ArcLayer unconditionally entered the Arrow-specific code path—which interprets pickingInfo.index as a row index in the full table—even for row-based data where that index is a position in the filtered subset array. This adds a geoArrowVector / geoArrowVector0 guard so the Arrow path only runs when the layer actually uses Arrow data, matching the pattern already used by GeoJsonLayer and getHoverData.