### PR TITLE
fix: fix layer toggle in dual map view

### DIFF
--- a/src/components/src/common/checkbox.tsx
+++ b/src/components/src/common/checkbox.tsx
@@ -97,8 +97,6 @@ const Checkbox: FC<CheckboxProps> = ({
     [onBlur]
   );
 
-  const inputType = type === 'radio' ? 'radio' : 'checkbox';
-
   const inputProps = {
     checked,
     disabled,
@@ -107,7 +105,7 @@ const Checkbox: FC<CheckboxProps> = ({
     onChange,
     value,
     secondary,
-    type: inputType,
+    type: 'checkbox' as const,
     onFocus: handleFocus,
     onBlur: handleBlur
   };


### PR DESCRIPTION
For #3462 

Fix regression where layers can be turned on but not off in split map view. The Checkbox component refactor (#3440) inadvertently changed the hidden input type from "checkbox" to "radio" when the type prop is "radio", preventing onChange from firing on uncheck.