### PR TITLE
feat: adjust Y-axis domain to filtered time range

### DIFF
--- a/src/components/src/common/line-chart.tsx
+++ b/src/components/src/common/line-chart.tsx
@@ -167,6 +167,21 @@ function LineChartFactory() {
       [timezone, timeFormat]
     );
 
+    const isHoveredDPVisible = hoveredDP
+      ? !yAxisAutoRange ||
+        !paddedYDomain ||
+        paddedYDomain.length < 2 ||
+        (hoveredDP.y >= paddedYDomain[0] && hoveredDP.y <= paddedYDomain[1])
+      : false;
+
+    const clampedHoveredDP = useMemo(() => {
+      if (!hoveredDP || !paddedYDomain || paddedYDomain.length < 2) return hoveredDP;
+      return {
+        ...hoveredDP,
+        y: Math.max(paddedYDomain[0], Math.min(paddedYDomain[1], hoveredDP.y))
+      };
+    }, [hoveredDP, paddedYDomain]);
+
     return (
       <LineChartWrapper style={{marginTop: `${margin.top}px`}}>
         <XYPlot
@@ -190,12 +205,12 @@ function LineChartFactory() {
               onNearestX={series.markers.length || !enableChartHover ? undefined : onMouseMove}
             />
           ))}
-          <MarkSeries data={hoveredDP ? [hoveredDP] : []} color={color} />
+          <MarkSeries data={isHoveredDPVisible && hoveredDP ? [hoveredDP] : []} color={color} />
           <CustomSVGSeries data={brushData} />
           {isEnlarged && <YAxis tickTotal={3} />}
