### PR TITLE
fix: serialize GeoDataFrames with multiple geometry columns in python binding

### DIFF
--- a/bindings/python/keplergl/serializers.py
+++ b/bindings/python/keplergl/serializers.py
@@ -114,24 +114,44 @@ def _serialize_dataframe_arrow(df: pd.DataFrame, name: str) -> dict:
     }
 
 
-def serialize_geodataframe(gdf: gpd.GeoDataFrame, name: str) -> dict:
-    """Serialize GeoDataFrame to GeoArrow format."""
+def _is_geometry_col(series: pd.Series) -> bool:
+    """Return True if the series has a geopandas geometry dtype."""
+    return isinstance(series.dtype, gpd.array.GeometryDtype)
+
+
+def _geoseries_to_geoarrow(geom_series: gpd.GeoSeries):
+    """Convert a GeoSeries to a GeoArrow array, handling all-null series."""
     import geoarrow.pyarrow as ga
 
-    # Convert geometry column to geoarrow format
-    geom_col = gdf.geometry.name
-    geom_series = gdf.geometry
     if geom_series.notna().any():
-        geom_array = ga.as_geoarrow(geom_series)
-    else:
-        # GeoArrow cannot infer a concrete geometry type from an empty/all-null series.
-        geom_array = ga.as_geoarrow(geom_series, type=ga.wkb())
+        return ga.as_geoarrow(geom_series)
+    # GeoArrow cannot infer a concrete geometry type from an empty/all-null series.
+    return ga.as_geoarrow(geom_series, type=ga.wkb())
 
