### PR TITLE
 feat: Add non-linear piecewise focus range to VisConfig sliders

### DIFF
--- a/src/components/src/common/range-slider.tsx
+++ b/src/components/src/common/range-slider.tsx
@@ -16,6 +16,7 @@ import {
   clamp,
   scaleSourceDomainToDestination
 } from '@kepler.gl/utils';
+import type {SliderScaleConfig} from '@kepler.gl/utils';
 import {LineChart, Filter, Bins} from '@kepler.gl/types';
 import {Datasets} from '@kepler.gl/table';
 import {ActionHandler, setFilterPlot} from '@kepler.gl/actions';
@@ -84,6 +85,7 @@ interface RangeSliderProps {
   datasets?: Datasets;
 
   invertTrendColor?: boolean;
+  scaleConfig?: SliderScaleConfig | null;
 }
 
 const RANGE_SLIDER_TIMELINE_PANEL_STYLE = {marginLeft: '-32px'};
@@ -286,7 +288,8 @@ export default function RangeSliderFactory(
         animationWindow,
         subAnimations: subAnimations,
         filter,
-        datasets
+        datasets,
+        scaleConfig
       } = this.props;
 
       const {width} = this.state;
@@ -374,6 +377,7 @@ export default function RangeSliderFactory(
                     onChange([val0, val1]);
                   }}
                   enableBarDrag
+                  scaleConfig={scaleConfig}
                 />
                 {!isRanged && showInput ? this._renderInput('value1') : null}
               </SliderWrapper>

--- a/src/components/src/common/slider/slider.tsx
+++ b/src/components/src/common/slider/slider.tsx
@@ -7,7 +7,8 @@ import styled from 'styled-components';
 
 import SliderHandle from './slider-handle';
 import SliderBarHandle from './slider-bar-handle';
