### PR TITLE
fix: failed duckDB table creation in Vite app

### DIFF
--- a/src/duckdb/src/table/duckdb-table.ts
+++ b/src/duckdb/src/table/duckdb-table.ts
@@ -144,10 +144,10 @@ export class KeplerGlDuckDbTable extends KeplerTable {
       const createTableSql = `
         install spatial;
         load spatial;
-        CREATE TABLE '${this.label}' AS
+        CREATE TABLE "${this.label}" AS
         SELECT *
-        FROM ST_READ('${this.id}', keep_wkb = TRUE);
-        ALTER TABLE '${this.label}' RENAME '${DUCKDB_WKB_COLUMN}' TO '${KEPLER_GEOM_FROM_GEOJSON_COLUMN}';
+        FROM ST_READ("${this.id}", keep_wkb = TRUE);
+        ALTER TABLE "${this.label}" RENAME "${DUCKDB_WKB_COLUMN}" TO "${KEPLER_GEOM_FROM_GEOJSON_COLUMN}";
       `;
 
       await c.query(createTableSql);


### PR DESCRIPTION
# Issue
SQL error on random json file upload with duckDB plugin switched on in an app with Vite. Dataset isn't created, nothing is added on a map.

<img width="1036" height="558" alt="image" src="https://github.com/user-attachments/assets/75a73aff-a3c4-4509-b32c-682714370239" />

# App settings
### NPM packages installed:
```
"@kepler.gl/actions": "^3.2.5",
"@kepler.gl/components": "^3.2.5",
"@kepler.gl/duckdb": "^3.2.5",
"@kepler.gl/processors": "^3.2.5",
"@kepler.gl/reducers": "^3.2.5",
"@kepler.gl/schemas": "^3.2.5",
"@kepler.gl/styles": "^3.2.5",
"@kepler.gl/table": "^3.2.5",
"@kepler.gl/utils": "^3.2.5",
"apache-arrow": ">=15.0.0"
"vite": "^6.2.6"
```

### Vite config:
```
export default defineConfig(({ mode }) => ({
    build: {
        outDir: 'build.prod',
        sourcemap: 'hidden',
    },
    plugins: [wasm(), react(), tsconfigPaths(), svgr()],
    server: {
        port: 3000,
        open: true,
    },
    define: {
        'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'development'),
        'process.env.MapboxAccessToken': JSON.stringify(process.env.MapboxAccessToken || ''),
    },
    resolve: {
        dedupe: ['styled-components', 'apache-arrow'],
        alias: {
            '@': resolve(__dirname, './src'),
            'apache-arrow': resolve(__dirname, 'node_modules/apache-arrow'),
        },
    },
    optimizeDeps: {
        exclude: ['parquet-wasm', '@loaders.gl/parquet'],
        include: [
            'apache-arrow',
            'buffer',
            'react',
            'react-dom',
            'react-redux',
            'redux',
            'styled-components',
            '@kepler.gl/components',
            '@kepler.gl/reducers',
            '@kepler.gl/actions',
            '@kepler.gl/constants',
            '@kepler.gl/utils',
            '@kepler.gl/schemas',
            '@kepler.gl/table',
            '@kepler.gl/layers',
            '@kepler.gl/deckgl-layers',
            '@kepler.gl/effects',
            '@kepler.gl/styles',
            '@kepler.gl/tasks',
            '@deck.gl/core',
            '@deck.gl/layers',
            '@deck.gl/aggregation-layers',
            '@deck.gl/geo-layers',
            '@deck.gl/mesh-layers',
            '@deck.gl/extensions',
            '@luma.gl/core',
            '@luma.gl/engine',
            '@luma.gl/gltools',
            '@luma.gl/shadertools',
            '@luma.gl/webgl',
            '@loaders.gl/core',
            '@loaders.gl/gltf',
            '@loaders.gl/images',
            '@loaders.gl/parquet',
            '@math.gl/core',
            '@math.gl/web-mercator',
            'gl-matrix',
        ],
        esbuildOptions: {
            target: 'es2022',
        },
    },
}));
```

# Fix
Replaced single quotes by double ones in the createTableSql of `duckdb/src/table/duckdb-table.ts`