-    # Build table with non-geometry columns as regular Arrow arrays
-    non_geom_cols = [c for c in gdf.columns if c != geom_col]
-    arrays = [pa.array(gdf[c]) for c in non_geom_cols]
-    arrays.append(geom_array)
-    col_names = non_geom_cols + [geom_col]
+
+def serialize_geodataframe(gdf: gpd.GeoDataFrame, name: str) -> dict:
+    """Serialize GeoDataFrame to GeoArrow format.
+
+    The active geometry column is encoded as GeoArrow. Any additional geometry
+    columns (GeoDataFrames can have more than one) are converted to WKT strings
+    so they round-trip through the Arrow table without serialization errors and
+    remain readable in kepler.gl as text attributes.
+    """
+    active_geom_col = gdf.geometry.name
+
+    arrays = []
+    col_names = []
+    for col in gdf.columns:
+        series = gdf[col]
+        if col == active_geom_col:
+            arrays.append(_geoseries_to_geoarrow(gdf.geometry))
+        elif _is_geometry_col(series):
+            # Secondary geometry columns: convert to WKT strings to avoid
+            # pa.array() failing on raw geometry objects.
+            arrays.append(pa.array(series.to_wkt()))
+        else:
+            arrays.append(pa.array(series))
+        col_names.append(col)
 
     table = pa.table(dict(zip(col_names, arrays)))
     return {

--- a/bindings/python/tests/test_serializers.py
+++ b/bindings/python/tests/test_serializers.py
@@ -162,6 +162,99 @@ class TestGeoDataFrameSerialization:
         assert result["format"] == "geoarrow"
         assert "data" in result
 
+    def test_serialize_geodataframe_multiple_geometry_columns(self):
+        """GeoDataFrame with multiple geometry columns must not raise.
+
+        Regression test for the serialization error reported in
+        https://github.com/keplergl/kepler.gl/issues/2283 — when a GeoDataFrame
+        has more than one geometry-typed column, pa.array() would fail on the
+        non-active geometry columns.  The active geometry column is encoded as
+        GeoArrow; secondary ones are converted to WKT strings.
+        """
+        import base64
+        import pyarrow as pa
+
+        gdf = gpd.GeoDataFrame(
+            {"name": ["SF", "LA"], "value": [1, 2]},
+            geometry=[Point(-122.4194, 37.7749), Point(-118.2437, 34.0522)],
+            crs="EPSG:4326",
+        )
+        # buffer() on a geographic CRS gives imprecise results — acceptable here
+        # since we only care about serialization, not geometric accuracy.
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            gdf["buffer"] = gdf.geometry.buffer(0.01)
+
+        result = serialize_dataset(gdf, "multi_geom")
+        assert result["id"] == "multi_geom"
+        assert result["format"] == "geoarrow"
+
+        # Decode the Arrow table and verify all columns survived
+        arrow_bytes = base64.b64decode(result["data"])
+        table = pa.ipc.open_stream(arrow_bytes).read_all()
+        assert "name" in table.column_names
+        assert "value" in table.column_names
+        assert "geometry" in table.column_names
+        assert "buffer" in table.column_names
+        assert table.num_rows == 2
+
+        # The secondary geometry column must be WKT strings, not raw geometry objects
+        buffer_col = table.column("buffer")
+        assert pa.types.is_string(buffer_col.type) or pa.types.is_large_string(buffer_col.type), (
+            f"Expected secondary geometry column to be WKT string, got {buffer_col.type}"
+        )
+        assert buffer_col[0].as_py().startswith("POLYGON")
+
+    def test_serialize_geodataframe_non_default_active_geometry(self):
+        """Active geometry column with non-default name is encoded as GeoArrow.
+
+        When a GeoDataFrame has two geometry columns and the active one is
+        not named 'geometry', the active column must still be GeoArrow-encoded
+        and the other must be WKT.
+        """
+        import base64
+        import pyarrow as pa
+
+        gdf = gpd.GeoDataFrame(
+            {"name": ["A", "B"]},
+            geometry=[Point(0, 0), Point(1, 1)],
+        )
+        gdf["secondary"] = gdf.geometry.buffer(0.1)
+        # Switch the active geometry to the buffered column
+        gdf = gdf.set_geometry("secondary")
+
+        result = serialize_dataset(gdf, "swapped")
+        assert result["format"] == "geoarrow"
+
+        arrow_bytes = base64.b64decode(result["data"])
+        table = pa.ipc.open_stream(arrow_bytes).read_all()
+        assert "geometry" in table.column_names
+        assert "secondary" in table.column_names
+
+        # Original (now non-active) column must be WKT
+        orig_col = table.column("geometry")
+        assert pa.types.is_string(orig_col.type) or pa.types.is_large_string(orig_col.type)
+
+    def test_serialize_geodataframe_null_secondary_geometry(self):
+        """A secondary geometry column that is all-null serializes as WKT nulls."""
+        import base64
+        import pyarrow as pa
+
+        gdf = gpd.GeoDataFrame(
+            {"name": ["A", "B"]},
+            geometry=[Point(0, 0), Point(1, 1)],
+        )
+        gdf["empty_geom"] = gpd.GeoSeries([None, None])
+
+        result = serialize_dataset(gdf, "null_secondary")
+        assert result["format"] == "geoarrow"
+
+        arrow_bytes = base64.b64decode(result["data"])
+        table = pa.ipc.open_stream(arrow_bytes).read_all()
+        assert "empty_geom" in table.column_names
+        assert table.num_rows == 2
+
 
 class TestGeoJSONSerialization:
     """Tests for GeoJSON serialization (from GeoJSON.ipynb)."""


### PR DESCRIPTION
Adapts the fix from #2283 (originally by @KrausMatthias) to the new `bindings/python` package.

## Problem

When a `GeoDataFrame` has more than one geometry-typed column, `serialize_geodataframe` called `pa.array()` directly on the non-active `GeoSeries` columns, raising:

```
ArrowInvalid: Could not convert POLYGON (...) with type Polygon: did not recognize Python value type
```

## Fix

- **Active geometry column** → encoded as GeoArrow (preserves rich geometry type for kepler.gl rendering)
- **Secondary geometry columns** → converted to WKT strings via `series.to_wkt()`, so they pass through Arrow cleanly and are visible as text attributes in the kepler.gl data table

## Tests

Three new regression tests in `TestGeoDataFrameSerialization`:
- GDF with two geometry columns (active + buffered)
- GDF where the active geometry is not the first geometry column
- GDF with a secondary geometry column that is all-null

Closes #2283