### PR TITLE
fix: video export resolution not applied in standard mode

### DIFF
--- a/src/components/src/modals/export-video-modal.spec.tsx
+++ b/src/components/src/modals/export-video-modal.spec.tsx
@@ -92,7 +92,7 @@ const DEFAULT_PROPS = {
     mediaType: 'webm',
     cameraPreset: 'None',
     fileName: 'kepler.gl',
-    resolution: '',
+    resolution: '1280x720',
     durationMs: 1000
   },
   containerW: 800,

--- a/src/components/src/modals/export-video-modal.tsx
+++ b/src/components/src/modals/export-video-modal.tsx
@@ -376,38 +376,7 @@ const ExportVideoModalFactory = () => {
       [keplerState, onViewChange, mapboxApiAccessToken, mapboxApiUrl]
     );
 
-    const trueDevicePixelRatio = useRef(
-      typeof window !== 'undefined' ? window.devicePixelRatio : 1
-    );
-
     const isSwipeMode = mapState.mapSplitMode === MapSplitMode.SWIPE_COMPARE && mapState.isSplit;
-
-    useEffect(() => {
-      // Block DPR changes during preview to keep basemap and deck.gl layers in sync.
-      // hubble.gl sets window.devicePixelRatio to scale render buffers, but this causes
-      // visual misalignment between MapLibre and DeckGL during animated preview.
-      // Skip in swipe mode — the swipe preview manages its own DPR for canvas compositing.
-      if (isSwipeMode) return;
-
-      const trueDpr = trueDevicePixelRatio.current;
-      const descriptor = Object.getOwnPropertyDescriptor(window, 'devicePixelRatio');
-
-      Object.defineProperty(window, 'devicePixelRatio', {
-        get: () => trueDpr,
-        set: () => {
-          // no-op: prevent hubble.gl from changing DPR during preview
-        },
-        configurable: true
-      });
-
-      return () => {
-        if (descriptor) {
-          Object.defineProperty(window, 'devicePixelRatio', descriptor);
-        } else {
-          delete (window as any).devicePixelRatio;
-        }
-      };
-    }, [isSwipeMode]);
 
     const onFilterFrameUpdate = useCallback(
       (filterIdx: number, name: string, value: any) => {

--- a/src/reducers/src/ui-state-updaters.ts
+++ b/src/reducers/src/ui-state-updaters.ts
@@ -231,7 +231,7 @@ export const DEFAULT_EXPORT_MAP: ExportMap = {
  * @property mediaType Default: `'webm'`
  * @property cameraPreset Default: `'None'`
  * @property fileName Default: `'kepler.gl'`
- * @property resolution Default: `''`
+ * @property resolution Default: `'1280x720'`
  * @property durationMs Default: `1000`
  * @public
  */
@@ -239,7 +239,7 @@ export const DEFAULT_EXPORT_VIDEO: ExportVideo = {
   mediaType: 'webm', // use webm as default as gif export tends to freeze on larger recordings
   cameraPreset: 'None',
   fileName: 'kepler.gl',
-  resolution: '',
+  resolution: '1280x720',
   durationMs: 1000,
   swipeStartPct: 0,
   swipeEndPct: 100,


### PR DESCRIPTION
The Quality dropdown in the video export modal had no default and its selection was ignored during recording in standard (non-swipe) mode.

- DEFAULT_EXPORT_VIDEO.resolution was '' (empty string), which overrode hubble.gl's internal '1280x720' default and left the Quality dropdown blank.
- A window.devicePixelRatio override (added to prevent preview misalignment) used a no-op setter that silently blocked hubble.gl from scaling render buffers to the target resolution, causing all recorded videos to be captured at preview size regardless of the selected quality. Removed the override so hubble.gl's own DPR mechanism works as designed.