-          {hoveredDP && enableChartHover && !brushing ? (
-            <Hint value={hoveredDP}>
-              <HintContent {...hoveredDP} format={hintFormatter} />
+          {clampedHoveredDP && enableChartHover && !brushing ? (
+            <Hint value={clampedHoveredDP}>
+              <HintContent {...hoveredDP!} format={hintFormatter} />
             </Hint>
           ) : null}
         </XYPlot>

--- a/src/components/src/common/line-chart.tsx
+++ b/src/components/src/common/line-chart.tsx
@@ -25,6 +25,7 @@ const LineChartWrapper = styled.div`
   .rv-xy-plot__inner {
     /* important to show axis */
     overflow: visible;
+    clip-path: inset(-2px -10px -2px -50px);
   }
 
   .rv-xy-plot__grid-lines__line {
@@ -83,13 +84,16 @@ interface LineChartProps {
   lineChart?: LineChart;
   margin: {top?: number; bottom?: number; left?: number; right?: number};
   onMouseMove: (datapoint: LineSeriesPoint | null, data?: RVNearestXData<LineSeriesPoint>) => void;
+  value?: number[];
   width: number;
   timezone?: string | null;
   timeFormat?: string;
   range?: number[];
+  yAxisAutoRange?: boolean;
 }
 
 const MARGIN = {top: 0, bottom: 0, left: 0, right: 0};
+
 function LineChartFactory() {
   const LineChartComponent = ({
     brushComponent,
@@ -102,10 +106,12 @@ function LineChartFactory() {
     lineChart,
     margin,
     onMouseMove,
+    value,
     width,
     timezone,
     timeFormat,
-    range
+    range,
+    yAxisAutoRange
   }: LineChartProps) => {
     const {yDomain, xDomain} = lineChart || {};
     // @ts-expect-error seems lineChart.series has ambiguous types. Requires refactoring.
@@ -116,12 +122,33 @@ function LineChartFactory() {
       [range, xDomain]
     );
 
+    const filteredYDomain = useMemo(() => {
+      if (!yAxisAutoRange || !series?.lines || !value || value.length < 2) return yDomain;
+      let min: number | undefined;
+      let max: number | undefined;
+      for (const line of series.lines) {
+        for (let i = 0; i < line.length; i++) {
+          const point = line[i];
+          const inRange = point.x >= value[0] && point.x <= value[1];
+          const isAdjacentToRange =
+            (!inRange && line[i + 1] && line[i + 1].x >= value[0] && line[i + 1].x <= value[1]) ||
+            (!inRange && line[i - 1] && line[i - 1].x >= value[0] && line[i - 1].x <= value[1]);
+          if ((inRange || isAdjacentToRange) && point.y != null) {
+            if (min === undefined || point.y < min) min = point.y;
+            if (max === undefined || point.y > max) max = point.y;
+          }
+        }
+      }
+      return min !== undefined && max !== undefined ? [min, max] : yDomain;
+    }, [series, value, yDomain, yAxisAutoRange]);
+
     const paddedYDomain = useMemo(
-      () =>
-        yDomain && yDomain[0] && yDomain[1]
-          ? [yDomain[0], yDomain[1] + (yDomain[1] - yDomain[0]) * 0.2]
-          : [],
-      [yDomain]
+      () => {
+        if (!filteredYDomain || filteredYDomain[0] == null || filteredYDomain[1] == null) return [];
+        const padding = (filteredYDomain[1] - filteredYDomain[0]) * 0.1;
+        return [filteredYDomain[0] - padding, filteredYDomain[1] + padding];
+      },
+      [filteredYDomain]
     );
     const brushData = useMemo(() => {
       return effectiveXDomain && paddedYDomain

--- a/src/components/src/common/range-plot.tsx
+++ b/src/components/src/common/range-plot.tsx
@@ -156,7 +156,7 @@ export default function RangePlotFactory(
     };
 
     return isLineChart(plotType) && lineChart ? (
-      <LineChartPlot lineChart={lineChart} range={range} {...commonProps} />
+      <LineChartPlot lineChart={lineChart} range={range} yAxisAutoRange={plotType.yAxisAutoRange} {...commonProps} />
     ) : (
       <HistogramPlot
         histogramsByGroup={bins}

--- a/src/components/src/filters/time-widget-top.tsx
+++ b/src/components/src/filters/time-widget-top.tsx
@@ -5,6 +5,7 @@ import React, {useCallback, useMemo} from 'react';
 import styled, {IStyledComponent} from 'styled-components';
 import {Clock, Close, LineChart, ArrowDown, ArrowUp} from '../common/icons';
 import FieldSelectorFactory from '../common/field-selector';
+import Switch from '../common/switch';
 import {SelectTextBold, IconRoundSmall, CenterFlexbox} from '../common/styled-components';
 import {TimeWidgetTopProps, TopSectionWrapperProps} from './types';
 import {Field} from '@kepler.gl/types';
@@ -104,6 +105,10 @@ function TimeWidgetTopFactory(FieldSelector: ReturnType<typeof FieldSelectorFact
       value => setFilterPlot({yAxis: value}),
       [setFilterPlot]
     );
+    const _toggleYAxisAutoRange = useCallback(
+      () => setFilterPlot({plotType: {yAxisAutoRange: !filter.plotType?.yAxisAutoRange}}),
+      [setFilterPlot, filter.plotType?.yAxisAutoRange]
+    );
 
     return (
       <TopSectionWrapper>
@@ -130,6 +135,15 @@ function TimeWidgetTopFactory(FieldSelector: ReturnType<typeof FieldSelectorFact
                 showToken={false}
               />
             </div>
+            {filter.yAxis ? (
+              <Switch
+                checked={Boolean(filter.plotType?.yAxisAutoRange)}
+                id={`${filter.id}-y-axis-auto-range`}
+                onChange={_toggleYAxisAutoRange}
+                secondary
+                label="Fit Y"
+              />
+            ) : null}
           </StyledTitle>
         ) : null}
         <StyledCenterBox>


### PR DESCRIPTION
- When a time filter is active, the Y-axis of the line chart now adjusts to reflect only the visible/filtered data range, instead of always showing the full data extent.
- This is an adaptation of the stale PR https://github.com/keplergl/kepler.gl/pull/3333 over the current codebase
