### PR TITLE
fix: remove mirrored control buttons in double view

### DIFF
--- a/.cursor/rules/no-auto-commit-push.mdc
+++ b/.cursor/rules/no-auto-commit-push.mdc
@@ -1,0 +1,31 @@
+---
+description: Never commit or push without explicit user approval
+alwaysApply: true
+---
+
+# Git Safety: Ask Before Commit or Push
+
+Never run `git commit`, `git push`, or any command that creates or publishes
+commits (e.g. `git commit --amend`, `git push --force`, `gh pr merge`) unless
+the user has explicitly asked for that action in the current turn.
+
+## Rules
+
+- Do NOT commit or push proactively, even after finishing a task or fixing tests.
+- Making local file edits is fine. Staging (`git add`) for inspection is fine.
+- Before committing or pushing, ask the user to confirm and wait for approval.
+- Never use `--no-verify` or bypass pre-commit / pre-push hooks.
+- If the user says something ambiguous like "fix the tests", stop after the fix
+  and ask whether they want it committed/pushed — do not assume.
+
+## Example
+
+```
+// ❌ BAD: user asked to fix a failing test
+<fix the test>
+git commit -m "fix test" && git push   // committed without being asked
+
+// ✅ GOOD
+<fix the test>
+"The fix is ready. Want me to commit and push it to the PR branch?"
+```

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -1515,50 +1515,56 @@ export default function MapContainerFactory(
         // in this case we don't want to render the map
         return null;
       }
