### PR TITLE
feat(demo-app): Add WMS, raster tile, bitmap, and 3D tile layer examples

### DIFF
--- a/docs/user-guides/c-types-of-layers/README.md
+++ b/docs/user-guides/c-types-of-layers/README.md
@@ -126,7 +126,6 @@ Supported URL templates:
 
   Examples of raster .pmtiles:
 
-  - Mount Whitney - https://pmtiles.io/usgs-mt-whitney-8-15-webp-512.pmtiles
   - Swiss historical - https://public-bucket-for-tests.s3.us-east-1.amazonaws.com/historic-swis-18xx.pmtiles
 
   Examples of supported STAC Items:

--- a/docs/user-guides/c-types-of-layers/n-raster-tile-layer.md
+++ b/docs/user-guides/c-types-of-layers/n-raster-tile-layer.md
@@ -38,7 +38,6 @@ To enable elevation rendering, you must provide one or more compatible raster ti
 
 Example Raster .pmtiles:
 
-- Mount Whitney - https://pmtiles.io/usgs-mt-whitney-8-15-webp-512.pmtiles
 - Swiss historical - https://public-bucket-for-tests.s3.us-east-1.amazonaws.com/historic-swis-18xx.pmtiles
 
 Example STAC Items:

--- a/examples/demo-app/src/app.tsx
+++ b/examples/demo-app/src/app.tsx
@@ -619,6 +619,159 @@ const App = props => {
     );
   }, [dispatch]);
 
+  const _loadWmsLayer = useCallback(() => {
+    dispatch(
+      addDataToMap({
+        datasets: [
+          {
+            info: {
+              label: 'OpenStreetMap WMS',
+              id: 'osm-wms',
+              type: 'wms-tile'
+            },
+            data: {
+              fields: [],
+              rows: []
+            },
+            metadata: {
+              type: 'remote',
+              remoteTileFormat: 'wms',
+              tilesetDataUrl: 'https://ows.terrestris.de/osm/service',
+              tilesetMetadataUrl:
+                'https://ows.terrestris.de/osm/service?service=WMS&request=GetCapabilities',
+              version: '1.1.1',
+              layers: [
+                {
+                  name: 'OSM-WMS',
+                  title: 'OpenStreetMap WMS',
+                  boundingBox: [-180, -88, 180, 88]
+                }
+              ],
+              label: 'OpenStreetMap WMS'
+            },
+            disableDataOperation: true
+          }
+        ],
+        options: {
+          autoCreateLayers: true,
+          centerMap: true
+        }
+      })
+    );
+  }, [dispatch]);
+
+  const _loadRasterTileLayer = useCallback(() => {
+    dispatch(
+      addDataToMap({
+        datasets: [
+          {
+            info: {
+              label: 'Swiss Historical Map',
+              id: 'swiss-historical-raster',
+              type: 'raster-tile'
+            },
+            data: {
+              fields: [],
+              rows: []
+            },
+            metadata: {
+              metadataUrl:
+                'https://public-bucket-for-tests.s3.us-east-1.amazonaws.com/historic-swis-18xx.pmtiles',
+              pmtilesType: 'raster'
+            },
+            disableDataOperation: true
+          }
+        ],
+        options: {
+          autoCreateLayers: true,
+          centerMap: true
+        }
+      })
+    );
+  }, [dispatch]);
+
+  const _loadBitmapLayer = useCallback(() => {
+    dispatch(
+      addDataToMap({
+        datasets: [
+          {
+            info: {
+              label: 'SF Bitmap Overlay',
+              id: 'sf-bitmap',
+              type: 'bitmap'
+            },
+            data: {
+              fields: [],
+              rows: []
+            },
+            metadata: {
+              imageUrl:
+                'https://raw.githubusercontent.com/visgl/deck.gl-data/master/website/sf-districts.png',
+              bounds: [-122.5179, 37.70391916246189, -122.35462834588868, 37.830428246756696]
+            },
+            disableDataOperation: true
+          }
+        ],
+        options: {
+          autoCreateLayers: true,
+          centerMap: true
+        }
+      })
+    );
+  }, [dispatch]);
+
+  const _loadTile3DLayer = useCallback(() => {
+    dispatch(
+      addDataToMap({
+        datasets: [
+          {
+            info: {
+              label: 'Royal Exhibition Building',
+              id: 'royal-exhibition-3d',
+              type: 'tile-3d'
+            },
+            data: {
+              fields: [],
+              rows: []
+            },
+            metadata: {
+              tile3dUrl:
+                'https://raw.githubusercontent.com/visgl/deck.gl-data/master/3d-tiles/RoyalExhibitionBuilding/tileset.json'
+            },
+            disableDataOperation: true
+          }
+        ],
+        config: {
+          version: 'v1',
+          config: {
+            visState: {
+              effects: [
+                {
+                  type: 'surfaceFog',
+                  isEnabled: true,
+                  parameters: {
+                    density: 1,
+                    height: 40,
+                    thickness: 50,
+                    fogColor: [70, 130, 180]
+                  }
+                }
+              ]
+            },
+            mapState: {
+              pitch: 0,
+              dragRotate: false
+            }
+          }
+        },
+        options: {
+          autoCreateLayers: true,
+          centerMap: true
+        }
+      })
+    );
+  }, [dispatch]);
+
   const _loadSampleData = useCallback(() => {
     // _loadPointData();
     // _loadGeojsonData();
@@ -631,6 +784,10 @@ const App = props => {
     // _loadRowData();
     // _loadVectorTileData();
     // _loadFlowData();
+    //_loadWmsLayer();
+    //_loadRasterTileLayer();
+    //_loadBitmapLayer();
+    // _loadTile3DLayer();
     // _loadSyncedFilterWTripLayer();
     // _replaceSyncedFilterWTripLayer();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -647,6 +804,10 @@ const App = props => {
     _replaceData,
     _loadVectorTileData,
     _loadFlowData,
+    _loadWmsLayer,
+    _loadRasterTileLayer,
+    _loadBitmapLayer,
+    _loadTile3DLayer,
     _loadSyncedFilterWTripLayer,
     _replaceSyncedFilterWTripLayer
   ]);

--- a/src/components/src/modals/tilesets-modals/tileset-raster-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-raster-form.tsx
@@ -155,11 +155,6 @@ const RASTER_TILE_EXAMPLES = [
   },
   {
     label: 'PMTiles',
-    name: 'Mt Whitney',
-    url: 'https://pmtiles.io/usgs-mt-whitney-8-15-webp-512.pmtiles'
-  },
-  {
-    label: 'PMTiles',
     name: 'Swiss Historical',
     url: 'https://public-bucket-for-tests.s3.us-east-1.amazonaws.com/historic-swis-18xx.pmtiles'
   },


### PR DESCRIPTION
## Summary
Adds programmatic example functions for all missing tile-based layer types in the demo app, addressing the question raised in https://github.com/keplergl/kepler.gl/discussions/3353 about loading WMS layers on startup.
- Add `_loadWmsLayer` using public OpenStreetMap WMS service
- Add `_loadRasterTileLayer` using Swiss Historical raster PMTiles
- Add `_loadBitmapLayer` using deck.gl SF Districts PNG overlay
- Add `_loadTile3DLayer` using Royal Exhibition Building 3D tileset (with surface fog effect)
- Fix broken PMTiles example URL in raster tile form (replace `pmtiles.io` with S3-hosted file)
## Details
Each function demonstrates how to programmatically add a tile-based layer via `addDataToMap` with the correct dataset `type`, `metadata` structure, and `autoCreateLayers: true` option. Developers can uncomment any example in `_loadSampleData()` to test.