### PR TITLE
fix: fix tooltip comparison for vector tile layers

### DIFF
--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -182,31 +182,24 @@ const EntryInfoRow: React.FC<EntryInfoRowProps> = ({
   const fieldValueAccessor = layer.accessVSFieldValue(field, currentTime);
   const value = fieldValueAccessor(field, data instanceof DataRow ? {index: data._rowIndex} : data);
 
-  // Handle WMS layer data in comparison mode - WMS layers don't have comparable field data
   let primaryValue = null;
   let displayDeltaValue: string | null = null;
 
   if (primaryData) {
     try {
-      // Only calculate primary value if primaryData has a compatible structure
-      if (
-        primaryData instanceof DataRow ||
-        (primaryData && typeof primaryData === 'object' && 'index' in primaryData)
-      ) {
-        primaryValue = fieldValueAccessor(
-          field,
-          primaryData instanceof DataRow ? {index: primaryData._rowIndex} : primaryData
-        );
-
-        displayDeltaValue = getTooltipDisplayDeltaValue({
-          field,
-          value,
-          primaryValue,
-          compareType
-        });
+      if (primaryData instanceof DataRow) {
+        primaryValue = fieldValueAccessor(field, {index: primaryData._rowIndex});
+      } else if (Array.isArray(primaryData) || (typeof primaryData === 'object' && primaryData)) {
+        primaryValue = fieldValueAccessor(field, primaryData);
       }
+
+      displayDeltaValue = getTooltipDisplayDeltaValue({
+        field,
+        value,
+        primaryValue,
+        compareType
+      });
     } catch (error) {
-      // If there's an error accessing primaryData (e.g., WMS layer data), skip comparison
       primaryValue = null;
     }
   }

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -58,11 +58,11 @@ export type AggregationLayerHoverData = {
 };
 
 export type LayerHoverProp = {
-  data: DataRow | AggregationLayerHoverData | null;
+  data: DataRow | AggregationLayerHoverData | any[] | null;
   fields: Field[];
   fieldsToShow: TooltipField[];
   layer: Layer;
-  primaryData?: DataRow | AggregationLayerHoverData | null;
+  primaryData?: DataRow | AggregationLayerHoverData | any[] | null;
   compareType?: CompareType;
   currentTime?: VisState['animationConfig']['currentTime'];
 };

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -837,7 +837,7 @@ export function addLayerToLayerOrder(
 }
 
 export function getLayerHoverPropValue(
-  data: DataRow | AggregationLayerHoverData | null | undefined,
+  data: DataRow | AggregationLayerHoverData | any[] | null | undefined,
   fieldIndex: number
 ) {
   if (!data) return undefined;


### PR DESCRIPTION
- Fix tooltip comparison (pinned vs hover) not working for Vector Tile layers by relaxing the guard condition in EntryInfoRow that prevented non-DataRow data from being used for delta computation
