### PR TITLE
fix: fix tooltip comparisson for aggregation layers

### DIFF
--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -256,7 +256,7 @@ const CellInfo = ({
   }, [fieldsToShow, sizeField, layer, data.elevationValue]);
 
   const colorDelta = useMemo(() => {
-    if (!primaryData || !colorField) return null;
+    if (!primaryData || !colorField || !('colorValue' in primaryData)) return null;
     return getTooltipDisplayDeltaValue({
       field: colorField,
       value: data.colorValue,
@@ -266,7 +266,7 @@ const CellInfo = ({
   }, [primaryData, colorField, data.colorValue, compareType]);
 
   const elevationDelta = useMemo(() => {
-    if (!primaryData || !sizeField) return null;
+    if (!primaryData || !sizeField || !('elevationValue' in primaryData)) return null;
     return getTooltipDisplayDeltaValue({
       field: sizeField,
       value: data.elevationValue,
@@ -337,7 +337,7 @@ const CellInfo = ({
         <Row
           name={dataForField.name}
           key={`data_${idx}`}
-          value={dataForField.value || 'N/A'}
+          value={dataForField.value != null ? String(dataForField.value) : 'N/A'}
           deltaValue={dataForField.deltaValue}
           isComparing={isComparing}
         />

--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -223,17 +223,21 @@ const EntryInfoRow: React.FC<EntryInfoRowProps> = ({
   );
 };
 
-// TODO: supporting comparative value for aggregated cells as well
 const CellInfo = ({
   fieldsToShow,
   data,
-  layer
+  layer,
+  primaryData,
+  compareType
 }: {
   data: AggregationLayerHoverData;
   fieldsToShow: TooltipField[];
   layer: Layer;
+  primaryData?: AggregationLayerHoverData | null;
+  compareType?: CompareType;
 }) => {
   const {colorField, sizeField} = layer.config as any;
+  const isComparing = Boolean(primaryData);
 
   const colorValue = useMemo(() => {
     if (colorField && layer.visualChannels.color) {
@@ -251,35 +255,92 @@ const CellInfo = ({
     return null;
   }, [fieldsToShow, sizeField, layer, data.elevationValue]);
 
+  const colorDelta = useMemo(() => {
+    if (!primaryData || !colorField) return null;
+    return getTooltipDisplayDeltaValue({
+      field: colorField,
+      value: data.colorValue,
+      primaryValue: primaryData.colorValue,
+      compareType
+    });
+  }, [primaryData, colorField, data.colorValue, compareType]);
+
+  const elevationDelta = useMemo(() => {
+    if (!primaryData || !sizeField) return null;
+    return getTooltipDisplayDeltaValue({
+      field: sizeField,
+      value: data.elevationValue,
+      primaryValue: primaryData.elevationValue,
+      compareType
+    });
+  }, [primaryData, sizeField, data.elevationValue, compareType]);
+
   const aggregatedData = useMemo(() => {
     if (data.aggregatedData && fieldsToShow) {
-      return fieldsToShow.reduce((acc, field) => {
-        const dataForField = data.aggregatedData?.[field.name];
-        if (dataForField?.measure && field.name !== colorField?.name) {
-          acc.push({
-            name: `${capitalizeFirstLetter(dataForField.measure)} of ${field.name}`,
-            value: dataForField.value
-          });
-        }
-        return acc;
-      }, [] as {name: string; value?: string}[]);
+      return fieldsToShow.reduce(
+        (acc, field) => {
+          const dataForField = data.aggregatedData?.[field.name];
+          if (dataForField?.measure && field.name !== colorField?.name) {
+            const primaryDataForField = primaryData?.aggregatedData?.[field.name];
+            const deltaValue = primaryDataForField
+              ? getTooltipDisplayDeltaValue({
+                  field: {type: 'real', name: field.name} as Field,
+                  value: dataForField.value != null ? Number(dataForField.value) : null,
+                  primaryValue:
+                    primaryDataForField.value != null ? Number(primaryDataForField.value) : null,
+                  compareType
+                })
+              : null;
+            acc.push({
+              name: `${capitalizeFirstLetter(dataForField.measure)} of ${field.name}`,
+              value: dataForField.value,
+              deltaValue
+            });
+          }
+          return acc;
+        },
+        [] as {name: string; value?: string; deltaValue: string | null}[]
+      );
     }
     return [];
-  }, [data.aggregatedData, fieldsToShow, colorField?.name]);
+  }, [data.aggregatedData, fieldsToShow, colorField?.name, primaryData, compareType]);
 
   const colorMeasure = layer.getVisualChannelDescription('color').measure;
   const sizeMeasure = layer.getVisualChannelDescription('size').measure;
   return (
     <tbody>
-      <Row name={'total points'} key="count" value={String(data.points && data.points.length)} />
+      <Row
+        name={'total points'}
+        key="count"
+        value={String(data.points && data.points.length)}
+        isComparing={isComparing}
+      />
       {colorField && layer.visualChannels.color && colorMeasure ? (
-        <Row name={colorMeasure} key="color" value={colorValue || 'N/A'} />
+        <Row
+          name={colorMeasure}
+          key="color"
+          value={colorValue || 'N/A'}
+          deltaValue={colorDelta}
+          isComparing={isComparing}
+        />
       ) : null}
       {sizeField && layer.visualChannels.size && sizeMeasure ? (
-        <Row name={sizeMeasure} key="size" value={elevationValue || 'N/A'} />
+        <Row
+          name={sizeMeasure}
+          key="size"
+          value={elevationValue || 'N/A'}
+          deltaValue={elevationDelta}
+          isComparing={isComparing}
+        />
       ) : null}
       {aggregatedData.map((dataForField, idx) => (
-        <Row name={dataForField.name} key={`data_${idx}`} value={dataForField.value || 'N/A'} />
+        <Row
+          name={dataForField.name}
+          key={`data_${idx}`}
+          value={dataForField.value || 'N/A'}
+          deltaValue={dataForField.deltaValue}
+          isComparing={isComparing}
+        />
       ))}
     </tbody>
   );


### PR DESCRIPTION
- Fix broken tooltip layout in compare mode for aggregation layers (e.g., Grid, Hexbin) where rows were misaligned due to CellInfo rendering 2 columns in a 3-column CSS grid
- Add delta value calculation support to CellInfo for colorValue, elevationValue, and aggregatedData fields, matching the comparison behavior already working in point layers

<img width="603" height="553" alt="Screenshot 2026-07-04 at 7 54 55 PM" src="https://github.com/user-attachments/assets/14da9857-a987-4156-8423-ef596baeee42" />

<img width="556" height="574" alt="Screenshot 2026-07-04 at 7 54 22 PM" src="https://github.com/user-attachments/assets/76e012fa-4af5-4470-b4e1-d2e19ac28e06" />
