### PR TITLE
fix placement add by dataset button

### DIFF
--- a/src/components/src/side-panel/add-by-dataset-button.tsx
+++ b/src/components/src/side-panel/add-by-dataset-button.tsx
@@ -44,7 +44,7 @@ const DropdownMenu = styled.div.attrs({
   max-width: 240px;
   position: absolute;
   top: 100%;
-  left: -53px;
+  left: -120px;
   z-index: 5;
 `;
 
@@ -149,7 +149,7 @@ const AddByDatasetButton: React.FC<AddByDatasetButtonProps> = ({
           trigger="click"
           arrow={false}
           interactive
-          placement="bottom"
+          placement="left-end"
           appendTo={context?.current || 'parent'}
           // @ts-ignore
           onCreate={setTippyInstance}


### PR DESCRIPTION
Fix placement so the two dropdowns match 
<img width="329" height="538" alt="Screenshot 2026-05-28 at 13 41 09" src="https://github.com/user-attachments/assets/675da995-6aed-488f-8c2f-d623250ad543" />
<img width="304" height="603" alt="Screenshot 2026-05-28 at 13 41 21" src="https://github.com/user-attachments/assets/bd237e86-bf21-4bc1-b67b-b7b6089ea531" />
