### PR TITLE
fix: stabilize Color By switching in vector tiles while dynamic color is enabled

### DIFF
--- a/src/layers/src/vector-tile/abstract-tile-layer.ts
+++ b/src/layers/src/vector-tile/abstract-tile-layer.ts
@@ -300,6 +300,8 @@ export default abstract class AbstractTileLayer<
     const next = newConfig.visConfig?.dynamicColor ?? old;
     const scaleTypeChanged =
       newConfig.colorScale && this.config.colorScale !== newConfig.colorScale;
+    const colorFieldChanged =
+      newConfig.colorField !== undefined && newConfig.colorField !== this.config.colorField;
 
     super.updateLayerConfig(newConfig);
     const {colorField} = this.config;
@@ -308,7 +310,7 @@ export default abstract class AbstractTileLayer<
       // When we switch from dynamic to non-dynamic or vice versa, we need to update
       // the color domain. This is downstream from a dispatch call, so we use
       // setTimeout to avoid "reducers may not dispatch actions" errors
-      if (next && (!old || scaleTypeChanged)) {
+      if (next && (!old || scaleTypeChanged || colorFieldChanged)) {
         setTimeout(() => this.setDynamicColorDomain(), 0);
       } else if (old && !next) {
         setTimeout(() => this.resetColorDomain(), 0);

--- a/src/layers/src/vector-tile/abstract-tile-layer.ts
+++ b/src/layers/src/vector-tile/abstract-tile-layer.ts
@@ -187,6 +187,15 @@ export default abstract class AbstractTileLayer<
     return [];
   }
 
+  get noneLayerDataAffectingProps() {
+    return [
+      ...super.noneLayerDataAffectingProps,
+      'colorDomain',
+      'sizeDomain',
+      'heightDomain'
+    ];
+  }
+
   get visualChannels(): Record<string, VisualChannel> {
     return {
       color: {

--- a/src/layers/src/vector-tile/abstract-tile-layer.ts
+++ b/src/layers/src/vector-tile/abstract-tile-layer.ts
@@ -190,6 +190,12 @@ export default abstract class AbstractTileLayer<
   get noneLayerDataAffectingProps() {
     return [
       ...super.noneLayerDataAffectingProps,
+      // For tile layers, domain changes only affect how tile features are colorized/sized
+      // at render time (via deck.gl accessors/uniforms). They do NOT require re-creating
+      // the tile source or re-fetching tiles. Without this, every domain update from
+      // setDynamicColorDomain() would trigger formatLayerData → new tileSource → tile
+      // reload → onViewportLoad → setDynamicColorDomain() in a feedback loop.
+      // Safe for both VectorTileLayer and WMSLayer (which doesn't use these domains).
       'colorDomain',
       'sizeDomain',
       'heightDomain'

--- a/src/layers/src/vector-tile/vector-tile-layer.ts
+++ b/src/layers/src/vector-tile/vector-tile-layer.ts
@@ -365,6 +365,25 @@ export default class VectorTileLayer extends AbstractTileLayer<VectorTile, Featu
       // if colorField or sizeField were set back to null
       return defaultDomain;
     }
+
+    // When dynamicColor is enabled, the domain is managed asynchronously by
+    // setDynamicColorDomain(). Preserve the current domain to avoid overwriting
+    // the async result with metadata-based [min, max] values.
+    if (this.config.visConfig.dynamicColor && visualChannel.key === 'color') {
+      if (scale === SCALE_TYPES.quantile) {
+        const current = this.config.colorDomain;
+        return Array.isArray(current) && current.length > 2
+          ? (current as number[])
+          : defaultDomain;
+      }
+      if (scale === SCALE_TYPES.quantize) {
+        const current = this.config.colorDomain;
+        return Array.isArray(current) && current.length === 2
+          ? (current as number[])
+          : defaultDomain;
+      }
+    }
+
     if (scale === SCALE_TYPES.quantile && isDomainQuantiles(field?.filterProps?.domainQuantiles)) {
       return field.filterProps.domainQuantiles;
     }


### PR DESCRIPTION
- stabilize Color By switching in vector tiles while dynamic color is enabled
- Before the fix, switching “Color By” was not consistent while the dynamic color checkbox was enabled.