### PR TITLE
fix: optimize raster tile layer UBOs not to fail in combination with effects

### DIFF
--- a/src/deckgl-layers/src/raster/pipeline-validation-patch.ts
+++ b/src/deckgl-layers/src/raster/pipeline-validation-patch.ts
@@ -26,7 +26,7 @@ const MIXED_SAMPLER_RE = /different type[s]? use the same sampler location/i;
 
 let _patched = false;
 
-function createPatchedLinkStatus(original: Function) {
+function createPatchedLinkStatus(_original: (...args: unknown[]) => unknown) {
   return function _patchedGetLinkStatus(this: any) {
     const {gl} = this.device;
     const linked = gl.getProgramParameter(this.handle, 0x8b82 /* LINK_STATUS */);

--- a/src/deckgl-layers/src/raster/pipeline-validation-patch.ts
+++ b/src/deckgl-layers/src/raster/pipeline-validation-patch.ts
@@ -79,34 +79,27 @@ export function patchPipelineValidation(): void {
   const origFactory = deviceProto?._createSharedRenderPipelineWebGL;
   if (typeof origFactory !== 'function') return;
 
-  let sharedClassPatched = false;
-
   deviceProto._createSharedRenderPipelineWebGL = function (this: any, ...args: any[]) {
-    if (!sharedClassPatched) {
-      sharedClassPatched = true;
+    const instance = origFactory.apply(this, args);
+    const SharedCtor = Object.getPrototypeOf(instance).constructor;
 
-      const instance = origFactory.apply(this, args);
-      const SharedCtor = Object.getPrototypeOf(instance).constructor;
+    if (
+      SharedCtor &&
+      SharedCtor !== WEBGLRenderPipeline &&
+      typeof SharedCtor.prototype._getLinkStatus === 'function'
+    ) {
+      const original = SharedCtor.prototype._getLinkStatus;
+      SharedCtor.prototype._getLinkStatus = createPatchedLinkStatus(original);
 
-      if (
-        SharedCtor &&
-        SharedCtor !== WEBGLRenderPipeline &&
-        typeof SharedCtor.prototype._getLinkStatus === 'function'
-      ) {
-        const original = SharedCtor.prototype._getLinkStatus;
-        SharedCtor.prototype._getLinkStatus = createPatchedLinkStatus(original);
-
-        // Re-validate this first instance since its _getLinkStatus already ran
-        // with the unpatched version during construction.
-        if (instance.linkStatus === 'error') {
-          instance._getLinkStatus();
-        }
+      // Re-validate this first instance since its _getLinkStatus already ran
+      // with the unpatched version during construction.
+      if (instance.linkStatus !== 'success') {
+        instance._getLinkStatus();
       }
-
-      // Restore original factory — future instances will use the patched prototype
-      deviceProto._createSharedRenderPipelineWebGL = origFactory;
-      return instance;
     }
-    return origFactory.apply(this, args);
+
+    // Restore original factory — future instances will use the patched prototype
+    deviceProto._createSharedRenderPipelineWebGL = origFactory;
+    return instance;
   };
 }

--- a/src/deckgl-layers/src/raster/pipeline-validation-patch.ts
+++ b/src/deckgl-layers/src/raster/pipeline-validation-patch.ts
@@ -2,48 +2,44 @@
 // Copyright contributors to the kepler.gl project
 
 /**
- * Patch luma.gl 9's WEBGLRenderPipeline to tolerate mixed-sampler-type
+ * Patch luma.gl 9's pipeline validation to tolerate mixed-sampler-type
  * validation errors in _getLinkStatus().
  *
  * WebGL2's validateProgram checks that sampler uniforms of different types
  * (sampler2D, usampler2D, isampler2D) are not assigned to the same texture
- * unit. Before any draw call the default texture unit for all samplers is 0,
- * so programs that mix sampler types (e.g. raster band data as usampler2D +
- * colormap as sampler2D) always fail validation even though the program linked
- * successfully and will work correctly once texture units are assigned at draw
- * time.
+ * unit. Programs that mix sampler types (e.g. raster band data as usampler2D +
+ * shadow maps as sampler2D) may fail validation even though they linked
+ * successfully and work correctly once texture units are assigned at draw time.
  *
- * luma.gl calls validateProgram inside _getLinkStatus() immediately after
- * linkProgram, before any texture units can be assigned. This patch keeps the
- * full validateProgram call but ignores only the known false-positive about
- * mixed sampler types. All other validation errors are still reported.
+ * In luma.gl ≥9.3 the _getLinkStatus method moved from WEBGLRenderPipeline to
+ * WEBGLSharedRenderPipeline and now calls _initializeSamplerUniforms() before
+ * validateProgram, which fixes most false positives. However, some WebGL
+ * drivers still report errors even with unique units, so we keep suppressing
+ * the known false-positive about mixed sampler types. We patch _getLinkStatus
+ * on whichever pipeline class owns it.
  */
 
-// @ts-ignore WEBGLRenderPipeline resolution depends on moduleResolution setting
-import {WEBGLRenderPipeline} from '@luma.gl/webgl';
+// @ts-ignore resolution depends on moduleResolution setting
+import {WEBGLRenderPipeline, WebGLDevice} from '@luma.gl/webgl';
 
 const MIXED_SAMPLER_RE = /different type[s]? use the same sampler location/i;
 
 let _patched = false;
 
-export function patchPipelineValidation(): void {
-  if (_patched) return;
-  _patched = true;
-
-  // @ts-ignore _getLinkStatus is an internal luma.gl API that may change between versions
-  if (!WEBGLRenderPipeline?.prototype?._getLinkStatus) {
-    return;
-  }
-
-  // @ts-ignore patching internal luma.gl method
-  WEBGLRenderPipeline.prototype._getLinkStatus = function (
-    this: WEBGLRenderPipeline & {linkStatus: string}
-  ) {
+function createPatchedLinkStatus(original: Function) {
+  return function _patchedGetLinkStatus(this: any) {
     const {gl} = this.device;
     const linked = gl.getProgramParameter(this.handle, 0x8b82 /* LINK_STATUS */);
     if (!linked) {
       this.linkStatus = 'error';
       return 'link-error';
+    }
+
+    // luma.gl ≥9.3 assigns unique texture units to samplers before
+    // validation via _initializeSamplerUniforms. Call it here so that
+    // the sampler-to-unit mapping is populated through our patched path.
+    if (typeof this._initializeSamplerUniforms === 'function') {
+      this._initializeSamplerUniforms();
     }
 
     gl.validateProgram(this.handle);
@@ -58,5 +54,59 @@ export function patchPipelineValidation(): void {
 
     this.linkStatus = 'success';
     return 'success';
+  };
+}
+
+export function patchPipelineValidation(): void {
+  if (_patched) return;
+  _patched = true;
+
+  // Strategy 1: luma.gl <9.3 — _getLinkStatus on WEBGLRenderPipeline
+  if (
+    WEBGLRenderPipeline?.prototype &&
+    typeof (WEBGLRenderPipeline.prototype as any)._getLinkStatus === 'function'
+  ) {
+    const original = (WEBGLRenderPipeline.prototype as any)._getLinkStatus;
+    (WEBGLRenderPipeline.prototype as any)._getLinkStatus = createPatchedLinkStatus(original);
+    return;
+  }
+
+  // Strategy 2: luma.gl ≥9.3 — _getLinkStatus moved to WEBGLSharedRenderPipeline.
+  // That class is not publicly exported, so we hook the factory on WebGLDevice
+  // that creates shared pipelines. The first invocation discovers the class,
+  // patches its prototype, then re-validates the instance.
+  const deviceProto = WebGLDevice?.prototype as any;
+  const origFactory = deviceProto?._createSharedRenderPipelineWebGL;
+  if (typeof origFactory !== 'function') return;
+
+  let sharedClassPatched = false;
+
+  deviceProto._createSharedRenderPipelineWebGL = function (this: any, ...args: any[]) {
+    if (!sharedClassPatched) {
+      sharedClassPatched = true;
+
+      const instance = origFactory.apply(this, args);
+      const SharedCtor = Object.getPrototypeOf(instance).constructor;
+
+      if (
+        SharedCtor &&
+        SharedCtor !== WEBGLRenderPipeline &&
+        typeof SharedCtor.prototype._getLinkStatus === 'function'
+      ) {
+        const original = SharedCtor.prototype._getLinkStatus;
+        SharedCtor.prototype._getLinkStatus = createPatchedLinkStatus(original);
+
+        // Re-validate this first instance since its _getLinkStatus already ran
+        // with the unpatched version during construction.
+        if (instance.linkStatus === 'error') {
+          instance._getLinkStatus();
+        }
+      }
+
+      // Restore original factory — future instances will use the patched prototype
+      deviceProto._createSharedRenderPipelineWebGL = origFactory;
+      return instance;
+    }
+    return origFactory.apply(this, args);
   };
 }

--- a/src/deckgl-layers/src/raster/raster-layer/raster-layer-shaders.ts
+++ b/src/deckgl-layers/src/raster/raster-layer/raster-layer-shaders.ts
@@ -86,10 +86,21 @@ export function prepareLumaModules(modules: LumaShaderModule[]): LumaModuleOutpu
     const nameMap = UNIFORM_NAME_MAP[mod.name];
     const consolidate = Boolean(nameMap && mod.uniformTypes);
 
+    if (mod.uniformTypes && !nameMap) {
+      console.warn(
+        `[raster] Module "${mod.name}" has uniformTypes but no UNIFORM_NAME_MAP entry. ` +
+          'Its UBO will not be consolidated and may push the fragment uniform block count over the WebGL2 limit.'
+      );
+    }
+
     if (consolidate) {
-      // Strip the per-module uniform block declaration so it doesn't create
-      // its own UBO.  Matches: uniform <name>Uniforms { ... } <name>;
-      fs = fs.replace(/uniform\s+\w+Uniforms\s*\{[^}]*\}\s*\w+\s*;/gs, '');
+      // Strip only this module's uniform block declaration so it doesn't
+      // create its own UBO.
+      const blockPattern = new RegExp(
+        `uniform\\s+${mod.name}Uniforms\\s*\\{[^}]*\\}\\s*${mod.name}\\s*;`,
+        'gs'
+      );
+      fs = fs.replace(blockPattern, '');
 
       // Rewrite moduleName.fieldName references to the shared UBO aliases
       for (const [origField, prefixedField] of Object.entries(nameMap)) {

--- a/src/deckgl-layers/src/raster/raster-layer/raster-layer-shaders.ts
+++ b/src/deckgl-layers/src/raster/raster-layer/raster-layer-shaders.ts
@@ -3,6 +3,7 @@
 
 import {ShaderAssembler} from '@luma.gl/shadertools';
 import type {ShaderModule as LumaShaderModule} from '../webgl/types';
+import {UNIFORM_NAME_MAP} from '../raster-processing-uniforms';
 
 /**
  * UBO-based shader module for raster layer uniforms.
@@ -78,11 +79,28 @@ interface LumaModuleOutput {
 
 export function prepareLumaModules(modules: LumaShaderModule[]): LumaModuleOutput[] {
   return modules.map(mod => {
-    const fs = mod.fs2 || mod.fs || '';
+    let fs = mod.fs2 || mod.fs || '';
+    // Replace texture2D with texture for GLSL 300 es
+    fs = fs.replace(/texture2D\(/g, 'texture(');
+
+    const nameMap = UNIFORM_NAME_MAP[mod.name];
+    const consolidate = Boolean(nameMap && mod.uniformTypes);
+
+    if (consolidate) {
+      // Strip the per-module uniform block declaration so it doesn't create
+      // its own UBO.  Matches: uniform <name>Uniforms { ... } <name>;
+      fs = fs.replace(/uniform\s+\w+Uniforms\s*\{[^}]*\}\s*\w+\s*;/gs, '');
+
+      // Rewrite moduleName.fieldName references to the shared UBO aliases
+      for (const [origField, prefixedField] of Object.entries(nameMap)) {
+        const pattern = new RegExp(`\\b${mod.name}\\.${origField}\\b`, 'g');
+        fs = fs.replace(pattern, `${prefixedField}_ALIAS`);
+      }
+    }
+
     const result: LumaModuleOutput = {
       name: mod.name,
-      // Replace texture2D with texture for GLSL 300 es
-      fs: fs.replace(/texture2D\(/g, 'texture('),
+      fs,
       dependencies: mod.dependencies,
       deprecations: mod.deprecations
     };
@@ -103,17 +121,27 @@ export function prepareLumaModules(modules: LumaShaderModule[]): LumaModuleOutpu
       result.uniforms = mod.uniforms;
     }
 
-    if (mod.uniformTypes) {
+    // Only keep uniformTypes for modules NOT consolidated into the shared UBO
+    if (mod.uniformTypes && !consolidate) {
       result.uniformTypes = mod.uniformTypes;
     }
 
-    // Convert inject code, replacing texture2D -> texture
+    // Convert inject code, replacing texture2D -> texture and UBO references
     if (mod.inject) {
       result.inject = {};
       for (const [hook, code] of Object.entries(mod.inject)) {
-        const codeStr =
+        let codeStr =
           typeof code === 'string' ? code : (code as {injection?: string}).injection || '';
-        result.inject[hook] = codeStr.replace(/texture2D\(/g, 'texture(');
+        codeStr = codeStr.replace(/texture2D\(/g, 'texture(');
+
+        if (consolidate && nameMap) {
+          for (const [origField, prefixedField] of Object.entries(nameMap)) {
+            const pattern = new RegExp(`\\b${mod.name}\\.${origField}\\b`, 'g');
+            codeStr = codeStr.replace(pattern, `${prefixedField}_ALIAS`);
+          }
+        }
+
+        result.inject[hook] = codeStr;
       }
     }
 

--- a/src/deckgl-layers/src/raster/raster-layer/raster-layer.ts
+++ b/src/deckgl-layers/src/raster/raster-layer/raster-layer.ts
@@ -15,6 +15,7 @@ import {loadImages} from '../images';
 import type {RasterLayerAddedProps, ImageState} from '../types';
 import {modulesEqual, applyModuleUniforms} from '../util';
 import {patchPipelineValidation} from '../pipeline-validation-patch';
+import {rasterProcessingUniforms} from '../raster-processing-uniforms';
 
 const defaultProps = {
   ...BitmapLayer.defaultProps,
@@ -103,7 +104,12 @@ export default class RasterLayer extends BitmapLayer<RasterLayerAddedProps> {
       ...parentShaders,
       vs: buildRasterVertexShader(),
       fs: buildRasterFragmentShader(),
-      modules: [...(parentShaders.modules || []), rasterUniforms, ...lumaModules]
+      modules: [
+        ...(parentShaders.modules || []),
+        rasterUniforms,
+        rasterProcessingUniforms,
+        ...lumaModules
+      ]
     };
   }
 

--- a/src/deckgl-layers/src/raster/raster-mesh-layer/raster-mesh-layer.ts
+++ b/src/deckgl-layers/src/raster/raster-mesh-layer/raster-mesh-layer.ts
@@ -19,6 +19,7 @@ import {loadImages} from '../images';
 import type {RasterLayerAddedProps, ImageState} from '../types';
 import {modulesEqual, applyModuleUniforms} from '../util';
 import {patchPipelineValidation} from '../pipeline-validation-patch';
+import {rasterProcessingUniforms} from '../raster-processing-uniforms';
 import {TOPOLOGY} from '@kepler.gl/constants';
 
 type Mesh = SimpleMeshLayerProps['mesh'];
@@ -88,11 +89,18 @@ export default class RasterMeshLayer extends SimpleMeshLayer<any, RasterLayerAdd
     const lumaModules = prepareLumaModules(modules);
     const parentShaders = super.getShaders();
 
+    // Filter out simpleMeshUniforms from parent — RasterMeshLayer uses its own
+    // shaders that don't reference SimpleMesh uniforms, and every UBO counts
+    // against the WebGL2 GL_MAX_FRAGMENT_UNIFORM_BUFFERS limit (typically 12).
+    const parentModules = (parentShaders.modules || []).filter(
+      (m: {name?: string}) => m.name !== 'simpleMesh'
+    );
+
     return {
       ...parentShaders,
       vs: buildRasterMeshVertexShader(),
       fs: buildRasterMeshFragmentShader(),
-      modules: [...(parentShaders.modules || []), rasterMeshUniforms, ...lumaModules]
+      modules: [...parentModules, rasterMeshUniforms, rasterProcessingUniforms, ...lumaModules]
     };
   }
 

--- a/src/deckgl-layers/src/raster/raster-processing-uniforms.ts
+++ b/src/deckgl-layers/src/raster/raster-processing-uniforms.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+/**
+ * Shared UBO for all raster processing module uniforms.
+ *
+ * WebGL2 guarantees only 12 fragment uniform blocks (GL_MAX_FRAGMENT_UNIFORM_BUFFERS).
+ * Without consolidation, the base layer already uses 8–9 blocks (project, picking,
+ * lighting, phongMaterial, floatColors, layer, shadow, simpleMesh/rasterMesh, raster),
+ * leaving only 3–4 for raster processing modules. Since a typical pipeline can use
+ * 5–9 raster modules (combineBands, mask, reorderBands, linearRescale, gammaContrast,
+ * sigmoidalContrast, colormap, filter, saturation), each declaring its own UBO block
+ * would exceed the limit.
+ *
+ * This module declares a single UBO that contains all possible raster processing
+ * uniforms. Individual modules' GLSL code still references the uniforms through
+ * the block instance name, and prepareLumaModules() rewires the declarations.
+ */
+
+const RASTER_PROCESSING_UNIFORM_BLOCK = `\
+uniform rasterProcessingUniforms {
+  // linear_rescale
+  float linear_rescale_scaler;
+  float linear_rescale_offset;
+
+  // gamma_contrast
+  float gamma_contrast_gamma1;
+  float gamma_contrast_gamma2;
+  float gamma_contrast_gamma3;
+  float gamma_contrast_gamma4;
+
+  // sigmoidalContrast
+  float sigmoidalContrast_contrast;
+  float sigmoidalContrast_bias;
+
+  // colormap
+  int colormap_hasCategoricalColors;
+  int colormap_categoricalMinValue;
+  int colormap_categoricalMaxValue;
+  int colormap_maxPixelValue;
+
+  // bandFilter
+  float bandFilter_min1;
+  float bandFilter_max1;
+  float bandFilter_min2;
+  float bandFilter_max2;
+  float bandFilter_min3;
+  float bandFilter_max3;
+  float bandFilter_min4;
+  float bandFilter_max4;
+
+  // saturation
+  float saturation_value;
+
+  // reorder_bands
+  mat4 reorder_bands_ordering;
+
+  // mask (shared by mask_image_float, mask_image_uint, mask_image_int)
+  float mask_keepMin;
+  float mask_keepMax;
+
+  // pansharpen_brovey
+  float pansharpen_brovey_panWeight;
+} rasterProcessing;
+`;
+
+/**
+ * GLSL #define aliases that let per-module code continue referencing uniforms
+ * through their original block instance names (e.g. `linear_rescale.scaler`).
+ */
+const ALIAS_DEFINES = `\
+#define linear_rescale_scaler_ALIAS rasterProcessing.linear_rescale_scaler
+#define linear_rescale_offset_ALIAS rasterProcessing.linear_rescale_offset
+#define gamma_contrast_gamma1_ALIAS rasterProcessing.gamma_contrast_gamma1
+#define gamma_contrast_gamma2_ALIAS rasterProcessing.gamma_contrast_gamma2
+#define gamma_contrast_gamma3_ALIAS rasterProcessing.gamma_contrast_gamma3
+#define gamma_contrast_gamma4_ALIAS rasterProcessing.gamma_contrast_gamma4
+#define sigmoidalContrast_contrast_ALIAS rasterProcessing.sigmoidalContrast_contrast
+#define sigmoidalContrast_bias_ALIAS rasterProcessing.sigmoidalContrast_bias
+#define colormap_hasCategoricalColors_ALIAS rasterProcessing.colormap_hasCategoricalColors
+#define colormap_categoricalMinValue_ALIAS rasterProcessing.colormap_categoricalMinValue
+#define colormap_categoricalMaxValue_ALIAS rasterProcessing.colormap_categoricalMaxValue
+#define colormap_maxPixelValue_ALIAS rasterProcessing.colormap_maxPixelValue
+#define bandFilter_min1_ALIAS rasterProcessing.bandFilter_min1
+#define bandFilter_max1_ALIAS rasterProcessing.bandFilter_max1
+#define bandFilter_min2_ALIAS rasterProcessing.bandFilter_min2
+#define bandFilter_max2_ALIAS rasterProcessing.bandFilter_max2
+#define bandFilter_min3_ALIAS rasterProcessing.bandFilter_min3
+#define bandFilter_max3_ALIAS rasterProcessing.bandFilter_max3
+#define bandFilter_min4_ALIAS rasterProcessing.bandFilter_min4
+#define bandFilter_max4_ALIAS rasterProcessing.bandFilter_max4
+#define saturation_value_ALIAS rasterProcessing.saturation_value
+#define reorder_bands_ordering_ALIAS rasterProcessing.reorder_bands_ordering
+#define mask_keepMin_ALIAS rasterProcessing.mask_keepMin
+#define mask_keepMax_ALIAS rasterProcessing.mask_keepMax
+#define pansharpen_brovey_panWeight_ALIAS rasterProcessing.pansharpen_brovey_panWeight
+`;
+
+export const RASTER_PROCESSING_FS = RASTER_PROCESSING_UNIFORM_BLOCK + ALIAS_DEFINES;
+
+export const rasterProcessingUniforms = {
+  name: 'rasterProcessing',
+  fs: RASTER_PROCESSING_FS,
+  vs: '',
+  uniformTypes: {
+    linear_rescale_scaler: 'f32',
+    linear_rescale_offset: 'f32',
+    gamma_contrast_gamma1: 'f32',
+    gamma_contrast_gamma2: 'f32',
+    gamma_contrast_gamma3: 'f32',
+    gamma_contrast_gamma4: 'f32',
+    sigmoidalContrast_contrast: 'f32',
+    sigmoidalContrast_bias: 'f32',
+    colormap_hasCategoricalColors: 'i32',
+    colormap_categoricalMinValue: 'i32',
+    colormap_categoricalMaxValue: 'i32',
+    colormap_maxPixelValue: 'i32',
+    bandFilter_min1: 'f32',
+    bandFilter_max1: 'f32',
+    bandFilter_min2: 'f32',
+    bandFilter_max2: 'f32',
+    bandFilter_min3: 'f32',
+    bandFilter_max3: 'f32',
+    bandFilter_min4: 'f32',
+    bandFilter_max4: 'f32',
+    saturation_value: 'f32',
+    reorder_bands_ordering: 'mat4x4<f32>',
+    mask_keepMin: 'f32',
+    mask_keepMax: 'f32',
+    pansharpen_brovey_panWeight: 'f32'
+  }
+};
+
+/**
+ * Map from original module uniform names (as returned by getUniforms) to
+ * the prefixed names used in the shared UBO.
+ */
+export const UNIFORM_NAME_MAP: Record<string, Record<string, string>> = {
+  linear_rescale: {
+    scaler: 'linear_rescale_scaler',
+    offset: 'linear_rescale_offset'
+  },
+  gamma_contrast: {
+    gamma1: 'gamma_contrast_gamma1',
+    gamma2: 'gamma_contrast_gamma2',
+    gamma3: 'gamma_contrast_gamma3',
+    gamma4: 'gamma_contrast_gamma4'
+  },
+  sigmoidalContrast: {
+    contrast: 'sigmoidalContrast_contrast',
+    bias: 'sigmoidalContrast_bias'
+  },
+  colormap: {
+    hasCategoricalColors: 'colormap_hasCategoricalColors',
+    categoricalMinValue: 'colormap_categoricalMinValue',
+    categoricalMaxValue: 'colormap_categoricalMaxValue',
+    maxPixelValue: 'colormap_maxPixelValue'
+  },
+  bandFilter: {
+    min1: 'bandFilter_min1',
+    max1: 'bandFilter_max1',
+    min2: 'bandFilter_min2',
+    max2: 'bandFilter_max2',
+    min3: 'bandFilter_min3',
+    max3: 'bandFilter_max3',
+    min4: 'bandFilter_min4',
+    max4: 'bandFilter_max4'
+  },
+  saturation: {
+    value: 'saturation_value'
+  },
+  reorder_bands: {
+    ordering: 'reorder_bands_ordering'
+  },
+  mask_image_float: {
+    keepMin: 'mask_keepMin',
+    keepMax: 'mask_keepMax'
+  },
+  mask_image_uint: {
+    keepMin: 'mask_keepMin',
+    keepMax: 'mask_keepMax'
+  },
+  mask_image_int: {
+    keepMin: 'mask_keepMin',
+    keepMax: 'mask_keepMax'
+  },
+  pansharpen_brovey: {
+    panWeight: 'pansharpen_brovey_panWeight'
+  }
+};

--- a/src/deckgl-layers/src/raster/util.ts
+++ b/src/deckgl-layers/src/raster/util.ts
@@ -99,8 +99,22 @@ export function applyModuleUniforms(
             Object.assign(shaderInputs.moduleBindings[mod.name], bindings);
           }
         } catch {
-          // Fallback: use the public setProps API if direct mutation is blocked
-          shaderInputs.setProps?.({[mod.name]: result});
+          const nameMap = UNIFORM_NAME_MAP[mod.name];
+          if (nameMap && mod.uniformTypes) {
+            const remappedUniforms: Record<string, unknown> = {};
+            for (const [key, val] of Object.entries(uniforms)) {
+              const remapped = nameMap[key];
+              if (remapped) {
+                remappedUniforms[remapped] = val;
+              }
+            }
+            shaderInputs.setProps?.({rasterProcessing: remappedUniforms});
+            if (Object.keys(bindings).length > 0) {
+              shaderInputs.setProps?.({[mod.name]: bindings});
+            }
+          } else {
+            shaderInputs.setProps?.({[mod.name]: result});
+          }
         }
       }
     }

--- a/src/deckgl-layers/src/raster/util.ts
+++ b/src/deckgl-layers/src/raster/util.ts
@@ -2,6 +2,7 @@
 // Copyright contributors to the kepler.gl project
 
 import {ShaderModule} from './webgl/types';
+import {UNIFORM_NAME_MAP} from './raster-processing-uniforms';
 
 /**
  * Test if two lists of modules are equal
@@ -39,6 +40,10 @@ function isUniformValue(value: unknown): boolean {
  * getUniforms exactly once and writing the result directly — avoiding the
  * double-getUniforms bug where shaderInputs.setProps() would re-invoke
  * getUniforms on already-transformed values.
+ *
+ * For modules whose uniforms have been consolidated into the shared
+ * rasterProcessing UBO, the uniform values are remapped (prefixed) and
+ * written to the rasterProcessing slot instead of the individual module slot.
  */
 export function applyModuleUniforms(
   shaderInputs: {
@@ -63,14 +68,36 @@ export function applyModuleUniforms(
           }
         }
         try {
-          if (!shaderInputs.moduleUniforms[mod.name]) {
-            shaderInputs.moduleUniforms[mod.name] = {};
+          const nameMap = UNIFORM_NAME_MAP[mod.name];
+          if (nameMap && mod.uniformTypes) {
+            // Consolidated module: remap uniforms to the shared rasterProcessing UBO
+            if (!shaderInputs.moduleUniforms.rasterProcessing) {
+              shaderInputs.moduleUniforms.rasterProcessing = {};
+            }
+            for (const [key, value] of Object.entries(uniforms)) {
+              const remapped = nameMap[key];
+              if (remapped) {
+                shaderInputs.moduleUniforms.rasterProcessing[remapped] = value;
+              }
+            }
+            // Bindings (textures) stay on the original module name
+            if (Object.keys(bindings).length > 0) {
+              if (!shaderInputs.moduleBindings[mod.name]) {
+                shaderInputs.moduleBindings[mod.name] = {};
+              }
+              Object.assign(shaderInputs.moduleBindings[mod.name], bindings);
+            }
+          } else {
+            // Non-consolidated module: write directly as before
+            if (!shaderInputs.moduleUniforms[mod.name]) {
+              shaderInputs.moduleUniforms[mod.name] = {};
+            }
+            if (!shaderInputs.moduleBindings[mod.name]) {
+              shaderInputs.moduleBindings[mod.name] = {};
+            }
+            Object.assign(shaderInputs.moduleUniforms[mod.name], uniforms);
+            Object.assign(shaderInputs.moduleBindings[mod.name], bindings);
           }
-          if (!shaderInputs.moduleBindings[mod.name]) {
-            shaderInputs.moduleBindings[mod.name] = {};
-          }
-          Object.assign(shaderInputs.moduleUniforms[mod.name], uniforms);
-          Object.assign(shaderInputs.moduleBindings[mod.name], bindings);
         } catch {
           // Fallback: use the public setProps API if direct mutation is blocked
           shaderInputs.setProps?.({[mod.name]: result});


### PR DESCRIPTION
- after deck.gl 9.3.1 and luma.gl upgrades the raster tile layer, sporadically crashes when the number of UBOs exceeds the validation limit.