### PR TITLE
feat: geojson mode for aggregation layers

### DIFF
--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -17,14 +17,23 @@ import {
   FIELD_OPTS,
   DEFAULT_AGGREGATION,
   AGGREGATION_TYPES,
-  ALL_FIELD_TYPES
+  ALL_FIELD_TYPES,
+  GEOJSON_FIELDS
 } from '@kepler.gl/constants';
 import {ColorRange, Field, LayerColumn, Merge} from '@kepler.gl/types';
 import {KeplerTable, Datasets} from '@kepler.gl/table';
+import {DATA_TYPES} from 'type-analyzer';
+import booleanWithin from '@turf/boolean-within';
+import {point as turfPoint} from '@turf/helpers';
+import {Feature, Polygon} from 'geojson';
+
+import {getGeoArrowPointLayerProps, FindDefaultLayerPropsReturnValue} from './layer-utils';
+import {parseGeoJsonRawFeature} from './geojson-layer/geojson-utils';
 
 type AggregationLayerColumns = {
   lat: LayerColumn;
   lng: LayerColumn;
+  geojson: LayerColumn;
 };
 
 export type AggregationLayerData = {
@@ -39,6 +48,35 @@ export const pointPosAccessor =
 
 export const pointPosResolver = ({lat, lng}: AggregationLayerColumns) =>
   `${lat.fieldIdx}-${lng.fieldIdx}`;
+
+export const geojsonAccessor =
+  ({geojson}: AggregationLayerColumns) =>
+  (dc: DataContainerInterface) =>
+  (d: {index: number}) =>
+    dc.valueAt(d.index, geojson.fieldIdx);
+
+export const COLUMN_MODE_POINTS = 'points';
+export const COLUMN_MODE_GEOJSON = 'geojson';
+
+const SUPPORTED_ANALYZER_TYPES = {
+  [DATA_TYPES.GEOMETRY]: true,
+  [DATA_TYPES.GEOMETRY_FROM_STRING]: true,
+  [DATA_TYPES.PAIR_GEOMETRY_FROM_STRING]: true
+};
+
+const SUPPORTED_COLUMN_MODES = [
+  {
+    key: COLUMN_MODE_POINTS,
+    label: 'Points',
+    requiredColumns: ['lat', 'lng']
+  },
+  {
+    key: COLUMN_MODE_GEOJSON,
+    label: 'GeoJSON',
+    requiredColumns: ['geojson']
+  }
+];
+const DEFAULT_COLUMN_MODE = COLUMN_MODE_POINTS;
 
 export const getValueAggrFunc = getPointData => (field, aggregation) => points =>
   field
@@ -91,6 +129,53 @@ const getLayerColorRange = (colorRange: ColorRange) => colorRange.colors.map(hex
 
 export const aggregateRequiredColumns: ['lat', 'lng'] = ['lat', 'lng'];
 
+/**
+ * Compute the centroid [lng, lat] of a GeoJSON geometry.
+ * For Point returns the coordinate directly; for complex geometries
+ * averages all vertex positions into a single representative point.
+ */
+function getCentroidFromGeometry(geometry: any): number[] | null {
+  if (!geometry) return null;
+  const positions = getAllPositions(geometry);
+  if (positions.length === 0) return null;
+  if (positions.length === 1) return positions[0];
+
+  let sumLng = 0;
+  let sumLat = 0;
+  let count = 0;
+  for (const pos of positions) {
+    if (Number.isFinite(pos[0]) && Number.isFinite(pos[1])) {
+      sumLng += pos[0];
+      sumLat += pos[1];
+      count++;
+    }
+  }
+  return count > 0 ? [sumLng / count, sumLat / count] : null;
+}
+
+/**
+ * Extract all vertex [lng, lat] coordinates from a GeoJSON geometry.
+ */
+function getAllPositions(geometry: any): number[][] {
+  if (!geometry) return [];
+  switch (geometry.type) {
+    case 'Point':
+      return [geometry.coordinates];
+    case 'MultiPoint':
+    case 'LineString':
+      return geometry.coordinates;
+    case 'MultiLineString':
+    case 'Polygon':
+      return geometry.coordinates.flat();
+    case 'MultiPolygon':
+      return geometry.coordinates.flat(2);
+    case 'GeometryCollection':
+      return (geometry.geometries || []).flatMap(getAllPositions);
+    default:
+      return [];
+  }
+}
+
 export type AggregationLayerVisualChannelConfig = LayerColorConfig & LayerSizeConfig;
 export type AggregationLayerConfig = Merge<LayerBaseConfig, {columns: AggregationLayerColumns}> &
   AggregationLayerVisualChannelConfig;
@@ -101,6 +186,11 @@ export default class AggregationLayer extends Layer {
   declare gpuFilterGetIndex: (any) => number;
   declare gpuFilterGetData: (dataContainer, data, fieldIndex) => any;
 
+  dataToFeature: any[] = [];
+  centroids: Array<number[] | null> = [];
+  private _geojsonFieldIdx = -1;
+  private _geojsonBounds: [number, number, number, number] | null = null;
+
   constructor(
     props: {
       id?: string;
@@ -108,8 +198,12 @@ export default class AggregationLayer extends Layer {
   ) {
     super(props);
 
-    this.getPositionAccessor = dataContainer =>
-      pointPosAccessor(this.config.columns)(dataContainer);
+    this.getPositionAccessor = dataContainer => {
+      if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
+        return geojsonAccessor(this.config.columns)(dataContainer as DataContainerInterface);
+      }
+      return pointPosAccessor(this.config.columns)(dataContainer);
+    };
     this.getColorRange = memoize(getLayerColorRange);
 
     // Access data of a point from aggregated bins
@@ -127,6 +221,10 @@ export default class AggregationLayer extends Layer {
 
   get requiredLayerColumns() {
     return aggregateRequiredColumns;
+  }
+
+  get supportedColumnModes() {
+    return SUPPORTED_COLUMN_MODES;
   }
 
   get columnPairs() {
@@ -149,6 +247,57 @@ export default class AggregationLayer extends Layer {
       'enableElevationZoomFactor',
       'fixedHeight'
     ];
+  }
+
+  static findDefaultLayerProps(dataset: KeplerTable): FindDefaultLayerPropsReturnValue {
+    const altProps = getGeoArrowPointLayerProps(dataset);
+
+    const geojsonColumns = dataset.fields
+      .filter(
+        f =>
+          (f.type === 'geojson' || f.type === 'geoarrow') &&
+          f.analyzerType &&
+          SUPPORTED_ANALYZER_TYPES[f.analyzerType]
+      )
+      .map(f => f.name);
+
+    const defaultColumns = {
+      geojson: [...(GEOJSON_FIELDS.geojson || []), ...geojsonColumns]
+    };
+    const foundColumns = this.findDefaultColumnField(defaultColumns, dataset.fields);
+
+    if (foundColumns?.length) {
+      const {label} = dataset;
+      altProps.push(
+        ...foundColumns.map(columns => ({
+          label: (typeof label === 'string' && label.replace(/\.[^/.]+$/, '')) || 'aggregation',
+          columns,
+          columnMode: COLUMN_MODE_GEOJSON
+        }))
+      );
+    }
+
+    return {
+      props: [],
+      altProps
+    };
+  }
+
+  getDefaultLayerConfig(props: LayerBaseConfigPartial) {
+    return {
+      ...super.getDefaultLayerConfig(props),
+      columnMode: props?.columnMode ?? DEFAULT_COLUMN_MODE
+    };
+  }
+
+  getDataUpdateTriggers(dataset: KeplerTable): any {
+    const triggers = super.getDataUpdateTriggers(dataset);
+    const {columnMode} = this.config;
+    return {
+      ...triggers,
+      getData: {...triggers.getData, columnMode},
+      getMeta: {...triggers.getMeta, columnMode}
+    };
   }
 
   get visualChannels(): VisualChannels {
@@ -350,15 +499,86 @@ export default class AggregationLayer extends Layer {
     return this;
   }
 
-  updateLayerMeta(dataset: KeplerTable, getPosition) {
+  updateLayerMeta(dataset: KeplerTable, getPosition?) {
     const {dataContainer} = dataset;
-    // get bounds from points
-    const bounds = this.getPointsBounds(dataContainer, getPosition);
 
-    this.updateMeta({bounds});
+    if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
+      const getFeature = this.getPositionAccessor(dataContainer);
+      this._buildGeojsonDataToFeature(dataContainer, getFeature);
+      this.updateMeta({bounds: this._geojsonBounds});
+    } else {
+      this.dataToFeature = [];
+      this.centroids = [];
+      if (!getPosition) {
+        getPosition = this.getPositionAccessor(dataContainer);
+      }
+      const bounds = this.getPointsBounds(dataContainer, getPosition);
+      this.updateMeta({bounds});
+    }
+  }
+
+  private _buildGeojsonDataToFeature(dataContainer: DataContainerInterface, getFeature: any) {
+    const fieldIdx = this.config.columns.geojson.fieldIdx;
+    if (
+      this.dataToFeature.length === dataContainer.numRows() &&
+      this._geojsonFieldIdx === fieldIdx
+    ) {
+      return;
+    }
+    this._geojsonFieldIdx = fieldIdx;
+    this.dataToFeature = [];
+    this.centroids = [];
+
+    let minLng = Infinity;
+    let maxLng = -Infinity;
+    let minLat = Infinity;
+    let maxLat = -Infinity;
+    let hasValid = false;
+
+    for (let i = 0; i < dataContainer.numRows(); i++) {
+      const rawFeature = getFeature({index: i});
+      const feature = parseGeoJsonRawFeature(rawFeature);
+      this.dataToFeature[i] = feature;
+      this.centroids[i] = feature?.geometry ? getCentroidFromGeometry(feature.geometry) : null;
+
+      if (feature?.geometry) {
+        const positions = getAllPositions(feature.geometry);
+        for (const pos of positions) {
+          const lng = pos[0];
+          const lat = pos[1];
+          if (Number.isFinite(lng) && Number.isFinite(lat)) {
+            hasValid = true;
+            if (lng < minLng) minLng = lng;
+            if (lng > maxLng) maxLng = lng;
+            if (lat < minLat) minLat = lat;
+            if (lat > maxLat) maxLat = lat;
+          }
+        }
+      }
+    }
+
+    this._geojsonBounds = hasValid ? [minLng, minLat, maxLng, maxLat] : null;
+  }
+
+  isInPolygon(data: DataContainerInterface, index: number, polygon: Feature<Polygon>): boolean {
+    if (this.centroids.length === 0 || !this.centroids[index]) {
+      return false;
+    }
+    const point = this.centroids[index];
+    if (!point) return false;
+    const isRectangleSearchBox = polygon.properties?.shape === 'Rectangle';
+    if (isRectangleSearchBox && polygon.properties?.bbox) {
+      const [minX, minY, maxX, maxY] = polygon.properties.bbox;
+      return point[0] >= minX && point[0] <= maxX && point[1] >= minY && point[1] <= maxY;
+    }
+    return booleanWithin(turfPoint(point), polygon);
   }
 
   calculateDataAttribute({filteredIndex}: KeplerTable, getPosition) {
+    if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
+      return this._calculateGeojsonDataAttribute(filteredIndex);
+    }
+
     const data: AggregationLayerData[] = [];
 
     for (let i = 0; i < filteredIndex.length; i++) {
@@ -377,12 +597,33 @@ export default class AggregationLayer extends Layer {
     return data;
   }
 
+  private _calculateGeojsonDataAttribute(filteredIndex: number[]) {
+    const data: {index: number; position: number[]}[] = [];
+
+    for (let i = 0; i < filteredIndex.length; i++) {
+      const index = filteredIndex[i];
+      const feature = this.dataToFeature[index];
+      if (!feature?.geometry) continue;
+
+      const centroid = getCentroidFromGeometry(feature.geometry);
+      if (centroid) {
+        data.push({index, position: centroid});
+      }
+    }
+
+    return data;
+  }
+
   formatLayerData(datasets: Datasets, oldLayerData) {
     if (this.config.dataId === null) {
       return {};
     }
     const {gpuFilter, dataContainer} = datasets[this.config.dataId];
-    const getPosition = this.getPositionAccessor(dataContainer);
+    const isGeojsonMode = this.config.columnMode === COLUMN_MODE_GEOJSON;
+
+    const getPosition = isGeojsonMode
+      ? (d: {position: number[]}) => d.position
+      : this.getPositionAccessor(dataContainer);
 
     const hasFilter = Object.values(gpuFilter.filterRange).some((arr: any) =>
       arr.some(v => v !== 0)
@@ -427,9 +668,6 @@ export default class AggregationLayer extends Layer {
     }
 
     // Wrap accessors to filter points within each bin before aggregating.
-    // deck.gl 9's native aggregation doesn't support per-bin filtering, so we
-    // apply gpuFilter at the accessor level to keep bin values in sync with
-    // active cross-filters / time-filters.
     const getFilteredColorValue =
       filterData && getColorValue
         ? points => getColorValue(points.filter(filterData))

--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -219,10 +219,6 @@ export default class AggregationLayer extends Layer {
     return true;
   }
 
-  get requiredLayerColumns() {
-    return aggregateRequiredColumns;
-  }
-
   get supportedColumnModes() {
     return SUPPORTED_COLUMN_MODES;
   }

--- a/test/browser/layer-tests/aggregation-layer-geojson-specs.js
+++ b/test/browser/layer-tests/aggregation-layer-geojson-specs.js
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import test from 'tape';
+
+import {
+  testFormatLayerDataCases,
+  prepareGeojsonDataset,
+  dataId
+} from 'test/helpers/layer-utils';
+
+import {KeplerGlLayers} from '@kepler.gl/layers';
+const {GridLayer, HexagonLayer, ClusterLayer} = KeplerGlLayers;
+
+const geojsonColumns = {
+  geojson: '_geojson'
+};
+
+// The geojson fixture has 5 polygon features; TRIPS filter [4, 12] passes features with TRIPS 11, 4, 20
+// filteredIndex depends on the filter state in prepareGeojsonDataset
+const filteredIndex = prepareGeojsonDataset.filteredIndex;
+
+// Expected centroids for the 5 polygon features (average of all boundary vertices)
+function computeCentroid(coordinates) {
+  const positions = coordinates.flat();
+  let sumLng = 0;
+  let sumLat = 0;
+  let count = 0;
+  for (const pos of positions) {
+    if (Number.isFinite(pos[0]) && Number.isFinite(pos[1])) {
+      sumLng += pos[0];
+      sumLat += pos[1];
+      count++;
+    }
+  }
+  return count > 0 ? [sumLng / count, sumLat / count] : null;
+}
+
+// feature0 polygon centroid
+const feature0Centroid = computeCentroid([
+  [
+    [-122.401159718585049, 37.782024266952142],
+    [-122.400374366843309, 37.782644515545172],
+    [-122.400019020063766, 37.782925153640136],
+    [-122.399891477967842, 37.783025880124256],
+    [-122.398930331092998, 37.783784933304034]
+  ]
+]);
+
+// feature1 polygon centroid
+const feature1Centroid = computeCentroid([
+  [
+    [-122.39249932896719, 37.793768814133983],
+    [-122.391890260341384, 37.794278544568918],
+    [-122.391666728649753, 37.794132425256194],
+    [-122.391723034266192, 37.79410061945832],
+    [-122.39249932896719, 37.793768814133983]
+  ]
+]);
+
+test('#AggregationLayer (Grid) -> constructor with geojson column mode', t => {
+  const layer = new GridLayer({
+    dataId: 'test',
+    label: 'test grid geojson',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  t.ok(layer.config.columnMode === 'geojson', 'should have geojson columnMode');
+  t.ok(layer.type === 'grid', 'type should be grid');
+  t.ok(layer.isAggregated === true, 'should be aggregated');
+  t.ok(layer.supportedColumnModes.length === 2, 'should have 2 supported column modes');
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'geojson'),
+    'should support geojson column mode'
+  );
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'points'),
+    'should support points column mode'
+  );
+  t.end();
+});
+
+test('#AggregationLayer (Hexagon) -> constructor with geojson column mode', t => {
+  const layer = new HexagonLayer({
+    dataId: 'test',
+    label: 'test hexagon geojson',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  t.ok(layer.config.columnMode === 'geojson', 'should have geojson columnMode');
+  t.ok(layer.type === 'hexagon', 'type should be hexagon');
+  t.ok(layer.isAggregated === true, 'should be aggregated');
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'geojson'),
+    'should support geojson column mode'
+  );
+  t.end();
+});
+
+test('#AggregationLayer (Cluster) -> constructor with geojson column mode', t => {
+  const layer = new ClusterLayer({
+    dataId: 'test',
+    label: 'test cluster geojson',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  t.ok(layer.config.columnMode === 'geojson', 'should have geojson columnMode');
+  t.ok(layer.type === 'cluster', 'type should be cluster');
+  t.ok(layer.isAggregated === true, 'should be aggregated');
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'geojson'),
+    'should support geojson column mode'
+  );
+  t.end();
+});
+
+test('#AggregationLayer (Grid) -> findDefaultLayerProps with geojson field', t => {
+  const result = GridLayer.findDefaultLayerProps(prepareGeojsonDataset);
+
+  t.ok(result, 'should return result');
+  t.ok(result.altProps, 'should have altProps');
+  t.ok(result.altProps.length > 0, 'should have at least one alt prop');
+
+  const geojsonAltProp = result.altProps.find(p => p.columnMode === 'geojson');
+  t.ok(geojsonAltProp, 'should find a geojson alt prop');
+  t.ok(geojsonAltProp.columns, 'geojson alt prop should have columns');
+  t.ok(geojsonAltProp.columns.geojson, 'geojson alt prop should have geojson column');
+  t.equal(
+    geojsonAltProp.columns.geojson.value,
+    '_geojson',
+    'geojson column value should be _geojson'
+  );
+  t.end();
+});
+
+test('#AggregationLayer (Hexagon) -> findDefaultLayerProps with geojson field', t => {
+  const result = HexagonLayer.findDefaultLayerProps(prepareGeojsonDataset);
+
+  t.ok(result, 'should return result');
+  t.ok(result.altProps, 'should have altProps');
+
+  const geojsonAltProp = result.altProps.find(p => p.columnMode === 'geojson');
+  t.ok(geojsonAltProp, 'should find a geojson alt prop');
+  t.equal(
+    geojsonAltProp.columns.geojson.value,
+    '_geojson',
+    'geojson column value should be _geojson'
+  );
+  t.end();
+});
+
+test('#AggregationLayer (Cluster) -> findDefaultLayerProps with geojson field', t => {
+  const result = ClusterLayer.findDefaultLayerProps(prepareGeojsonDataset);
+
+  t.ok(result, 'should return result');
+  t.ok(result.altProps, 'should have altProps');
+
+  const geojsonAltProp = result.altProps.find(p => p.columnMode === 'geojson');
+  t.ok(geojsonAltProp, 'should find a geojson alt prop');
+  t.equal(
+    geojsonAltProp.columns.geojson.value,
+    '_geojson',
+    'geojson column value should be _geojson'
+  );
+  t.end();
+});
+
+test('#AggregationLayer (Grid) -> formatLayerData with geojson column mode', t => {
+  const TEST_CASES = [
+    {
+      name: 'Grid geojson column mode',
+      layer: {
+        type: 'grid',
+        id: 'test_grid_geojson_1',
+        config: {
+          dataId,
+          label: 'grid geojson',
+          columns: geojsonColumns,
+          columnMode: 'geojson',
+          color: [1, 2, 3]
+        }
+      },
+      datasets: {
+        [dataId]: {
+          ...prepareGeojsonDataset,
+          filteredIndex
+        }
+      },
+      assert: result => {
+        const {layerData, layer} = result;
+
+        t.ok(layerData, 'should have layer data');
+        t.ok(layerData.data, 'should have data array');
+        t.ok(layerData.data.length > 0, 'should have data entries');
+        t.ok(layerData.getPosition, 'should have getPosition accessor');
+
+        // In geojson mode, each data point should have index and position (centroid)
+        const firstPoint = layerData.data[0];
+        t.ok(Number.isFinite(firstPoint.index), 'data entry should have numeric index');
+        t.ok(Array.isArray(firstPoint.position), 'data entry should have position array');
+        t.equal(firstPoint.position.length, 2, 'position should have 2 elements [lng, lat]');
+        t.ok(Number.isFinite(firstPoint.position[0]), 'longitude should be finite');
+        t.ok(Number.isFinite(firstPoint.position[1]), 'latitude should be finite');
+
+        // getPosition should return the centroid from the data entry
+        const pos = layerData.getPosition(firstPoint);
+        t.deepEqual(pos, firstPoint.position, 'getPosition should return entry position');
+
+        // layer meta should have bounds
+        t.ok(layer.meta.bounds, 'layer should have bounds');
+        t.equal(layer.meta.bounds.length, 4, 'bounds should have 4 elements');
+
+        // centroids should be populated
+        t.ok(layer.centroids.length > 0, 'layer should have centroids populated');
+
+        // dataToFeature should be populated
+        t.ok(layer.dataToFeature.length > 0, 'layer should have dataToFeature populated');
+
+        // verify centroids are correct for polygon features (centroid = average of vertices)
+        const firstCentroid = layer.centroids[0];
+        t.ok(firstCentroid, 'first centroid should exist');
+        t.ok(
+          Math.abs(firstCentroid[0] - feature0Centroid[0]) < 1e-10,
+          'centroid lng should match computed value'
+        );
+        t.ok(
+          Math.abs(firstCentroid[1] - feature0Centroid[1]) < 1e-10,
+          'centroid lat should match computed value'
+        );
+      }
+    }
+  ];
+
+  testFormatLayerDataCases(t, GridLayer, TEST_CASES);
+  t.end();
+});
+
+test('#AggregationLayer (Hexagon) -> formatLayerData with geojson column mode', t => {
+  const TEST_CASES = [
+    {
+      name: 'Hexagon geojson column mode',
+      layer: {
+        type: 'hexagon',
+        id: 'test_hexagon_geojson_1',
+        config: {
+          dataId,
+          label: 'hexagon geojson',
+          columns: geojsonColumns,
+          columnMode: 'geojson',
+          color: [1, 2, 3]
+        }
+      },
+      datasets: {
+        [dataId]: {
+          ...prepareGeojsonDataset,
+          filteredIndex
+        }
+      },
+      assert: result => {
+        const {layerData, layer} = result;
+
+        t.ok(layerData, 'should have layer data');
+        t.ok(layerData.data, 'should have data array');
+        t.ok(layerData.data.length > 0, 'should have data entries');
+        t.ok(layerData.getPosition, 'should have getPosition accessor');
+
+        // In geojson mode, data points have centroid positions
+        const firstPoint = layerData.data[0];
+        t.ok(Array.isArray(firstPoint.position), 'data entry should have position array');
+        t.deepEqual(
+          layerData.getPosition(firstPoint),
+          firstPoint.position,
+          'getPosition should return entry position'
+        );
+
+        // layer meta and centroids
+        t.ok(layer.meta.bounds, 'layer should have bounds');
+        t.ok(layer.centroids.length > 0, 'layer should have centroids');
+        t.ok(layer.dataToFeature.length > 0, 'layer should have dataToFeature');
+      }
+    }
+  ];
+
+  testFormatLayerDataCases(t, HexagonLayer, TEST_CASES);
+  t.end();
+});
+
+test('#AggregationLayer (Cluster) -> formatLayerData with geojson column mode', t => {
+  const TEST_CASES = [
+    {
+      name: 'Cluster geojson column mode',
+      layer: {
+        type: 'cluster',
+        id: 'test_cluster_geojson_1',
+        config: {
+          dataId,
+          label: 'cluster geojson',
+          columns: geojsonColumns,
+          columnMode: 'geojson',
+          color: [1, 2, 3]
+        }
+      },
+      datasets: {
+        [dataId]: {
+          ...prepareGeojsonDataset,
+          filteredIndex
+        }
+      },
+      assert: result => {
+        const {layerData, layer} = result;
+
+        t.ok(layerData, 'should have layer data');
+        t.ok(layerData.data, 'should have data array');
+        t.ok(layerData.data.length > 0, 'should have data entries');
+        t.ok(layerData.getPosition, 'should have getPosition accessor');
+
+        // In geojson mode, data points have centroid positions
+        const firstPoint = layerData.data[0];
+        t.ok(Array.isArray(firstPoint.position), 'data entry should have position array');
+        t.deepEqual(
+          layerData.getPosition(firstPoint),
+          firstPoint.position,
+          'getPosition should return entry position'
+        );
+
+        // layer meta and centroids
+        t.ok(layer.meta.bounds, 'layer should have bounds');
+        t.ok(layer.centroids.length > 0, 'layer should have centroids');
+        t.ok(layer.dataToFeature.length > 0, 'layer should have dataToFeature');
+      }
+    }
+  ];
+
+  testFormatLayerDataCases(t, ClusterLayer, TEST_CASES);
+  t.end();
+});
+
+test('#AggregationLayer -> geojson mode handles Point, LineString, Polygon geometries', t => {
+  // Test that getCentroidFromGeometry handles different geometry types correctly
+  // by creating a layer with mixed geometry data
+
+  const layer = new GridLayer({
+    dataId: 'test',
+    label: 'test',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  // Simulate dataContainer with different geometry types
+  const mockFeatures = [
+    // Point - should return point directly
+    {
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [-122.4, 37.8]},
+      properties: {}
+    },
+    // LineString - should return center (average of vertices)
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [-122.4, 37.8],
+          [-122.5, 37.9]
+        ]
+      },
+      properties: {}
+    },
+    // Polygon - should return centroid (average of boundary vertices)
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-122.4, 37.8],
+            [-122.5, 37.8],
+            [-122.5, 37.9],
+            [-122.4, 37.9],
+            [-122.4, 37.8]
+          ]
+        ]
+      },
+      properties: {}
+    }
+  ];
+
+  const mockDataContainer = {
+    numRows: () => mockFeatures.length,
+    valueAt: (index, fieldIdx) => JSON.stringify(mockFeatures[index])
+  };
+
+  // Call updateLayerMeta-like logic
+  const getFeature = layer.getPositionAccessor(mockDataContainer);
+
+  // Manually invoke _buildGeojsonDataToFeature through the public API
+  layer.config.columns = {
+    lat: {value: null, fieldIdx: -1},
+    lng: {value: null, fieldIdx: -1},
+    geojson: {value: '_geojson', fieldIdx: 0}
+  };
+  layer.config.columnMode = 'geojson';
+
+  // Use updateLayerMeta with a mock dataset
+  const mockDataset = {
+    dataContainer: mockDataContainer,
+    filteredIndex: [0, 1, 2],
+    id: 'test'
+  };
+  layer.updateLayerMeta(mockDataset);
+
+  // Verify centroids
+  t.equal(layer.centroids.length, 3, 'should have 3 centroids');
+
+  // Point: centroid should be the point itself
+  t.deepEqual(layer.centroids[0], [-122.4, 37.8], 'Point centroid should be point coordinates');
+
+  // LineString: centroid should be average of vertices
+  const expectedLineCentroid = [(-122.4 + -122.5) / 2, (37.8 + 37.9) / 2];
+  t.ok(
+    Math.abs(layer.centroids[1][0] - expectedLineCentroid[0]) < 1e-10,
+    'LineString centroid lng should be average of vertices'
+  );
+  t.ok(
+    Math.abs(layer.centroids[1][1] - expectedLineCentroid[1]) < 1e-10,
+    'LineString centroid lat should be average of vertices'
+  );
+
+  // Polygon: centroid should be average of all boundary vertices
+  const polyCoords = [
+    [-122.4, 37.8],
+    [-122.5, 37.8],
+    [-122.5, 37.9],
+    [-122.4, 37.9],
+    [-122.4, 37.8]
+  ];
+  const expectedPolyCentroid = [
+    polyCoords.reduce((s, c) => s + c[0], 0) / polyCoords.length,
+    polyCoords.reduce((s, c) => s + c[1], 0) / polyCoords.length
+  ];
+  t.ok(
+    Math.abs(layer.centroids[2][0] - expectedPolyCentroid[0]) < 1e-10,
+    'Polygon centroid lng should be average of boundary vertices'
+  );
+  t.ok(
+    Math.abs(layer.centroids[2][1] - expectedPolyCentroid[1]) < 1e-10,
+    'Polygon centroid lat should be average of boundary vertices'
+  );
+
+  // Verify bounds encompass all geometries
+  t.ok(layer.meta.bounds, 'should have computed bounds');
+  const [minLng, minLat, maxLng, maxLat] = layer.meta.bounds;
+  t.ok(minLng <= -122.5, 'minLng should include westernmost point');
+  t.ok(maxLng >= -122.4, 'maxLng should include easternmost point');
+  t.ok(minLat <= 37.8, 'minLat should include southernmost point');
+  t.ok(maxLat >= 37.9, 'maxLat should include northernmost point');
+
+  t.end();
+});
+
+test('#AggregationLayer -> isInPolygon with geojson mode', t => {
+  const layer = new GridLayer({
+    dataId: 'test',
+    label: 'test',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  // Set up centroids manually
+  layer.centroids = [
+    [-122.4, 37.8],
+    [-122.5, 37.9],
+    null
+  ];
+
+  // Create a polygon that contains the first centroid but not the second
+  const filterPolygon = {
+    type: 'Feature',
+    properties: {
+      shape: 'Rectangle',
+      bbox: [-122.45, 37.75, -122.35, 37.85]
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-122.45, 37.75],
+          [-122.35, 37.75],
+          [-122.35, 37.85],
+          [-122.45, 37.85],
+          [-122.45, 37.75]
+        ]
+      ]
+    }
+  };
+
+  t.ok(
+    layer.isInPolygon(null, 0, filterPolygon),
+    'first point should be inside polygon'
+  );
+  t.notOk(
+    layer.isInPolygon(null, 1, filterPolygon),
+    'second point should be outside polygon'
+  );
+  t.notOk(
+    layer.isInPolygon(null, 2, filterPolygon),
+    'null centroid should return false'
+  );
+  t.notOk(
+    layer.isInPolygon(null, 99, filterPolygon),
+    'out-of-bounds index should return false'
+  );
+
+  t.end();
+});

