### PR TITLE
feat:  Add Docker setup for running kepler.gl demo app locally

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,9 @@ dist/
 node_modules/
 __pycache__/
 build/
+.git/
+website/
+bindings/
+test/
+docs/
+*.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,36 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+RUN apk add --no-cache git python3 make g++ bash sed
+
+RUN corepack enable && corepack prepare yarn@4.4.0 --activate
+
+COPY . .
+
+# gl package requires GPU headers only needed for tests; skip build scripts then selectively rebuild esbuild
+RUN yarn config set enableScripts false && \
+    yarn install && \
+    yarn config set enableScripts true
+
+RUN cd node_modules/esbuild && node install.js
+
+RUN yarn fix-dependencies
+RUN yarn workspaces foreach -At run stab
+
+WORKDIR /app/examples/demo-app
+
+RUN yarn install
+RUN yarn build
+
+FROM node:20-alpine AS runtime
+
+WORKDIR /app
+
+RUN npm install -g serve@14
+
+COPY --from=builder /app/examples/demo-app/dist ./dist
+
+EXPOSE 8080
+
+CMD ["serve", "-s", "dist", "-l", "8080"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,14 +6,21 @@ RUN apk add --no-cache git python3 make g++ bash sed
 
 RUN corepack enable && corepack prepare yarn@4.4.0 --activate
 
-COPY . .
+# Copy dependency manifests first for better layer caching
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY --parents src/*/package.json ./
+COPY --parents examples/demo-app/package.json examples/demo-app/yarn.lock examples/demo-app/.yarnrc.yml ./
 
-# gl package requires GPU headers only needed for tests; skip build scripts then selectively rebuild esbuild
+# Skip all postinstall scripts to avoid building the gl native package (GPU headers not available)
 RUN yarn config set enableScripts false && \
     yarn install && \
     yarn config set enableScripts true
 
+# Selectively run esbuild postinstall (needed for the correct platform binary)
 RUN cd node_modules/esbuild && node install.js
+
+# Now copy the full source
+COPY . .
 
 RUN yarn fix-dependencies
 RUN yarn workspaces foreach -At run stab

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -9,15 +9,21 @@ RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/xdg-open && chmod +x /usr/loca
 
 RUN corepack enable && corepack prepare yarn@4.4.0 --activate
 
-COPY . .
+# Copy dependency manifests first for better layer caching
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY --parents src/*/package.json ./
+COPY --parents examples/demo-app/package.json examples/demo-app/yarn.lock examples/demo-app/.yarnrc.yml ./
 
-# gl package requires GPU headers only needed for tests; allow its build to fail
+# Skip all postinstall scripts to avoid building the gl native package (GPU headers not available)
 RUN yarn config set enableScripts false && \
     yarn install && \
     yarn config set enableScripts true
 
-# Manually run esbuild postinstall (needed for the correct platform binary)
+# Selectively run esbuild postinstall (needed for the correct platform binary)
 RUN cd node_modules/esbuild && node install.js
+
+# Now copy the full source
+COPY . .
 
 RUN yarn fix-dependencies
 RUN yarn workspaces foreach -At run stab

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,31 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+RUN apk add --no-cache git python3 make g++ bash sed
+
+# Provide a no-op xdg-open so the dev server doesn't crash trying to open a browser
+RUN printf '#!/bin/sh\nexit 0\n' > /usr/local/bin/xdg-open && chmod +x /usr/local/bin/xdg-open
+
+RUN corepack enable && corepack prepare yarn@4.4.0 --activate
+
+COPY . .
+
+# gl package requires GPU headers only needed for tests; allow its build to fail
+RUN yarn config set enableScripts false && \
+    yarn install && \
+    yarn config set enableScripts true
+
+# Manually run esbuild postinstall (needed for the correct platform binary)
+RUN cd node_modules/esbuild && node install.js
+
+RUN yarn fix-dependencies
+RUN yarn workspaces foreach -At run stab
+
+WORKDIR /app/examples/demo-app
+
+RUN yarn install
+
+EXPOSE 8080
+
+CMD ["yarn", "start:local"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,63 @@
+# Docker Setup for kepler.gl Demo App
+
+Two Dockerfiles are provided:
+
+- **Dockerfile** — production multi-stage build. Compiles the demo-app to static files and serves with `serve`.
+- **Dockerfile.dev** — development mode with hot-reload via esbuild watch.
+
+## Prerequisites
+
+1. [Docker](https://docs.docker.com/get-docker/) installed and running
+2. Create a `.env` file at the repository root (copy from `.env.template`):
+
+```bash
+cp .env.template .env
+```
+
+Fill in at least `MapboxAccessToken` for the map to render.
+
+## Running with Docker Compose
+
+From the repository root:
+
+```bash
+# Development mode (hot-reload, esbuild watch)
+docker compose -f docker/docker-compose.yml up kepler-dev
+
+# Production mode (static build served by serve)
+docker compose -f docker/docker-compose.yml up kepler-prod
+```
+
+Then open http://localhost:8080.
+
+To rebuild after code changes:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build kepler-dev
+```
+
+## Running with Docker directly
+
+### Development
+
+```bash
+docker build -f docker/Dockerfile.dev -t kepler-dev .
+docker run -p 8080:8080 --env-file .env -e NODE_ENV=local kepler-dev
+```
+
+### Production
+
+Make sure `.env` exists at the root — env vars are baked in at build time:
+
+```bash
+docker build -f docker/Dockerfile -t kepler-prod .
+docker run -p 8080:8080 kepler-prod
+```
+
+## Notes
+
+- The build context must be the repository root (both Dockerfiles reference `src/`, `scripts/`, etc.).
+- The `.dockerignore` at the root excludes `node_modules/`, `.git/`, `website/`, `bindings/`, `test/`, and `docs/` to keep the build context small.
+- The `gl` native package (used only for testing) is skipped during Docker builds by disabling postinstall scripts. The `esbuild` binary is manually installed afterward since it's required for bundling.
+- Environment variables like `MapboxAccessToken` are embedded at build time in production mode. Rebuild the image to change them.
+- The dev image provides a no-op `xdg-open` to prevent the server from crashing when it tries to open a browser.

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 Two Dockerfiles are provided:
 
 - **Dockerfile** — production multi-stage build. Compiles the demo-app to static files and serves with `serve`.
-- **Dockerfile.dev** — development mode with hot-reload via esbuild watch.
+- **Dockerfile.dev** — development build with esbuild watch mode inside the container.
 
 ## Prerequisites
 
@@ -21,7 +21,7 @@ Fill in at least `MapboxAccessToken` for the map to render.
 From the repository root:
 
 ```bash
-# Development mode (hot-reload, esbuild watch)
+# Development mode (esbuild watch inside the container)
 docker compose -f docker/docker-compose.yml up kepler-dev
 
 # Production mode (static build served by serve)
@@ -30,11 +30,13 @@ docker compose -f docker/docker-compose.yml up kepler-prod
 
 Then open http://localhost:8080.
 
-To rebuild after code changes:
+To rebuild after code changes on the host:
 
 ```bash
 docker compose -f docker/docker-compose.yml up --build kepler-dev
 ```
+
+> **Note:** The dev container does not mount the host source tree, so changes you make on the host require a rebuild (`--build`). The esbuild watch mode only picks up changes made inside the container itself (e.g. via `docker exec`).
 
 ## Running with Docker directly
 
@@ -58,6 +60,6 @@ docker run -p 8080:8080 kepler-prod
 
 - The build context must be the repository root (both Dockerfiles reference `src/`, `scripts/`, etc.).
 - The `.dockerignore` at the root excludes `node_modules/`, `.git/`, `website/`, `bindings/`, `test/`, and `docs/` to keep the build context small.
-- The `gl` native package (used only for testing) is skipped during Docker builds by disabling postinstall scripts. The `esbuild` binary is manually installed afterward since it's required for bundling.
-- Environment variables like `MapboxAccessToken` are embedded at build time in production mode. Rebuild the image to change them.
+- All postinstall scripts are disabled during `yarn install` to avoid building the `gl` native package (requires GPU headers, only used for tests). The `esbuild` platform binary is then installed selectively since it's required for bundling.
+- Environment variables like `MapboxAccessToken` are read from the `.env` file copied into the build context. Rebuild the image to change them.
 - The dev image provides a no-op `xdg-open` to prevent the server from crashing when it tries to open a browser.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,5 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-      args:
-        - MAPBOX_ACCESS_TOKEN=${MAPBOX_ACCESS_TOKEN:-}
     ports:
       - "8080:8080"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  kepler-dev:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.dev
+    ports:
+      - "8080:8080"
+    env_file:
+      - ../.env
+    environment:
+      - NODE_ENV=local
+
+  kepler-prod:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+      args:
+        - MAPBOX_ACCESS_TOKEN=${MAPBOX_ACCESS_TOKEN:-}
+    ports:
+      - "8080:8080"


### PR DESCRIPTION
Adds a docker/ directory with development and production Dockerfiles, a docker-compose file, and a README with usage instructions. Improves on #2986 by using local source (no git clone), Node 20, multi-stage production builds, and proper handling of the gl native package and xdg-open in containers. Also updates .dockerignore to reduce build context size.

- instead of the stale https://github.com/keplergl/kepler.gl/pull/2986