### PR TITLE
feat: optional background stars in globe mode

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -627,7 +627,8 @@ export default function MapContainerFactory(
     mapStyleBackgroundColorSelector = props => props.mapStyle.backgroundColor;
     globeModeSelector = props => Boolean(props.mapState?.globe?.enabled);
     globeBackgroundColorSelector = props => props.mapState?.globe?.config?.backgroundColor;
-    globeStarsSelector = props => Boolean(props.mapState?.globe?.config?.stars);
+    // Stars are enabled by default; only an explicit `false` disables them.
+    globeStarsSelector = props => props.mapState?.globe?.config?.stars !== false;
     styleSelector = createSelector(
       this.mapStyleTypeSelector,
       this.mapStyleBackgroundColorSelector,
@@ -650,7 +651,7 @@ export default function MapContainerFactory(
               // Optionally overlay a tileable star-field pattern on the background.
               ...(globeStars
                 ? {
-                    backgroundImage: `url(${getStarsBackgroundImage()})`,
+                    backgroundImage: `url('${getStarsBackgroundImage()}')`,
                     backgroundRepeat: 'repeat'
                   }
                 : {})

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -89,6 +89,7 @@ import {
   getGlobeClearColor,
   getGlobeBasemapAttributions,
   resolveGlobeBasemapProvider,
+  getStarsBackgroundImage,
   KeplerGlobeView
 } from '@kepler.gl/deckgl-layers';
 import type {GlobeAttribution} from '@kepler.gl/deckgl-layers';
@@ -626,12 +627,14 @@ export default function MapContainerFactory(
     mapStyleBackgroundColorSelector = props => props.mapStyle.backgroundColor;
     globeModeSelector = props => Boolean(props.mapState?.globe?.enabled);
     globeBackgroundColorSelector = props => props.mapState?.globe?.config?.backgroundColor;
+    globeStarsSelector = props => Boolean(props.mapState?.globe?.config?.stars);
     styleSelector = createSelector(
       this.mapStyleTypeSelector,
       this.mapStyleBackgroundColorSelector,
       this.globeModeSelector,
       this.globeBackgroundColorSelector,
-      (styleType, backgroundColor, isGlobeMode, globeBackgroundColor) => ({
+      this.globeStarsSelector,
+      (styleType, backgroundColor, isGlobeMode, globeBackgroundColor, globeStars) => ({
         ...MAP_STYLE.container,
         ...(styleType === NO_MAP_ID ? {backgroundColor: rgbToHex(backgroundColor)} : {}),
         // In globe mode the deck.gl canvas is transparent (the globe View uses
@@ -643,7 +646,14 @@ export default function MapContainerFactory(
               backgroundColor: rgbToHex(
                 (globeBackgroundColor as [number, number, number]) ||
                   (getGlobeClearColor().slice(0, 3) as [number, number, number])
-              )
+              ),
+              // Optionally overlay a tileable star-field pattern on the background.
+              ...(globeStars
+                ? {
+                    backgroundImage: `url(${getStarsBackgroundImage()})`,
+                    backgroundRepeat: 'repeat'
+                  }
+                : {})
             }
           : {})
       })

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -627,8 +627,7 @@ export default function MapContainerFactory(
     mapStyleBackgroundColorSelector = props => props.mapStyle.backgroundColor;
     globeModeSelector = props => Boolean(props.mapState?.globe?.enabled);
     globeBackgroundColorSelector = props => props.mapState?.globe?.config?.backgroundColor;
-    // Stars are enabled by default; only an explicit `false` disables them.
-    globeStarsSelector = props => props.mapState?.globe?.config?.stars !== false;
+    globeStarsSelector = props => Boolean(props.mapState?.globe?.config?.stars);
     styleSelector = createSelector(
       this.mapStyleTypeSelector,
       this.mapStyleBackgroundColorSelector,

--- a/src/components/src/side-panel/map-style-panel/globe-config-panel.tsx
+++ b/src/components/src/side-panel/map-style-panel/globe-config-panel.tsx
@@ -342,6 +342,24 @@ function GlobeConfigPanelFactory(
               disabled={false}
             />
           </StyledConfigRow>
+
+          {/* Stars (rendered behind the globe in 3D space) */}
+          <StyledConfigRow>
+            <PanelLabelWrapper>
+              <PanelHeaderAction
+                className="layer-group__visibility-toggle"
+                id="globe-stars-toggle"
+                tooltip={globeConfig.stars ? 'tooltip.hide' : 'tooltip.show'}
+                onClick={() => onToggle('stars')}
+                IconComponent={globeConfig.stars ? EyeSeen : EyeUnseen}
+                active={globeConfig.stars}
+                flush
+              />
+              <LayerLabel $active={globeConfig.stars}>
+                <FormattedMessage id="mapLayers.stars" />
+              </LayerLabel>
+            </PanelLabelWrapper>
+          </StyledConfigRow>
         </PanelContent>
       </StyledGlobeConfigPanel>
     );

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1418,7 +1418,7 @@ export const DEFAULT_GLOBE_CONFIG: GlobeConfig = {
   // Color of the empty space rendered around the globe (deck.gl clear color).
   // Matches the previous hardcoded clear color [0.015, 0.035, 0.065] in 0-1 space.
   backgroundColor: [4, 9, 17],
-  stars: true
+  stars: false
 };
 
 export const GLOBE_SUPPORTED_LAYERS: Record<string, boolean> = {

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1392,6 +1392,7 @@ export type GlobeConfig = {
   surfaceColor: [number, number, number];
   surface: boolean;
   backgroundColor: [number, number, number];
+  stars: boolean;
 };
 
 export type Globe = {
@@ -1416,7 +1417,8 @@ export const DEFAULT_GLOBE_CONFIG: GlobeConfig = {
   surfaceColor: [9, 16, 29],
   // Color of the empty space rendered around the globe (deck.gl clear color).
   // Matches the previous hardcoded clear color [0.015, 0.035, 0.065] in 0-1 space.
-  backgroundColor: [4, 9, 17]
+  backgroundColor: [4, 9, 17],
+  stars: true
 };
 
 export const GLOBE_SUPPORTED_LAYERS: Record<string, boolean> = {

--- a/src/deckgl-layers/src/globe/globe-stars-layer.ts
+++ b/src/deckgl-layers/src/globe/globe-stars-layer.ts
@@ -20,6 +20,12 @@ function seededRandom(seed: number): () => number {
   };
 }
 
+// Transparent 1x1 PNG used as a fallback when a canvas context is unavailable
+// (SSR or unsupported browser), so that `url(...)` never resolves to an empty
+// value that could trigger a request for the current document.
+const TRANSPARENT_PIXEL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+
 let cachedDataUrl: string | null = null;
 
 /**
@@ -31,14 +37,14 @@ export function getStarsBackgroundImage(): string {
 
   if (typeof document === 'undefined') {
     // SSR fallback: return a transparent 1x1 pixel to avoid url() triggering a page request
-    return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+    return TRANSPARENT_PIXEL;
   }
 
   const canvas = document.createElement('canvas');
   canvas.width = STAR_CANVAS_SIZE;
   canvas.height = STAR_CANVAS_SIZE;
   const ctx = canvas.getContext('2d');
-  if (!ctx) return '';
+  if (!ctx) return (cachedDataUrl = TRANSPARENT_PIXEL);
 
   // Transparent background so CSS backgroundColor shows through
   ctx.clearRect(0, 0, STAR_CANVAS_SIZE, STAR_CANVAS_SIZE);

--- a/src/deckgl-layers/src/globe/globe-stars-layer.ts
+++ b/src/deckgl-layers/src/globe/globe-stars-layer.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+/**
+ * Generates a CSS-compatible star-field background image as a data URL.
+ * The stars are rendered onto an offscreen canvas, tiled seamlessly via CSS
+ * `background-repeat`. The result is deterministic (seeded PRNG) and cached
+ * so it's only generated once.
+ */
+
+const STAR_CANVAS_SIZE = 512;
+const STAR_COUNT = 600;
+
+// Seeded pseudo-random number generator (Park-Miller) for determinism.
+function seededRandom(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s = (s * 16807) % 2147483647;
+    return (s - 1) / 2147483646;
+  };
+}
+
+let cachedDataUrl: string | null = null;
+
+/**
+ * Returns a data URL of a tileable star-field image (512×512 PNG).
+ * Generates the image once and caches it for subsequent calls.
+ */
+export function getStarsBackgroundImage(): string {
+  if (cachedDataUrl) return cachedDataUrl;
+
+  if (typeof document === 'undefined') {
+    // SSR fallback: return a transparent 1x1 pixel to avoid url() triggering a page request
+    return 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=';
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = STAR_CANVAS_SIZE;
+  canvas.height = STAR_CANVAS_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return '';
+
+  // Transparent background so CSS backgroundColor shows through
+  ctx.clearRect(0, 0, STAR_CANVAS_SIZE, STAR_CANVAS_SIZE);
+
+  const random = seededRandom(42);
+
+  for (let i = 0; i < STAR_COUNT; i++) {
+    const x = random() * STAR_CANVAS_SIZE;
+    const y = random() * STAR_CANVAS_SIZE;
+    const brightness = 140 + Math.floor(random() * 115); // 140–255
+    const alpha = 0.4 + random() * 0.6; // 0.4–1.0
+    const radius = 0.3 + random() * 1.0; // 0.3–1.3 px
+
+    ctx.beginPath();
+    ctx.arc(x, y, radius, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(${brightness}, ${brightness}, ${brightness}, ${alpha})`;
+    ctx.fill();
+  }
+
+  cachedDataUrl = canvas.toDataURL('image/png');
+  return cachedDataUrl;
+}
+

--- a/src/deckgl-layers/src/globe/index.ts
+++ b/src/deckgl-layers/src/globe/index.ts
@@ -50,3 +50,4 @@ export type {GlobeBasemapProvider, GlobeAttribution} from './globe-layers';
 export {MVTLabelLayer} from './mvt-label-layer';
 export {default as EnhancedMultiIconLayer} from './enhanced-multi-icon-layer';
 export {KeplerGlobeView} from './globe-view';
+export {getStarsBackgroundImage} from './globe-stars-layer';

--- a/src/localization/src/translations/en.ts
+++ b/src/localization/src/translations/en.ts
@@ -52,7 +52,8 @@ export default {
     adminBorders: 'Admin Borders',
     terminator: 'Day/Night',
     sunAzimuth: 'Sun Azimuth',
-    surface: 'Globe Surface'
+    surface: 'Globe Surface',
+    stars: 'Stars'
   },
   panel: {
     text: {

--- a/src/schemas/src/schema-manager.ts
+++ b/src/schemas/src/schema-manager.ts
@@ -46,6 +46,7 @@ export type SavedMapState = {
       surface: boolean;
       surfaceColor: [number, number, number];
       backgroundColor: [number, number, number];
+      stars: boolean;
     };
   };
 };

--- a/src/schemas/src/schema-manager.ts
+++ b/src/schemas/src/schema-manager.ts
@@ -46,7 +46,7 @@ export type SavedMapState = {
       surface: boolean;
       surfaceColor: [number, number, number];
       backgroundColor: [number, number, number];
-      stars: boolean;
+      stars?: boolean;
     };
   };
 };

--- a/src/types/reducers.d.ts
+++ b/src/types/reducers.d.ts
@@ -58,6 +58,7 @@ export type MapState = {
       surfaceColor: [number, number, number];
       surface: boolean;
       backgroundColor: [number, number, number];
+      stars: boolean;
     };
   };
   /** The current split map mode (single, dual, swipe) */


### PR DESCRIPTION
## Summary

Adds an optional star-field background behind the globe in Globe view mode. Stars are enabled by default and can be toggled off via the Globe Layers panel.

## Approach

The globe background is CSS-based (the deck.gl canvas is transparent, with a solid `backgroundColor` on the container div). Stars are rendered the same way — a 512×512 canvas with procedurally generated star dots (seeded PRNG for determinism) is converted to a PNG data URL and applied as a tiling `background-image` over the dark background color.

## Changes

- **`src/constants/src/default-settings.ts`** — Added `stars: boolean` to `GlobeConfig` type and `stars: true` to defaults
- **`src/deckgl-layers/src/globe/globe-stars-layer.ts`** — New file: generates and caches a tileable star-field PNG data URL
- **`src/deckgl-layers/src/globe/index.ts`** — Re-exports `getStarsBackgroundImage`
- **`src/components/src/map-container.tsx`** — Applies `backgroundImage` + `backgroundRepeat` on the map container when stars are enabled
- **`src/components/src/side-panel/map-style-panel/globe-config-panel.tsx`** — Adds eye-toggle for Stars in Globe Layers panel
- **`src/localization/src/translations/en.ts`** — Adds `mapLayers.stars` label
- **`src/types/reducers.d.ts`**, **`src/schemas/src/schema-manager.ts`** — Adds `stars` to inline globe config types

<img width="1280" height="1219" alt="Screenshot 2026-07-22 at 3 01 51 AM" src="https://github.com/user-attachments/assets/0b8a5092-314d-4682-87eb-e99369280210" />