+      // In split (dual) view mode, only render the map control buttons on the
+      // right-side map (primary === true, i.e. index === 1). Otherwise the same
+      // buttons are duplicated on both maps and any opened menu appears mirrored.
+      const showMapControl = !isSplit || Boolean(primary);
       return (
         <>
-          <MapControl
-            mapState={mapState}
-            mapStateActions={mapStateActions}
-            datasets={datasets}
-            availableLocales={LOCALE_CODES_ARRAY}
-            dragRotate={mapState.dragRotate}
-            isSplit={isSplit}
-            primary={Boolean(primary)}
-            isExport={isExport}
-            layers={layers}
-            layerOrder={layerOrder}
-            layersToRender={layersToRender}
-            mapIndex={index || 0}
-            mapControls={mapControls}
-            readOnly={this.props.readOnly}
-            scale={mapState.scale || 1}
-            logoComponent={this.props.logoComponent}
-            top={
-              interactionConfig.geocoder && interactionConfig.geocoder.enabled
-                ? theme.mapControlTop
-                : 0
-            }
-            editor={editor}
-            locale={locale}
-            onTogglePerspective={mapStateActions.togglePerspective}
-            onSetMapViewMode={mapStateActions.setMapViewMode}
-            mapViewMode={mapState.mapViewMode}
-            onToggleSplitMap={mapStateActions.toggleSplitMap}
-            onMapToggleLayer={this._handleMapToggleLayer}
-            onToggleMapControl={this._toggleMapControl}
-            onToggleSplitMapViewport={mapStateActions.toggleSplitMapViewport}
-            onSetEditorMode={visStateActions.setEditorMode}
-            onSetLocale={uiStateActions.setLocale}
-            onToggleEditorVisibility={visStateActions.toggleEditorVisibility}
-            onLayerVisConfigChange={visStateActions.layerVisConfigChange}
-            onToggleLayerVisibility={this._handleToggleLayerVisibility}
-            mapHeight={mapState.height}
-            setMapControlSettings={uiStateActions.setMapControlSettings}
-            activeSidePanel={activeSidePanel}
-            splitMaps={this.props.visState.splitMaps}
-            onToggleLayerForMap={visStateActions.toggleLayerForMap}
-          />
+          {showMapControl && (
+            <MapControl
+              mapState={mapState}
+              mapStateActions={mapStateActions}
+              datasets={datasets}
+              availableLocales={LOCALE_CODES_ARRAY}
+              dragRotate={mapState.dragRotate}
+              isSplit={isSplit}
+              primary={Boolean(primary)}
+              isExport={isExport}
+              layers={layers}
+              layerOrder={layerOrder}
+              layersToRender={layersToRender}
+              mapIndex={index || 0}
+              mapControls={mapControls}
+              readOnly={this.props.readOnly}
+              scale={mapState.scale || 1}
+              logoComponent={this.props.logoComponent}
+              top={
+                interactionConfig.geocoder && interactionConfig.geocoder.enabled
+                  ? theme.mapControlTop
+                  : 0
+              }
+              editor={editor}
+              locale={locale}
+              onTogglePerspective={mapStateActions.togglePerspective}
+              onSetMapViewMode={mapStateActions.setMapViewMode}
+              mapViewMode={mapState.mapViewMode}
+              onToggleSplitMap={mapStateActions.toggleSplitMap}
+              onMapToggleLayer={this._handleMapToggleLayer}
+              onToggleMapControl={this._toggleMapControl}
+              onToggleSplitMapViewport={mapStateActions.toggleSplitMapViewport}
+              onSetEditorMode={visStateActions.setEditorMode}
+              onSetLocale={uiStateActions.setLocale}
+              onToggleEditorVisibility={visStateActions.toggleEditorVisibility}
+              onLayerVisConfigChange={visStateActions.layerVisConfigChange}
+              onToggleLayerVisibility={this._handleToggleLayerVisibility}
+              mapHeight={mapState.height}
+              setMapControlSettings={uiStateActions.setMapControlSettings}
+              activeSidePanel={activeSidePanel}
+              splitMaps={this.props.visState.splitMaps}
+              onToggleLayerForMap={visStateActions.toggleLayerForMap}
+            />
+          )}
           {isSplitSelector(this.props) && <Droppable containerId={containerId} />}
 
           {deck}

--- a/src/components/src/map/map-legend-panel.tsx
+++ b/src/components/src/map/map-legend-panel.tsx
@@ -19,7 +19,6 @@ import {CSS} from '@dnd-kit/utilities';
 import {useMergeRefs} from '@floating-ui/react';
 
 import {ActionHandler, setMapControlSettings, toggleSplitMapViewport} from '@kepler.gl/actions';
-import {MapSplitMode} from '@kepler.gl/constants';
 import {Layer} from '@kepler.gl/layers';
 import {breakPointValues} from '@kepler.gl/styles';
 import {LayerVisConfig, LayerOrder, MapControlMapLegend, MapControls, MapState} from '@kepler.gl/types';
@@ -375,7 +374,6 @@ const MapLegendPanelComponent = ({
   MapControlPanel,
   MapLegend
 }: MapLegendPanelProps & MapLegendPanelComponents) => {
-  const isSwipeMode = mapState?.mapSplitMode === MapSplitMode.SWIPE_COMPARE;
   const isSidePanelShown = Boolean(activeSidePanel);
   const settings = mapControls?.mapLegend?.settings;
 
@@ -398,10 +396,10 @@ const MapLegendPanelComponent = ({
     [onToggleMapControl]
   );
 
-  if (isSplit && !isSwipeMode && mapIndex !== 0) {
-    return null;
-  }
-  if (isSwipeMode && mapIndex !== 1) {
+  // In split view (both dual and swipe-compare modes) the map controls are only
+  // rendered on the right-side map (mapIndex === 1), so the legend must render
+  // there too. Rendering on any other index would hide the legend entirely.
+  if (isSplit && mapIndex !== 1) {
     return null;
   }
 

--- a/src/components/src/map/map-legend-panel.tsx
+++ b/src/components/src/map/map-legend-panel.tsx
@@ -369,7 +369,6 @@ const MapLegendPanelComponent = ({
   isSplit,
   splitMaps,
   onToggleLayerForMap,
-  mapIndex,
   MapControlTooltip,
   MapControlPanel,
   MapLegend
@@ -396,12 +395,9 @@ const MapLegendPanelComponent = ({
     [onToggleMapControl]
   );
 
-  // In split view (both dual and swipe-compare modes) the map controls are only
-  // rendered on the right-side map (mapIndex === 1), so the legend must render
-  // there too. Rendering on any other index would hide the legend entirely.
-  if (isSplit && mapIndex !== 1) {
-    return null;
-  }
+  // In split view the map controls (and therefore this legend) are only
+  // rendered once, on the right-side / primary map. That gating happens in
+  // MapContainer, so no per-index suppression is needed here anymore.
 
   if (!mapLegend.show) {
     return null;


### PR DESCRIPTION
In dual/split view the map control buttons were rendered on both maps, so any menu opened on one side was mirrored on the other. This keeps the controls (and the legend) only on the right-side map.

Before:
<img width="1078" height="767" alt="Screenshot 2026-07-23 at 5 51 12 AM" src="https://github.com/user-attachments/assets/32b14903-b183-421b-8d0b-1a529a409516" />