--- a/test/browser/layer-tests/aggregation-layer-geojson-specs.js
+++ b/test/browser/layer-tests/aggregation-layer-geojson-specs.js
@@ -393,9 +393,6 @@ test('#AggregationLayer -> geojson mode handles Point, LineString, Polygon geome
     valueAt: (index, fieldIdx) => JSON.stringify(mockFeatures[index])
   };
 
-  // Call updateLayerMeta-like logic
-  const getFeature = layer.getPositionAccessor(mockDataContainer);
-
   // Manually invoke _buildGeojsonDataToFeature through the public API
   layer.config.columns = {
     lat: {value: null, fieldIdx: -1},

--- a/test/browser/layer-tests/heatmap-layer-specs.js
+++ b/test/browser/layer-tests/heatmap-layer-specs.js
@@ -6,6 +6,7 @@ import {
   testCreateCases,
   testFormatLayerDataCases,
   preparedDataset,
+  prepareGeojsonDataset,
   dataId,
   pointLayerMeta
 } from 'test/helpers/layer-utils';
@@ -149,5 +150,286 @@ test('#Heatmaplayer -> formatLayerData -> w/o GpuFilter', t => {
   ];
 
   testFormatLayerDataCases(t, HeatmapLayer, TEST_CASES);
+  t.end();
+});
+
+const geojsonColumns = {
+  geojson: '_geojson'
+};
+
+const geojsonFilteredIndex = prepareGeojsonDataset.filteredIndex;
+
+test('#HeatmapLayer -> constructor with geojson column mode', t => {
+  const layer = new HeatmapLayer({
+    dataId: 'test',
+    label: 'test heatmap geojson',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  t.equal(layer.config.columnMode, 'geojson', 'should have geojson columnMode');
+  t.equal(layer.type, 'heatmap', 'type should be heatmap');
+  t.ok(layer.isAggregated, 'should be aggregated');
+  t.equal(layer.supportedColumnModes.length, 3, 'should have 3 supported column modes');
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'geojson'),
+    'should support geojson column mode'
+  );
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'points'),
+    'should support points column mode'
+  );
+  t.ok(
+    layer.supportedColumnModes.find(m => m.key === 'geoarrow'),
+    'should support geoarrow column mode'
+  );
+  t.end();
+});
+
+test('#HeatmapLayer -> findDefaultLayerProps with geojson field', t => {
+  const result = HeatmapLayer.findDefaultLayerProps(prepareGeojsonDataset);
+
+  t.ok(result, 'should return result');
+  t.ok(result.altProps, 'should have altProps');
+  t.ok(result.altProps.length > 0, 'should have at least one alt prop');
+
+  const geojsonAltProp = result.altProps.find(p => p.columnMode === 'geojson');
+  t.ok(geojsonAltProp, 'should find a geojson alt prop');
+  t.ok(geojsonAltProp.columns, 'geojson alt prop should have columns');
+  t.ok(geojsonAltProp.columns.geojson, 'geojson alt prop should have geojson column');
+  t.equal(
+    geojsonAltProp.columns.geojson.value,
+    '_geojson',
+    'geojson column value should be _geojson'
+  );
+  t.end();
+});
+
+test('#HeatmapLayer -> formatLayerData with geojson column mode', t => {
+  const TEST_CASES = [
+    {
+      name: 'Heatmap geojson column mode',
+      layer: {
+        type: 'heatmap',
+        id: 'heatmap_geojson_test_1',
+        config: {
+          dataId,
+          label: 'heatmap geojson',
+          columns: geojsonColumns,
+          columnMode: 'geojson',
+          color: [1, 2, 3]
+        }
+      },
+      datasets: {
+        [dataId]: {
+          ...prepareGeojsonDataset,
+          filteredIndex: geojsonFilteredIndex
+        }
+      },
+      assert: result => {
+        const {layerData, layer} = result;
+
+        t.ok(layerData, 'should have layer data');
+        t.ok(Array.isArray(layerData.data), 'layerData.data should be an array');
+        t.ok(layerData.data.length > 0, 'should have data entries');
+        t.ok(typeof layerData.getPosition === 'function', 'should have getPosition accessor');
+
+        // In geojson mode, each data point should have index and position (centroid)
+        const firstPoint = layerData.data[0];
+        t.ok(Number.isFinite(firstPoint.index), 'data entry should have numeric index');
+        t.ok(Array.isArray(firstPoint.position), 'data entry should have position array');
+        t.equal(firstPoint.position.length, 2, 'position should have 2 elements [lng, lat]');
+        t.ok(Number.isFinite(firstPoint.position[0]), 'longitude should be finite');
+        t.ok(Number.isFinite(firstPoint.position[1]), 'latitude should be finite');
+
+        // getPosition should return the centroid from the data entry
+        const pos = layerData.getPosition(firstPoint);
+        t.deepEqual(pos, firstPoint.position, 'getPosition should return entry position');
+
+        // layer meta should have bounds
+        t.ok(layer.meta.bounds, 'layer should have bounds');
+        t.equal(layer.meta.bounds.length, 4, 'bounds should have 4 elements');
+
+        // centroids should be populated
+        t.ok(layer.centroids.length > 0, 'layer should have centroids populated');
+
+        // dataToFeature should be populated
+        t.ok(layer.dataToFeature.length > 0, 'layer should have dataToFeature populated');
+      }
+    }
+  ];
+
+  testFormatLayerDataCases(t, HeatmapLayer, TEST_CASES);
+  t.end();
+});
+
+test('#HeatmapLayer -> geojson mode handles Point, LineString, Polygon geometries', t => {
+  const layer = new HeatmapLayer({
+    dataId: 'test',
+    label: 'test',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  const mockFeatures = [
+    // Point - should return point directly
+    {
+      type: 'Feature',
+      geometry: {type: 'Point', coordinates: [-122.4, 37.8]},
+      properties: {}
+    },
+    // LineString - should return center (average of vertices)
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [-122.4, 37.8],
+          [-122.5, 37.9]
+        ]
+      },
+      properties: {}
+    },
+    // Polygon - should return centroid (average of boundary vertices)
+    {
+      type: 'Feature',
+      geometry: {
+        type: 'Polygon',
+        coordinates: [
+          [
+            [-122.4, 37.8],
+            [-122.5, 37.8],
+            [-122.5, 37.9],
+            [-122.4, 37.9],
+            [-122.4, 37.8]
+          ]
+        ]
+      },
+      properties: {}
+    }
+  ];
+
+  const mockDataContainer = {
+    numRows: () => mockFeatures.length,
+    valueAt: (index, fieldIdx) => JSON.stringify(mockFeatures[index])
+  };
+
+  layer.config.columns = {
+    lat: {value: null, fieldIdx: -1},
+    lng: {value: null, fieldIdx: -1},
+    geoarrow: {value: null, fieldIdx: -1},
+    geojson: {value: '_geojson', fieldIdx: 0}
+  };
+  layer.config.columnMode = 'geojson';
+
+  const mockDataset = {
+    dataContainer: mockDataContainer,
+    filteredIndex: [0, 1, 2],
+    id: 'test'
+  };
+  layer.updateLayerMeta(mockDataset);
+
+  // Verify centroids
+  t.equal(layer.centroids.length, 3, 'should have 3 centroids');
+
+  // Point: centroid should be the point itself
+  t.deepEqual(layer.centroids[0], [-122.4, 37.8], 'Point centroid should be point coordinates');
+
+  // LineString: centroid should be average of vertices
+  const expectedLineCentroid = [(-122.4 + -122.5) / 2, (37.8 + 37.9) / 2];
+  t.ok(
+    Math.abs(layer.centroids[1][0] - expectedLineCentroid[0]) < 1e-10,
+    'LineString centroid lng should be average of vertices'
+  );
+  t.ok(
+    Math.abs(layer.centroids[1][1] - expectedLineCentroid[1]) < 1e-10,
+    'LineString centroid lat should be average of vertices'
+  );
+
+  // Polygon: centroid should be average of all boundary vertices
+  const polyCoords = [
+    [-122.4, 37.8],
+    [-122.5, 37.8],
+    [-122.5, 37.9],
+    [-122.4, 37.9],
+    [-122.4, 37.8]
+  ];
+  const expectedPolyCentroid = [
+    polyCoords.reduce((s, c) => s + c[0], 0) / polyCoords.length,
+    polyCoords.reduce((s, c) => s + c[1], 0) / polyCoords.length
+  ];
+  t.ok(
+    Math.abs(layer.centroids[2][0] - expectedPolyCentroid[0]) < 1e-10,
+    'Polygon centroid lng should be average of boundary vertices'
+  );
+  t.ok(
+    Math.abs(layer.centroids[2][1] - expectedPolyCentroid[1]) < 1e-10,
+    'Polygon centroid lat should be average of boundary vertices'
+  );
+
+  // Verify bounds
+  t.ok(layer.meta.bounds, 'should have computed bounds');
+  const [minLng, minLat, maxLng, maxLat] = layer.meta.bounds;
+  t.ok(minLng <= -122.5, 'minLng should include westernmost point');
+  t.ok(maxLng >= -122.4, 'maxLng should include easternmost point');
+  t.ok(minLat <= 37.8, 'minLat should include southernmost point');
+  t.ok(maxLat >= 37.9, 'maxLat should include northernmost point');
+
+  t.end();
+});
+
+test('#HeatmapLayer -> isInPolygon with geojson mode', t => {
+  const layer = new HeatmapLayer({
+    dataId: 'test',
+    label: 'test',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+
+  // Set up centroids manually
+  layer.centroids = [
+    [-122.4, 37.8],
+    [-122.5, 37.9],
+    null
+  ];
+
+  // Rectangle polygon that contains the first centroid but not the second
+  const filterPolygon = {
+    type: 'Feature',
+    properties: {
+      shape: 'Rectangle',
+      bbox: [-122.45, 37.75, -122.35, 37.85]
+    },
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-122.45, 37.75],
+          [-122.35, 37.75],
+          [-122.35, 37.85],
+          [-122.45, 37.85],
+          [-122.45, 37.75]
+        ]
+      ]
+    }
+  };
+
+  t.ok(
+    layer.isInPolygon(null, 0, filterPolygon),
+    'first point should be inside polygon'
+  );
+  t.notOk(
+    layer.isInPolygon(null, 1, filterPolygon),
+    'second point should be outside polygon'
+  );
+  t.notOk(
+    layer.isInPolygon(null, 2, filterPolygon),
+    'null centroid should return false'
+  );
+  t.notOk(
+    layer.isInPolygon(null, 99, filterPolygon),
+    'out-of-bounds index should return false'
+  );
+
   t.end();
 });

