### PR TITLE
fix: render tooltip comparison delta in separate column

### DIFF
--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -305,7 +305,7 @@ const LayerHoverInfoFactory = () => {
           {props.layer.config.label}
         </StyledLayerName>
         {hasFieldsToShow && <StyledDivider />}
-        <StyledTable>
+        <StyledTable className={props.primaryData ? 'comparing' : undefined}>
           {data.wmsFeatureData ? (
             <tbody>
               {data.wmsFeatureData.map(({name, value}, i) => (

--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -70,6 +70,7 @@ interface RowProps {
   value: string;
   deltaValue?: string | null;
   url?: string;
+  isComparing?: boolean;
 }
 
 const TOOLTIP_VALUE_MAX_LENGTH = 256;
@@ -101,7 +102,7 @@ const TooltipImage: React.FC<{src: string}> = ({src}) => {
   return <img ref={imgRef} src={src} />;
 };
 
-const Row: React.FC<RowProps> = ({name, value, deltaValue, url}) => {
+const Row: React.FC<RowProps> = ({name, value, deltaValue, url, isComparing}) => {
   // Set 'url' to 'value' if it looks like a url
   if (!url && value && typeof value === 'string' && value.match(/^http/)) {
     url = value;
@@ -124,20 +125,22 @@ const Row: React.FC<RowProps> = ({name, value, deltaValue, url}) => {
             {displayValue}
           </a>
         ) : (
-          <>
-            <span>{displayValue}</span>
-            {notNullorUndefined(deltaValue) ? (
-              <span
-                className={`row__delta-value ${
-                  deltaValue?.toString().charAt(0) === '+' ? 'positive' : 'negative'
-                }`}
-              >
-                {deltaValue}
-              </span>
-            ) : null}
-          </>
+          <span>{displayValue}</span>
         )}
       </td>
+      {isComparing ? (
+        <td
+          className={`row__delta-value ${
+            notNullorUndefined(deltaValue)
+              ? deltaValue?.toString().charAt(0) === '+'
+                ? 'positive'
+                : 'negative'
+              : ''
+          }`}
+        >
+          {deltaValue ?? ''}
+        </td>
+      ) : null}
     </tr>
   );
 };
@@ -215,6 +218,7 @@ const EntryInfoRow: React.FC<EntryInfoRowProps> = ({
       name={field.displayName || field.name}
       value={displayValue}
       deltaValue={displayDeltaValue}
+      isComparing={Boolean(primaryData)}
     />
   );
 };

--- a/src/components/src/map/map-popover.tsx
+++ b/src/components/src/map/map-popover.tsx
@@ -76,6 +76,9 @@ const StyledMapPopover = styled.div`
   .map-popover__layer-info > table {
     grid-template-columns: auto auto;
   }
+  .map-popover__layer-info > table:has(td.row__delta-value) {
+    grid-template-columns: auto auto auto;
+  }
 
   tbody,
   tr {

--- a/src/components/src/map/map-popover.tsx
+++ b/src/components/src/map/map-popover.tsx
@@ -76,7 +76,7 @@ const StyledMapPopover = styled.div`
   .map-popover__layer-info > table {
     grid-template-columns: auto auto;
   }
-  .map-popover__layer-info > table:has(td.row__delta-value) {
+  .map-popover__layer-info > table.comparing {
     grid-template-columns: auto auto auto;
   }
 

--- a/test/browser/components/map/map-popover-test.js
+++ b/test/browser/components/map/map-popover-test.js
@@ -15,8 +15,11 @@ import {
 } from '@kepler.gl/components';
 import {
   expectedLayerHoverProp as layerHoverProp,
-  expectedGeojsonLayerHoverProp as geojsonLayerHoverProp
+  expectedGeojsonLayerHoverProp as geojsonLayerHoverProp,
+  testCsvDataId,
+  mockKeplerProps
 } from 'test/helpers/mock-state';
+import {COMPARE_TYPES} from '@kepler.gl/constants';
 
 const {Pin} = Icons;
 const MapPopover = appInjector.get(MapPopoverFactory);
@@ -172,6 +175,42 @@ test('Map Popover - render with geojsonLayerHoverProp', t => {
   t.equal(wrapper.find('.row__value').at(1).text(), '127.123457,', 'should render longitude');
 
   t.equal(wrapper.find('.row__value').at(2).text(), '12.1z', 'should render zoom');
+
+  t.end();
+});
+
+test('Map Popover - render comparison mode with delta column', t => {
+  const comparisonLayerHoverProp = {
+    ...layerHoverProp,
+    primaryData: mockKeplerProps.visState.datasets[testCsvDataId].dataContainer.row(14),
+    compareType: COMPARE_TYPES.ABSOLUTE
+  };
+
+  let wrapper;
+  t.doesNotThrow(() => {
+    wrapper = mountWithTheme(
+      <IntlWrapper>
+        <MapPopover {...defaultProps} layerHoverProp={comparisonLayerHoverProp} />
+      </IntlWrapper>
+    );
+  }, 'Should render map popover in comparison mode');
+
+  t.equal(wrapper.find(LayerHoverInfo).length, 1, 'Should render LayerHoverInfo');
+  t.equal(wrapper.find('table').length, 1, 'Should render 1 table');
+
+  const table = wrapper.find('table').at(0);
+  t.ok(
+    table.hasClass('comparing'),
+    'Table should have "comparing" class when primaryData is present'
+  );
+
+  const rows = table.find('.layer-hover-info__row');
+  t.ok(rows.length > 0, 'Should render tooltip rows');
+
+  for (let i = 0; i < rows.length; i++) {
+    const deltaCell = rows.at(i).find('td.row__delta-value');
+    t.equal(deltaCell.length, 1, `Row ${i} should render a delta value cell`);
+  }
 
   t.end();
 });


### PR DESCRIPTION
- render tooltip comparison delta in a separate column
- instead of a stale PR #3339 

Before
<img width="625" height="284" alt="Screenshot 2026-05-12 at 4 09 26 AM" src="https://github.com/user-attachments/assets/7c0ad4b5-f0ad-4402-b041-86ef6a1e35d1" />

After
<img width="611" height="300" alt="Screenshot 2026-05-12 at 4 08 47 AM" src="https://github.com/user-attachments/assets/6536b85c-934f-4cac-80df-824fb9ce1902" />
