### PR TITLE
fix: WMS layer doesn't respect left/right visibility in dual/swipe split modes

### DIFF
--- a/src/layers/src/wms-layer/wms-layer.ts
+++ b/src/layers/src/wms-layer/wms-layer.ts
@@ -253,6 +253,8 @@ export default class WMSLayer extends AbstractTileLayer<WMSTile, any[]> {
       layers: [wmsLayerName],
       opacity: visConfig.opacity,
       transparent: visConfig.transparent,
+      // layer should be visible and, if splitMap, shown in one of the panels
+      visible: defaultLayerProps.visible,
       pickable,
       // @ts-ignore
       onClick: pickable ? this._onClick.bind(this, layerCallbacks) : null


### PR DESCRIPTION
## Summary

In split map (Dual / Swipe) modes, a WMS layer kept rendering on both panels regardless of the per-map left/right visibility toggle, unlike other layers (e.g. Scatterplot) which hide/show correctly.

## Fix

Forward `defaultLayerProps.visible` to `DeckWMSLayer`.

<img width="996" height="873" alt="Screenshot 2026-07-26 at 4 50 43 AM" src="https://github.com/user-attachments/assets/08176788-327d-421f-b447-75668205e1c6" />