--- a/test/browser/layer-tests/index.js
+++ b/test/browser/layer-tests/index.js
@@ -18,3 +18,4 @@ import './trip-layer-specs';
 import './s2-geometry-layer-specs';
 import './wms-layer-specs';
 import './flow-layer-specs';
+import './aggregation-layer-geojson-specs';

--- a/test/fixtures/state-saved-v0.js
+++ b/test/fixtures/state-saved-v0.js
@@ -1238,6 +1238,7 @@ mergedLayer3.config = {
   dataId: '9h10t7fyb',
   label: 'begintrip_hex',
   color: [241, 92, 23],
+  columnMode: 'points',
   columns: {
     lat: {
       value: 'begintrip_lat',

--- a/test/fixtures/state-saved-v1-3.js
+++ b/test/fixtures/state-saved-v1-3.js
@@ -416,6 +416,7 @@ mergedLayer1.config = {
   dataId: 'fm8v2jcza',
   label: 'hexagon',
   color: [221, 178, 124],
+  columnMode: 'points',
   columns: {
     lat: {
       value: 'restaurant_lat',

--- a/test/helpers/mock-state.js
+++ b/test/helpers/mock-state.js
@@ -803,6 +803,7 @@ export const expectedSavedLayer0 = {
     label: DEFAULT_LAYER_LABEL,
     highlightColor: DEFAULT_HIGHLIGHT_COLOR,
     color: [2, 2, 2],
+    columnMode: 'points',
     columns: {
       lat: 'gps_data.lat',
       lng: 'gps_data.lng'
@@ -843,6 +844,7 @@ export const expectedLoadedLayer0 = {
     label: DEFAULT_LAYER_LABEL,
     highlightColor: DEFAULT_HIGHLIGHT_COLOR,
     color: [2, 2, 2],
+    columnMode: 'points',
     columns: {
       lat: 'gps_data.lat',
       lng: 'gps_data.lng'


### PR DESCRIPTION
For #1979 

- extend aggregation layers (Grid, Hexbin, Cluster) with geojson input column, similar to Heatmap layer.

<img width="847" height="884" alt="Screenshot 2026-05-23 at 12 41 58 AM" src="https://github.com/user-attachments/assets/c90a64e4-4845-4945-a72b-76743516d726" />
<img width="897" height="885" alt="Screenshot 2026-05-23 at 12 42 08 AM" src="https://github.com/user-attachments/assets/9c567b47-77c6-453c-97ec-fcc9a3901773" />
<img width="872" height="861" alt="Screenshot 2026-05-23 at 12 42 29 AM" src="https://github.com/user-attachments/assets/b793c779-f134-4ebf-a50b-996273ad30fc" />