-import {normalizeSliderValue, clamp} from '@kepler.gl/utils';
+import {normalizeSliderValue, clamp, valueToPosition, positionToValue} from '@kepler.gl/utils';
+import type {SliderScaleConfig} from '@kepler.gl/utils';
 
 function noop() {
   return;
@@ -55,6 +56,7 @@ type SliderProps = {
   disabled: boolean;
   className?: string;
   style?: object;
+  scaleConfig?: SliderScaleConfig | null;
 };
 
 export default class Slider extends Component<SliderProps> {
@@ -99,6 +101,28 @@ export default class Slider extends Component<SliderProps> {
     return this.props.vertical ? this.ref.current.offsetHeight : this.ref.current.offsetWidth;
   }
 
+  private getValueFromPixelOffset(pixelOffset: number): number {
+    const {minValue, maxValue, scaleConfig} = this.props;
+    const baseDistance = this.getBaseDistance();
+    if (baseDistance === 0) return minValue;
+
+    const position = pixelOffset / baseDistance;
+
+    if (scaleConfig) {
+      return positionToValue(position, minValue, maxValue, scaleConfig);
+    }
+    return minValue + position * (maxValue - minValue);
+  }
+
+  private getPositionFromValue(value: number): number {
+    const {minValue, maxValue, scaleConfig} = this.props;
+    if (scaleConfig) {
+      return valueToPosition(value, minValue, maxValue, scaleConfig);
+    }
+    if (maxValue === minValue) return 0;
+    return (value - minValue) / (maxValue - minValue);
+  }
+
   private getDeltaVal(x: number) {
     const percent = x / this.getBaseDistance();
     const maxDelta = this.props.maxValue - this.props.minValue;
@@ -123,29 +147,55 @@ export default class Slider extends Component<SliderProps> {
   }
 
   slide0Listener = (x: number) => {
-    const {value1, minValue} = this.props;
-    const val = this.getValue(minValue, x);
+    const {value1, minValue, scaleConfig} = this.props;
+    const val = scaleConfig
+      ? this.normalizeValue(this.getValueFromPixelOffset(x))
+      : this.getValue(minValue, x);
     this.props.onSlider0Change(clamp([minValue, value1], val));
   };
 
   slide1Listener = (x: number) => {
-    const {minValue, maxValue, value0} = this.props;
-    const val = this.getValue(minValue, x);
+    const {minValue, maxValue, value0, scaleConfig} = this.props;
+    const val = scaleConfig
+      ? this.normalizeValue(this.getValueFromPixelOffset(x))
+      : this.getValue(minValue, x);
     this.props.onSlider1Change(clamp([value0, maxValue], val));
   };
 
   sliderBarListener = (x: number) => {
-    const {value0, value1, minValue, maxValue} = this.props;
-    // for slider bar, we use distance delta
-    const anchor = this.anchor;
-    const length = value1 - value0; // the length of the selected range shouldn't change when clamping
-    const val0 = clamp([minValue, maxValue - length], this.getValue(value0, x - anchor));
-    const val1 = clamp([val0 + length, maxValue], this.getValue(value1, x - anchor));
+    const {value0, value1, minValue, maxValue, scaleConfig} = this.props;
 
-    const deltaX = this.getDeltaX(val0 - this.props.value0);
-    this.props.onSliderBarChange(val0, val1);
-    // update anchor
-    this.anchor = this.anchor + deltaX;
+    if (scaleConfig) {
+      const anchor = this.anchor;
+      const baseDistance = this.getBaseDistance();
+
+      // Convert current positions to pixel positions, apply delta, convert back
+      const pos0Px = this.getPositionFromValue(value0) * baseDistance;
+      const pos1Px = this.getPositionFromValue(value1) * baseDistance;
+      const deltaPx = x - anchor;
+
+      const newVal0Raw = this.normalizeValue(
+        this.getValueFromPixelOffset(pos0Px + deltaPx)
+      );
+      const newVal1Raw = this.normalizeValue(
+        this.getValueFromPixelOffset(pos1Px + deltaPx)
+      );
+
+      const val0 = clamp([minValue, maxValue - (newVal1Raw - newVal0Raw)], newVal0Raw);
+      const val1 = clamp([val0 + (newVal1Raw - newVal0Raw), maxValue], newVal1Raw);
+
+      this.props.onSliderBarChange(val0, val1);
+      this.anchor = x;
+    } else {
+      const anchor = this.anchor;
+      const length = value1 - value0;
+      const val0 = clamp([minValue, maxValue - length], this.getValue(value0, x - anchor));
+      const val1 = clamp([val0 + length, maxValue], this.getValue(value1, x - anchor));
+
+      const deltaX = this.getDeltaX(val0 - this.props.value0);
+      this.props.onSliderBarChange(val0, val1);
+      this.anchor = this.anchor + deltaX;
+    }
   };
 
   calcHandleLeft0 = (w: number, l: number) => {
@@ -175,11 +225,9 @@ export default class Slider extends Component<SliderProps> {
       style
     } = this.props;
     const value0 = !isRanged && minValue > 0 ? minValue : this.props.value0;
-    const currValDelta = value1 - value0;
-    const maxDelta = maxValue - minValue;
-    const width = (currValDelta / maxDelta) * 100;
-
-    const v0Left = ((value0 - minValue) / maxDelta) * 100;
+    const v0Left = this.getPositionFromValue(value0) * 100;
+    const v1Right = this.getPositionFromValue(value1) * 100;
+    const width = v1Right - v0Left;
 
     return (
       <SliderWrapper

--- a/src/components/src/common/slider/slider.tsx
+++ b/src/components/src/common/slider/slider.tsx
@@ -216,7 +216,6 @@ export default class Slider extends Component<SliderProps> {
       classSet,
       disabled,
       isRanged,
-      maxValue,
       minValue,
       value1,
       vertical,

--- a/src/components/src/side-panel/layer-panel/vis-config-slider.tsx
+++ b/src/components/src/side-panel/layer-panel/vis-config-slider.tsx
@@ -10,7 +10,7 @@ import {FormattedMessage} from '@kepler.gl/localization';
 import {KeyEvent} from '@kepler.gl/constants';
 import {Checkbox} from '../..';
 import {Layer, LayerBaseConfig} from '@kepler.gl/layers';
-import {isInRange, clamp} from '@kepler.gl/utils';
+import {isInRange, clamp, createSliderScale} from '@kepler.gl/utils';
 
 type LazyInputProps = {
   value: string | [string, string];
@@ -35,6 +35,8 @@ type VisConfigSliderProps = {
   disabled?: boolean;
   inputTheme?: string;
   allowCustomValue?: boolean;
+  focusRange?: [number, number];
+  focusWeight?: number;
 };
 
 const InputWrapper = styled.div`
@@ -162,10 +164,13 @@ export default function VisConfigSliderFactory(RangeSlider: ReturnType<typeof Ra
     allowCustomValue,
     disabled,
     onChange,
-    inputTheme
+    inputTheme,
+    focusRange,
+    focusWeight
   }) => {
     const value = config.visConfig[property];
     const [custom, setCustom] = useState(false || !isInRange(value, range));
+    const scaleConfig = createSliderScale(focusRange, focusWeight);
 
     const onChangeCheckbox = useCallback(() => {
       if (custom) {
@@ -210,6 +215,7 @@ export default function VisConfigSliderFactory(RangeSlider: ReturnType<typeof Ra
             onChange={v => onChange({[property]: isRanged ? v : v[1]})}
             inputTheme={inputTheme}
             showInput
+            scaleConfig={scaleConfig}
           />
         ) : (
           <CustomInput

--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -77,7 +77,7 @@ export const geojsonVisConfigs: {
   sizeRange: 'strokeWidthRange';
   radiusRange: 'radiusRange';
   heightRange: 'elevationRange';
-  elevationScale: 'elevationScale';
+  elevationScale: VisConfigNumber;
   stroked: 'stroked';
   filled: 'filled';
   enable3d: 'enable3d';
@@ -92,7 +92,9 @@ export const geojsonVisConfigs: {
   },
   thickness: {
     ...LAYER_VIS_CONFIGS.thickness,
-    defaultValue: 0.5
+    defaultValue: 0.5,
+    focusRange: [0, 1],
+    focusWeight: 0.3
   },
   strokeColor: 'strokeColor',
   colorRange: 'colorRange',
@@ -102,7 +104,11 @@ export const geojsonVisConfigs: {
   sizeRange: 'strokeWidthRange',
   radiusRange: 'radiusRange',
   heightRange: 'elevationRange',
-  elevationScale: 'elevationScale',
+  elevationScale: {
+    ...LAYER_VIS_CONFIGS.elevationScale,
+    focusRange: [0, 1],
+    focusWeight: 0.3
+  },
   stroked: 'stroked',
   filled: 'filled',
   enable3d: 'enable3d',

--- a/src/layers/src/heatmap-layer/heatmap-layer.ts
+++ b/src/layers/src/heatmap-layer/heatmap-layer.ts
@@ -173,7 +173,7 @@ export const heatmapVisConfigs: {
     range: [0.001, 20],
     step: 0.001,
     property: 'intensity',
-    focusRange: [0.001, 1],
+    focusRange: [0.001, 0.5],
     focusWeight: 0.4
   } as VisConfigNumber,
   threshold: {

--- a/src/layers/src/heatmap-layer/heatmap-layer.ts
+++ b/src/layers/src/heatmap-layer/heatmap-layer.ts
@@ -172,7 +172,9 @@ export const heatmapVisConfigs: {
     isRanged: false,
     range: [0.001, 20],
     step: 0.001,
-    property: 'intensity'
+    property: 'intensity',
+    focusRange: [0.001, 1],
+    focusWeight: 0.4
   } as VisConfigNumber,
   threshold: {
     type: 'number',

--- a/src/types/layers.d.ts
+++ b/src/types/layers.d.ts
@@ -244,6 +244,8 @@ export type VisConfigNumber = VisConfig & {
   defaultValue: number;
   range: SizeRange;
   step: number;
+  focusRange?: [number, number];
+  focusWeight?: number;
 };
 
 export type VisConfigBoolean = VisConfig & {

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -193,3 +193,6 @@ export {isAppleDevice} from './browser-utils';
 export {default as quickInsertionSort} from './quick-insertion-sort';
 
 export type {KeplerTableModel} from './types';
+
+export {valueToPosition, positionToValue, createSliderScale} from './slider-scale-utils';
+export type {SliderScaleConfig} from './slider-scale-utils';

--- a/src/utils/src/slider-scale-utils.ts
+++ b/src/utils/src/slider-scale-utils.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+/**
+ * Piecewise-linear mapping utilities for non-linear slider behavior.
+ *
+ * When a slider's useful values are concentrated in a sub-range, these functions
+ * allow that sub-range (the "focus range") to occupy a larger fraction of the
+ * slider's physical width, giving finer control over sensitive values.
+ *
+ * The slider is split into up to three zones:
+ *   [min, focusMin] — "before" zone
+ *   [focusMin, focusMax] — "focus" zone (gets focusWeight of the width)
+ *   [focusMax, max] — "after" zone
+ *
+ * The before and after zones share (1 - focusWeight) proportionally to their
+ * value span relative to the total non-focus span.
+ */
+
+export type SliderScaleConfig = {
+  focusRange: [number, number];
+  focusWeight: number;
+};
+
+/**
+ * Computes the position-space boundaries for the three zones.
+ * Returns [beforeEnd, focusEnd] where:
+ *   before zone occupies [0, beforeEnd]
+ *   focus zone occupies [beforeEnd, focusEnd]
+ *   after zone occupies [focusEnd, 1]
+ */
+function getZoneBoundaries(
+  min: number,
+  max: number,
+  config: SliderScaleConfig
+): [number, number] {
+  const {focusRange, focusWeight} = config;
+  const [focusMin, focusMax] = focusRange;
+
+  const totalSpan = max - min;
+  const beforeSpan = Math.max(0, focusMin - min);
+  const afterSpan = Math.max(0, max - focusMax);
+  const nonFocusSpan = beforeSpan + afterSpan;
+
+  const nonFocusWeight = 1 - focusWeight;
+
+  let beforeWeight: number;
+  if (nonFocusSpan === 0) {
+    beforeWeight = 0;
+  } else {
+    beforeWeight = (beforeSpan / nonFocusSpan) * nonFocusWeight;
+  }
+
+  const beforeEnd = beforeWeight;
+  const focusEnd = beforeWeight + focusWeight;
+
+  return [beforeEnd, focusEnd];
+}
+
+/**
+ * Maps a real value to a normalized position [0, 1] using piecewise-linear scaling.
+ */
+export function valueToPosition(
+  value: number,
+  min: number,
+  max: number,
+  config: SliderScaleConfig
+): number {
+  const {focusRange} = config;
+  const [focusMin, focusMax] = focusRange;
+
+  if (max === min) return 0;
+
+  const v = Math.max(min, Math.min(max, value));
+  const [beforeEnd, focusEnd] = getZoneBoundaries(min, max, config);
+
+  if (v < focusMin) {
+    // Before zone: map [min, focusMin] -> [0, beforeEnd]
+    const span = focusMin - min;
+    if (span === 0) return 0;
+    return ((v - min) / span) * beforeEnd;
+  } else if (v <= focusMax) {
+    // Focus zone: map [focusMin, focusMax] -> [beforeEnd, focusEnd]
+    const span = focusMax - focusMin;
+    if (span === 0) return beforeEnd;
+    return beforeEnd + ((v - focusMin) / span) * (focusEnd - beforeEnd);
+  } else {
+    // After zone: map [focusMax, max] -> [focusEnd, 1]
+    const span = max - focusMax;
+    if (span === 0) return 1;
+    return focusEnd + ((v - focusMax) / span) * (1 - focusEnd);
+  }
+}
+
+/**
+ * Maps a normalized position [0, 1] back to a real value using piecewise-linear scaling.
+ * Inverse of valueToPosition.
+ */
+export function positionToValue(
+  position: number,
+  min: number,
+  max: number,
+  config: SliderScaleConfig
+): number {
+  const {focusRange} = config;
+  const [focusMin, focusMax] = focusRange;
+
+  if (max === min) return min;
+
+  const p = Math.max(0, Math.min(1, position));
+  const [beforeEnd, focusEnd] = getZoneBoundaries(min, max, config);
+
+  if (p < beforeEnd) {
+    // Before zone: map [0, beforeEnd] -> [min, focusMin]
+    const span = focusMin - min;
+    if (beforeEnd === 0) return min;
+    return min + (p / beforeEnd) * span;
+  } else if (p <= focusEnd) {
+    // Focus zone: map [beforeEnd, focusEnd] -> [focusMin, focusMax]
+    const span = focusMax - focusMin;
+    const zoneWeight = focusEnd - beforeEnd;
+    if (zoneWeight === 0) return focusMin;
+    return focusMin + ((p - beforeEnd) / zoneWeight) * span;
+  } else {
+    // After zone: map [focusEnd, 1] -> [focusMax, max]
+    const span = max - focusMax;
+    const zoneWeight = 1 - focusEnd;
+    if (zoneWeight === 0) return max;
+    return focusMax + ((p - focusEnd) / zoneWeight) * span;
+  }
+}
+
+/**
+ * Creates a scale config object if valid focus parameters are provided.
+ * Returns null if no focus config is provided, indicating linear behavior.
+ */
+export function createSliderScale(
+  focusRange?: [number, number],
+  focusWeight?: number
+): SliderScaleConfig | null {
+  if (!focusRange || focusWeight == null || focusWeight <= 0 || focusWeight >= 1) {
+    return null;
+  }
+  return {focusRange, focusWeight};
+}

--- a/src/utils/src/slider-scale-utils.ts
+++ b/src/utils/src/slider-scale-utils.ts
@@ -37,19 +37,17 @@ function getZoneBoundaries(
   const {focusRange, focusWeight} = config;
   const [focusMin, focusMax] = focusRange;
 
-  const totalSpan = max - min;
   const beforeSpan = Math.max(0, focusMin - min);
   const afterSpan = Math.max(0, max - focusMax);
   const nonFocusSpan = beforeSpan + afterSpan;
 
-  const nonFocusWeight = 1 - focusWeight;
-
-  let beforeWeight: number;
+  // When focusRange covers the entire slider span, treat as full-width focus (linear)
   if (nonFocusSpan === 0) {
-    beforeWeight = 0;
-  } else {
-    beforeWeight = (beforeSpan / nonFocusSpan) * nonFocusWeight;
+    return [0, 1];
   }
+
+  const nonFocusWeight = 1 - focusWeight;
+  const beforeWeight = (beforeSpan / nonFocusSpan) * nonFocusWeight;
 
   const beforeEnd = beforeWeight;
   const focusEnd = beforeWeight + focusWeight;
@@ -138,7 +136,15 @@ export function createSliderScale(
   focusRange?: [number, number],
   focusWeight?: number
 ): SliderScaleConfig | null {
-  if (!focusRange || focusWeight == null || focusWeight <= 0 || focusWeight >= 1) {
+  if (
+    !focusRange ||
+    focusWeight == null ||
+    !Number.isFinite(focusWeight) ||
+    !Number.isFinite(focusRange[0]) ||
+    !Number.isFinite(focusRange[1]) ||
+    focusWeight <= 0 ||
+    focusWeight >= 1
+  ) {
     return null;
   }
   return {focusRange, focusWeight};

--- a/test/node/utils/index.js
+++ b/test/node/utils/index.js
@@ -29,3 +29,4 @@ import './dom-to-image';
 import './effect-utils-test';
 import './duckdb-utils-test';
 import './annotation-utils-test';
+import './slider-scale-utils-test';

--- a/test/node/utils/slider-scale-utils-test.js
+++ b/test/node/utils/slider-scale-utils-test.js
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import test from 'tape';
+
+import {valueToPosition, positionToValue, createSliderScale} from '@kepler.gl/utils';
+
+const HEATMAP_CONFIG = {focusRange: [0.001, 1], focusWeight: 0.6};
+
+test('sliderScaleUtils -> createSliderScale', t => {
+  t.equal(createSliderScale(), null, 'returns null when no args');
+  t.equal(createSliderScale(undefined, 0.5), null, 'returns null when no focusRange');
+  t.equal(createSliderScale([0, 1], undefined), null, 'returns null when no focusWeight');
+  t.equal(createSliderScale([0, 1], 0), null, 'returns null when focusWeight is 0');
+  t.equal(createSliderScale([0, 1], 1), null, 'returns null when focusWeight is 1');
+  t.deepEqual(
+    createSliderScale([0, 1], 0.6),
+    {focusRange: [0, 1], focusWeight: 0.6},
+    'returns config when valid'
+  );
+  t.end();
+});
+
+test('sliderScaleUtils -> valueToPosition boundary values (focus at start)', t => {
+  const config = HEATMAP_CONFIG;
+
+  // min value => position 0
+  const posAtMin = valueToPosition(0.001, 0.001, 20, config);
+  t.equal(posAtMin, 0, 'min value maps to position 0');
+
+  // max value => position 1
+  const posAtMax = valueToPosition(20, 0.001, 20, config);
+  t.equal(posAtMax, 1, 'max value maps to position 1');
+
+  // focus boundary value => position equals focusWeight
+  // Since focusRange starts at min (0.001), beforeWeight = 0, so focusEnd = 0.6
+  const posAtFocusBound = valueToPosition(1, 0.001, 20, config);
+  t.ok(
+    Math.abs(posAtFocusBound - 0.6) < 1e-10,
+    'focus boundary maps to focusWeight position'
+  );
+
+  t.end();
+});
+
+test('sliderScaleUtils -> valueToPosition distributes space correctly (focus at start)', t => {
+  const config = HEATMAP_CONFIG;
+
+  // A value halfway through focus range should be at ~0.3 (half of 0.6)
+  const midFocus = (0.001 + 1) / 2; // ~0.5005
+  const posAtMidFocus = valueToPosition(midFocus, 0.001, 20, config);
+  t.ok(
+    Math.abs(posAtMidFocus - 0.3) < 0.01,
+    'midpoint of focus range maps to ~half of focusWeight'
+  );
+
+  // A value halfway through rest range should be at ~0.8 (0.6 + half of 0.4)
+  const midRest = (1 + 20) / 2; // 10.5
+  const posAtMidRest = valueToPosition(midRest, 0.001, 20, config);
+  t.ok(
+    Math.abs(posAtMidRest - 0.8) < 0.01,
+    'midpoint of rest range maps to ~0.8'
+  );
+
+  t.end();
+});
+
+test('sliderScaleUtils -> positionToValue boundary values (focus at start)', t => {
+  const config = HEATMAP_CONFIG;
+
+  // position 0 => min value
+  const valAt0 = positionToValue(0, 0.001, 20, config);
+  t.equal(valAt0, 0.001, 'position 0 maps to min value');
+
+  // position 1 => max value
+  const valAt1 = positionToValue(1, 0.001, 20, config);
+  t.equal(valAt1, 20, 'position 1 maps to max value');
+
+  // position at focusWeight => focus boundary
+  const valAtWeight = positionToValue(0.6, 0.001, 20, config);
+  t.ok(
+    Math.abs(valAtWeight - 1) < 1e-10,
+    'position at focusWeight maps to focus boundary'
+  );
+
+  t.end();
+});
+
+test('sliderScaleUtils -> roundtrip: valueToPosition and positionToValue are inverses', t => {
+  const config = HEATMAP_CONFIG;
+  const testValues = [0.001, 0.1, 0.5, 1, 2, 5, 10, 15, 20];
+
+  testValues.forEach(val => {
+    const pos = valueToPosition(val, 0.001, 20, config);
+    const recovered = positionToValue(pos, 0.001, 20, config);
+    t.ok(
+      Math.abs(recovered - val) < 1e-10,
+      `roundtrip for value ${val}: got ${recovered}`
+    );
+  });
+
+  const testPositions = [0, 0.1, 0.3, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
+  testPositions.forEach(pos => {
+    const val = positionToValue(pos, 0.001, 20, config);
+    const recoveredPos = valueToPosition(val, 0.001, 20, config);
+    t.ok(
+      Math.abs(recoveredPos - pos) < 1e-10,
+      `roundtrip for position ${pos}: got ${recoveredPos}`
+    );
+  });
+
+  t.end();
+});
+
+test('sliderScaleUtils -> mid-range focus: focusRange in the middle of the range', t => {
+  // range [0, 100], focus on [30, 50] with 60% weight
+  const config = {focusRange: [30, 50], focusWeight: 0.6};
+
+  // Boundaries:
+  //   beforeSpan = 30, afterSpan = 50, nonFocusSpan = 80
+  //   beforeWeight = (30/80) * 0.4 = 0.15
+  //   focusEnd = 0.15 + 0.6 = 0.75
+
+  const posAtMin = valueToPosition(0, 0, 100, config);
+  t.equal(posAtMin, 0, 'min value maps to 0');
+
+  const posAtMax = valueToPosition(100, 0, 100, config);
+  t.equal(posAtMax, 1, 'max value maps to 1');
+
+  const posAtFocusMin = valueToPosition(30, 0, 100, config);
+  t.ok(Math.abs(posAtFocusMin - 0.15) < 1e-10, 'focusMin (30) maps to beforeEnd (0.15)');
+
+  const posAtFocusMax = valueToPosition(50, 0, 100, config);
+  t.ok(Math.abs(posAtFocusMax - 0.75) < 1e-10, 'focusMax (50) maps to focusEnd (0.75)');
+
+  // Mid of focus range (40) should map to middle of focus zone: (0.15+0.75)/2 = 0.45
+  const posAtMidFocus = valueToPosition(40, 0, 100, config);
+  t.ok(Math.abs(posAtMidFocus - 0.45) < 1e-10, 'mid focus (40) maps to 0.45');
+
+  // Mid of before zone (15) maps to 0.075
+  const posAtMidBefore = valueToPosition(15, 0, 100, config);
+  t.ok(Math.abs(posAtMidBefore - 0.075) < 1e-10, 'mid before (15) maps to 0.075');
+
+  // Mid of after zone (75) maps to (0.75 + 1)/2 = 0.875
+  const posAtMidAfter = valueToPosition(75, 0, 100, config);
+  t.ok(Math.abs(posAtMidAfter - 0.875) < 1e-10, 'mid after (75) maps to 0.875');
+
+  t.end();
+});
+
+test('sliderScaleUtils -> mid-range focus: positionToValue inverse', t => {
+  const config = {focusRange: [30, 50], focusWeight: 0.6};
+  const testValues = [0, 10, 15, 30, 35, 40, 50, 60, 75, 100];
+
+  testValues.forEach(val => {
+    const pos = valueToPosition(val, 0, 100, config);
+    const recovered = positionToValue(pos, 0, 100, config);
+    t.ok(
+      Math.abs(recovered - val) < 1e-10,
+      `mid-range roundtrip for value ${val}: got ${recovered}`
+    );
+  });
+
+  t.end();
+});
+
+test('sliderScaleUtils -> focus range at the end of the range', t => {
+  // range [0, 100], focus on [80, 100] with 0.5 weight
+  const config = {focusRange: [80, 100], focusWeight: 0.5};
+
+  // beforeSpan = 80, afterSpan = 0, nonFocusSpan = 80
+  // beforeWeight = (80/80) * 0.5 = 0.5
+  // focusEnd = 0.5 + 0.5 = 1.0
+
+  const posAt0 = valueToPosition(0, 0, 100, config);
+  t.equal(posAt0, 0, 'min maps to 0');
+
+  const posAt80 = valueToPosition(80, 0, 100, config);
+  t.ok(Math.abs(posAt80 - 0.5) < 1e-10, 'focusMin (80) maps to 0.5');
+
+  const posAt100 = valueToPosition(100, 0, 100, config);
+  t.ok(Math.abs(posAt100 - 1) < 1e-10, 'max (100) maps to 1');
+
+  const posAt90 = valueToPosition(90, 0, 100, config);
+  t.ok(Math.abs(posAt90 - 0.75) < 1e-10, 'mid focus (90) maps to 0.75');
+
+  // Roundtrip
+  const testValues = [0, 20, 40, 60, 80, 85, 90, 95, 100];
+  testValues.forEach(val => {
+    const pos = valueToPosition(val, 0, 100, config);
+    const recovered = positionToValue(pos, 0, 100, config);
+    t.ok(
+      Math.abs(recovered - val) < 1e-10,
+      `end-focus roundtrip for value ${val}: got ${recovered}`
+    );
+  });
+
+  t.end();
+});
+
+test('sliderScaleUtils -> handles edge cases', t => {
+  const config = {focusRange: [0, 5], focusWeight: 0.5};
+
+  // equal min and max
+  t.equal(valueToPosition(5, 5, 5, config), 0, 'returns 0 when min equals max');
+  t.equal(positionToValue(0.5, 5, 5, config), 5, 'returns min when min equals max');
+
+  // values clamped to range
+  t.equal(valueToPosition(-1, 0, 10, config), 0, 'clamps below-min values to 0');
+  t.equal(valueToPosition(15, 0, 10, config), 1, 'clamps above-max values to 1');
+
+  // positions clamped to [0,1]
+  t.equal(positionToValue(-0.5, 0, 10, config), 0, 'clamps negative positions');
+  t.equal(positionToValue(1.5, 0, 10, config), 10, 'clamps positions above 1');
+
+  t.end();
+});

--- a/test/node/utils/slider-scale-utils-test.js
+++ b/test/node/utils/slider-scale-utils-test.js
@@ -215,3 +215,34 @@ test('sliderScaleUtils -> handles edge cases', t => {
 
   t.end();
 });
+
+test('sliderScaleUtils -> focusRange covers entire slider span (degenerates to linear)', t => {
+  // When focusRange === [min, max], there's no before/after zone
+  const config = {focusRange: [0, 100], focusWeight: 0.6};
+
+  // Should behave linearly: position = (value - min) / (max - min)
+  t.equal(valueToPosition(0, 0, 100, config), 0, 'min maps to 0');
+  t.equal(valueToPosition(100, 0, 100, config), 1, 'max maps to 1');
+  t.equal(valueToPosition(50, 0, 100, config), 0.5, 'midpoint maps to 0.5');
+  t.equal(valueToPosition(25, 0, 100, config), 0.25, '25 maps to 0.25');
+
+  t.equal(positionToValue(0, 0, 100, config), 0, 'position 0 maps to min');
+  t.equal(positionToValue(1, 0, 100, config), 100, 'position 1 maps to max');
+  t.equal(positionToValue(0.5, 0, 100, config), 50, 'position 0.5 maps to midpoint');
+
+  t.end();
+});
+
+test('sliderScaleUtils -> createSliderScale rejects non-finite inputs', t => {
+  t.equal(createSliderScale([NaN, 1], 0.5), null, 'rejects NaN in focusRange[0]');
+  t.equal(createSliderScale([0, NaN], 0.5), null, 'rejects NaN in focusRange[1]');
+  t.equal(createSliderScale([0, 1], NaN), null, 'rejects NaN focusWeight');
+  t.equal(createSliderScale([0, Infinity], 0.5), null, 'rejects Infinity in focusRange');
+  t.equal(createSliderScale([0, 1], Infinity), null, 'rejects Infinity focusWeight');
+  t.deepEqual(
+    createSliderScale([0, 1], 0.5),
+    {focusRange: [0, 1], focusWeight: 0.5},
+    'accepts valid finite inputs'
+  );
+  t.end();
+});


### PR DESCRIPTION
Adds focusRange and focusWeight options to VisConfigNumber sliders, allowing a configurable sub-range to occupy a disproportionately larger portion of the slider's physical width for finer control. Applied to heatmap intensity (0–1 range gets 60% of slider space out of the full 0–20 range). The slider splits into up to three zones (before, focus, after) with proportional width distribution.

Example: The heatmap intensity slider has a range of 0 to 20, but in practice, most useful adjustments happen between 0 and 1. With a linear slider, that entire 0–1 sweet spot occupies only 5% of the slider's pixel width — just a few pixels — making precise adjustments nearly impossible. This change lets the 0–1 range take up 40% of the slider, so users can fine-tune intensity without fighting the UI.