### PR TITLE
fix(globe): prevent globe rotation when drag starts or moves outside the globe silhouette

### DIFF
--- a/src/deckgl-layers/src/globe/globe-depth-disk-layer.ts
+++ b/src/deckgl-layers/src/globe/globe-depth-disk-layer.ts
@@ -35,7 +35,7 @@ const DEPTH_DISK_FULL_RADIUS = 6.371e6;
 // The disk orientation math is done in that 256-unit common space (matching
 // viewport.cameraPosition), then the resulting radius/shift ratios are converted to
 // meters for the shader, since the disk geometry is expressed in meters.
-const GLOBE_COMMON_RADIUS = 256;
+export const GLOBE_COMMON_RADIUS = 256;
 
 /**
  * Creates a view-oriented disk positioned along the direction from the globe's center to the camera.

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -4,6 +4,7 @@
 import * as DeckCore from '@deck.gl/core';
 import {clamp} from '@math.gl/core';
 import {GLOBE_MAX_LATITUDE} from '@kepler.gl/constants';
+import {GLOBE_COMMON_RADIUS} from './globe-depth-disk-layer';
 
 // deck.gl exposes GlobeView / GlobeController as experimental, underscore-prefixed
 // members. Their named type bindings aren't reliably resolvable through the
@@ -23,22 +24,22 @@ function zoomAdjust(latitude: number): number {
 }
 
 /**
- * The internal world-space radius that deck.gl's GlobeViewport uses for the
- * sphere (see GLOBE_RADIUS in @deck.gl/core globe-viewport.ts).
- */
-const DECK_GLOBE_RADIUS = 256;
-
-/**
  * Transform a homogeneous 4-vector by a column-major 4×4 matrix and
  * divide by w (perspective divide).  Mirrors deck.gl's transformVector().
+ * Returns null when rw is zero (degenerate projection) so callers can
+ * treat the pixel as off-globe rather than producing Infinity/NaN.
  */
-function transformVector(matrix: number[], v: [number, number, number, number]): [number, number, number] {
+function transformVector(
+  matrix: number[],
+  v: [number, number, number, number]
+): [number, number, number] | null {
   const [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15] = matrix;
   const [vx, vy, vz, vw] = v;
   const rx = m0 * vx + m4 * vy + m8 * vz + m12 * vw;
   const ry = m1 * vx + m5 * vy + m9 * vz + m13 * vw;
   const rz = m2 * vx + m6 * vy + m10 * vz + m14 * vw;
   const rw = m3 * vx + m7 * vy + m11 * vz + m15 * vw;
+  if (rw === 0) return null;
   return [rx / rw, ry / rw, rz / rw];
 }
 
@@ -66,6 +67,9 @@ function isPixelOnGlobe(viewport: any, pos: [number, number]): boolean {
   const coord0 = transformVector(m, [x, y, -1, 1]);
   const coord1 = transformVector(m, [x, y, 1, 1]);
 
+  // Degenerate projection — treat conservatively as on-globe.
+  if (!coord0 || !coord1) return true;
+
   // Distance² from the ray to the sphere center (origin) — mirror of deck's math.
   const dx = coord0[0] - coord1[0];
   const dy = coord0[1] - coord1[1];
@@ -76,7 +80,7 @@ function isPixelOnGlobe(viewport: any, pos: [number, number]): boolean {
   const sSqr = (4 * l0Sqr * l1Sqr - (lSqr - l0Sqr - l1Sqr) ** 2) / 16;
   const dSqr = (4 * sSqr) / lSqr;
 
-  return dSqr <= DECK_GLOBE_RADIUS * DECK_GLOBE_RADIUS;
+  return dSqr <= GLOBE_COMMON_RADIUS * GLOBE_COMMON_RADIUS;
 }
 
 /**

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -24,58 +24,37 @@ function zoomAdjust(latitude: number): number {
 }
 
 /**
- * Transform a homogeneous 4-vector by a column-major 4×4 matrix and apply
- * the perspective divide.  Uses @math.gl/core's vec4.transformMat4 for the
- * multiply, then divides by w.  Returns null when w is zero (degenerate
- * projection) so callers can treat the pixel as off-globe rather than
- * producing Infinity/NaN.
- */
-function transformAndDivide(
-  matrix: number[],
-  v: [number, number, number, number]
-): [number, number, number] | null {
-  const out = vec4.transformMat4([], v, matrix);
-  const w = out[3];
-  if (w === 0) return null;
-  return [out[0] / w, out[1] / w, out[2] / w];
-}
-
-/**
  * Returns true if the screen pixel `pos` lies within the visible globe
  * silhouette.
  *
- * GlobeViewport.unproject() does a ray–sphere intersection but uses
- * `Math.max(0, r² - d²)` to clamp the discriminant, so it *always* returns a
- * valid lng/lat even for pixels outside the sphere silhouette (it snaps to the
- * nearest point on the limb).  We replicate the same ray–sphere math here but
- * check the discriminant *before* the clamp: if d² > r² the ray misses the
- * sphere entirely and the pixel is outside the globe.
- *
- * The viewport's `pixelUnprojectionMatrix` is used exactly as deck.gl does
- * internally, so the test stays accurate across all zoom levels and viewport
- * sizes.
+ * GlobeViewport.unproject() clamps the ray–sphere discriminant with
+ * Math.max(0, r²−d²), so it always returns a valid lng/lat even for
+ * off-globe pixels (snapping to the limb).  We replicate the same ray cast
+ * but check the discriminant before the clamp using the standard
+ * squared-distance-from-origin-to-ray formula: |P₀ × dir|² / |dir|².
  */
 function isPixelOnGlobe(viewport: any, pos: [number, number]): boolean {
-  const [x, y] = pos;
   const m: number[] = viewport.pixelUnprojectionMatrix;
-  if (!m) return true; // conservative: allow if matrix unavailable
+  if (!m) return true; // conservative fallback if matrix unavailable
 
-  // Cast a ray through the pixel (near and far plane points in world space).
-  const coord0 = transformAndDivide(m, [x, y, -1, 1]);
-  const coord1 = transformAndDivide(m, [x, y, 1, 1]);
+  // Cast a ray through the pixel at the near and far planes.
+  const p0 = vec4.transformMat4([], [pos[0], pos[1], -1, 1], m);
+  const p1 = vec4.transformMat4([], [pos[0], pos[1], 1, 1], m);
+  if (p0[3] === 0 || p1[3] === 0) return true; // degenerate projection
 
-  // Degenerate projection — treat conservatively as on-globe.
-  if (!coord0 || !coord1) return true;
+  // Perspective-divide to world space.
+  const ax = p0[0] / p0[3], ay = p0[1] / p0[3], az = p0[2] / p0[3];
+  const bx = p1[0] / p1[3], by = p1[1] / p1[3], bz = p1[2] / p1[3];
 
-  // Distance² from the ray to the sphere center (origin) — mirror of deck's math.
-  const dx = coord0[0] - coord1[0];
-  const dy = coord0[1] - coord1[1];
-  const dz = coord0[2] - coord1[2];
-  const lSqr = dx * dx + dy * dy + dz * dz;
-  const l0Sqr = coord0[0] ** 2 + coord0[1] ** 2 + coord0[2] ** 2;
-  const l1Sqr = coord1[0] ** 2 + coord1[1] ** 2 + coord1[2] ** 2;
-  const sSqr = (4 * l0Sqr * l1Sqr - (lSqr - l0Sqr - l1Sqr) ** 2) / 16;
-  const dSqr = (4 * sSqr) / lSqr;
+  // Ray direction.
+  const dx = bx - ax, dy = by - ay, dz = bz - az;
+
+  // Squared distance from the origin (globe center) to the ray:
+  //   d² = |P₀ × dir|² / |dir|²
+  const cx = ay * dz - az * dy;
+  const cy = az * dx - ax * dz;
+  const cz = ax * dy - ay * dx;
+  const dSqr = (cx * cx + cy * cy + cz * cz) / (dx * dx + dy * dy + dz * dz);
 
   return dSqr <= GLOBE_COMMON_RADIUS * GLOBE_COMMON_RADIUS;
 }
@@ -161,47 +140,29 @@ class ZoomToCursorGlobeController extends GlobeController {
         startPos?: [number, number];
         scale: number;
       }) {
-        const state = (this as any).getState();
-        let {startZoom, startZoomLngLat} = state;
-
+        let {startZoom, startZoomLngLat} = (this as any).getState();
         const currentProps = (this as any).getViewportProps();
 
-        // `false` sentinel: pinch zoom started off-globe.
-        // (For wheel zoom we use the closure variable `offGlobeZoomAt` instead,
-        // because deck.gl never calls zoomEnd() for wheel events.)
-        if (startZoomLngLat === false) {
-          const zoom = (this as any)._constrainZoom(
-            (startZoom ?? currentProps.zoom) + Math.log2(scale)
-          );
-          return (this as any)._getUpdatedState({zoom, startZoomLngLat: false});
-        }
-
         if (!startZoomLngLat) {
-          // Wheel zoom: re-derive each tick. For pinch,
-          // startZoom/startZoomLngLat are set once by zoomStart.
+          // Wheel zoom: re-derive anchor each tick (pinch sets it once in zoomStart).
           startZoom = currentProps.zoom;
 
+          // Suppress cursor-anchoring when the cursor is off-globe or when a
+          // recent tick was off-globe (within BURST_TIMEOUT_MS).  deck.gl never
+          // calls zoomEnd() for wheel events so we track the session with the
+          // closure variable `offGlobeZoomAt` rather than ViewState.
           const BURST_TIMEOUT_MS = 200;
           const now = Date.now();
           const anchorViewport = (this as any).makeViewport(currentProps);
-          const anchorPos: [number, number] = startPos || pos;
-          const onGlobe = isPixelOnGlobe(anchorViewport, anchorPos);
+          const onGlobe = isPixelOnGlobe(anchorViewport, startPos || pos);
 
-          // Keep track of when we last saw an off-globe tick. While the session
-          // is recent (< BURST_TIMEOUT_MS), stay in center-zoom even if the
-          // cursor has since entered the globe, to prevent a snap to the edge.
-          if (!onGlobe) {
-            offGlobeZoomAt = now; // refresh the session clock
-          }
-          const inOffGlobeSession =
-            offGlobeZoomAt !== null && now - offGlobeZoomAt < BURST_TIMEOUT_MS;
+          if (!onGlobe) offGlobeZoomAt = now;
 
-          if (!onGlobe || inOffGlobeSession) {
+          if (!onGlobe || (offGlobeZoomAt !== null && now - offGlobeZoomAt < BURST_TIMEOUT_MS)) {
             const zoom = (this as any)._constrainZoom(startZoom + Math.log2(scale));
             return (this as any)._getUpdatedState({zoom});
           }
 
-          // New burst that started on-globe — clear the session flag.
           offGlobeZoomAt = null;
           startZoomLngLat = (this as any)._unproject(startPos) || (this as any)._unproject(pos);
         }
@@ -212,36 +173,30 @@ class ZoomToCursorGlobeController extends GlobeController {
           return (this as any)._getUpdatedState({zoom});
         }
 
-        // Zoom-out (scale < 1): exact cursor anchoring is unstable on a globe (the
-        // geo point under an off-center pixel moves non-linearly near the limb and
-        // drags the view toward the poles). Instead, gently steer the CENTER toward
-        // the geo location under the cursor — the map recenters on the cursor as you
-        // zoom out, similar in spirit to zoom-in, but without the pole-ward spin.
+        // Zoom-out (scale < 1): exact cursor anchoring is unstable near the limb
+        // (non-linear geo-to-pixel mapping pulls the view toward the poles).
+        // Instead, gently steer the center toward the cursor location per tick.
         if (scale < 1) {
-          const cursorLngLat = startZoomLngLat;
-          const cursorValid =
-            Array.isArray(cursorLngLat) &&
-            Number.isFinite(cursorLngLat[0]) &&
-            Number.isFinite(cursorLngLat[1]);
-          if (!cursorValid) {
+          if (
+            !Array.isArray(startZoomLngLat) ||
+            !Number.isFinite(startZoomLngLat[0]) ||
+            !Number.isFinite(startZoomLngLat[1])
+          ) {
             return (this as any)._getUpdatedState({zoom});
           }
 
-          // Fraction of the way to move the center toward the cursor per tick.
-          // Scales with how much we zoomed out this tick so a bigger step moves
-          // more. Clamped so a single large tick can't overshoot.
-          const RECENTER_STRENGTH = 0.11;
-          const t = Math.min(1, (1 - scale) * RECENTER_STRENGTH);
+          // Per-tick lerp strength scales with zoom-out amount; clamped to avoid overshoot.
+          const t = Math.min(1, (1 - scale) * 0.11);
 
-          // Shortest-path longitude interpolation (handle antimeridian wrap).
-          let dLng = cursorLngLat[0] - currentProps.longitude;
+          // Shortest-path longitude interpolation (handles antimeridian wrap).
+          let dLng = startZoomLngLat[0] - currentProps.longitude;
           if (dLng > 180) dLng -= 360;
           if (dLng < -180) dLng += 360;
 
           return (this as any)._getUpdatedState({
             zoom,
             longitude: currentProps.longitude + dLng * t,
-            latitude: currentProps.latitude + (cursorLngLat[1] - currentProps.latitude) * t
+            latitude: currentProps.latitude + (startZoomLngLat[1] - currentProps.latitude) * t
           });
         }
 
@@ -250,12 +205,10 @@ class ZoomToCursorGlobeController extends GlobeController {
           zoom
         });
 
-        // Anchor the grabbed geo point back under the cursor:
-        //   fromPosition = viewport.unproject(pos)   // geo point now under the cursor
-        //   longitude = startZoomLngLat[0] - fromPosition[0] + viewport.longitude
-        //   latitude  = startZoomLngLat[1] - fromPosition[1] + viewport.latitude
-        // Guard with isPixelOnGlobe: if pos has moved off-globe since the anchor
-        // was set (e.g. during a fast pinch), just apply the zoom toward center.
+        // Zoom-in: exact anchor — unproject the cursor in the post-zoom viewport and
+        // shift the center so the grabbed geo point lands back under the cursor.
+        // Guard with isPixelOnGlobe: if pos moved off-globe during a fast pinch,
+        // fall back to center zoom.
         if (!isPixelOnGlobe(zoomedViewport, pos)) {
           return (this as any)._getUpdatedState({zoom});
         }

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -269,18 +269,27 @@ class ZoomToCursorGlobeController extends GlobeController {
       pan({pos, startPos}: {pos: [number, number]; startPos?: [number, number]}) {
         const storedStart = (this as any).getState().startPanLngLat;
 
-        // `false` means the drag was initiated outside the globe — do not rotate.
+        const props = (this as any).getViewportProps();
+        const viewport = (this as any).makeViewport(props);
+
+        // `false` means the drag started outside the globe. If the cursor has
+        // now moved onto the globe, latch the current position as the anchor
+        // so rotation begins from the entry point. Otherwise stay frozen.
         if (storedStart === false) {
-          return this;
+          if (!isPixelOnGlobe(viewport, pos)) {
+            return this;
+          }
+          // Cursor just entered the globe — establish the anchor and return
+          // without moving; the next pan event will apply the first delta.
+          return (this as any)._getUpdatedState({
+            startPanLngLat: (this as any)._unproject(pos)
+          });
         }
 
         const startPanLngLat = storedStart || (this as any)._unproject(startPos);
         if (!startPanLngLat) {
           return this;
         }
-
-        const props = (this as any).getViewportProps();
-        const viewport = (this as any).makeViewport(props);
 
         // Once the cursor leaves the globe silhouette mid-drag, freeze the view.
         // viewport.unproject() snaps off-globe pixels to the nearest limb point

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -23,6 +23,63 @@ function zoomAdjust(latitude: number): number {
 }
 
 /**
+ * The internal world-space radius that deck.gl's GlobeViewport uses for the
+ * sphere (see GLOBE_RADIUS in @deck.gl/core globe-viewport.ts).
+ */
+const DECK_GLOBE_RADIUS = 256;
+
+/**
+ * Transform a homogeneous 4-vector by a column-major 4×4 matrix and
+ * divide by w (perspective divide).  Mirrors deck.gl's transformVector().
+ */
+function transformVector(matrix: number[], v: [number, number, number, number]): [number, number, number] {
+  const [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15] = matrix;
+  const [vx, vy, vz, vw] = v;
+  const rx = m0 * vx + m4 * vy + m8 * vz + m12 * vw;
+  const ry = m1 * vx + m5 * vy + m9 * vz + m13 * vw;
+  const rz = m2 * vx + m6 * vy + m10 * vz + m14 * vw;
+  const rw = m3 * vx + m7 * vy + m11 * vz + m15 * vw;
+  return [rx / rw, ry / rw, rz / rw];
+}
+
+/**
+ * Returns true if the screen pixel `pos` lies within the visible globe
+ * silhouette.
+ *
+ * GlobeViewport.unproject() does a ray–sphere intersection but uses
+ * `Math.max(0, r² - d²)` to clamp the discriminant, so it *always* returns a
+ * valid lng/lat even for pixels outside the sphere silhouette (it snaps to the
+ * nearest point on the limb).  We replicate the same ray–sphere math here but
+ * check the discriminant *before* the clamp: if d² > r² the ray misses the
+ * sphere entirely and the pixel is outside the globe.
+ *
+ * The viewport's `pixelUnprojectionMatrix` is used exactly as deck.gl does
+ * internally, so the test stays accurate across all zoom levels and viewport
+ * sizes.
+ */
+function isPixelOnGlobe(viewport: any, pos: [number, number]): boolean {
+  const [x, y] = pos;
+  const m: number[] = viewport.pixelUnprojectionMatrix;
+  if (!m) return true; // conservative: allow if matrix unavailable
+
+  // Cast a ray through the pixel (near and far plane points in world space).
+  const coord0 = transformVector(m, [x, y, -1, 1]);
+  const coord1 = transformVector(m, [x, y, 1, 1]);
+
+  // Distance² from the ray to the sphere center (origin) — mirror of deck's math.
+  const dx = coord0[0] - coord1[0];
+  const dy = coord0[1] - coord1[1];
+  const dz = coord0[2] - coord1[2];
+  const lSqr = dx * dx + dy * dy + dz * dz;
+  const l0Sqr = coord0[0] ** 2 + coord0[1] ** 2 + coord0[2] ** 2;
+  const l1Sqr = coord1[0] ** 2 + coord1[1] ** 2 + coord1[2] ** 2;
+  const sSqr = (4 * l0Sqr * l1Sqr - (lSqr - l0Sqr - l1Sqr) ** 2) / 16;
+  const dSqr = (4 * sSqr) / lSqr;
+
+  return dSqr <= DECK_GLOBE_RADIUS * DECK_GLOBE_RADIUS;
+}
+
+/**
  * Custom GlobeController that restores zoom-to-cursor behavior.
  *
  * In deck.gl 9.x, the default GlobeController's GlobeState.zoom() ignores the
@@ -190,30 +247,47 @@ class ZoomToCursorGlobeController extends GlobeController {
       // which incremental deltas track fine. The exact anchor below removes that
       // first-frame snap.
       panStart({pos}: {pos: [number, number]}) {
+        const viewport = (this as any).makeViewport((this as any).getViewportProps());
+        // If the mousedown pixel is outside the globe silhouette, store `false`
+        // as an explicit sentinel so that every subsequent `pan` call for this
+        // gesture is a no-op.  We can't rely on `_unproject(pos)` returning
+        // undefined here because GlobeViewport.unproject clamps the
+        // ray–sphere discriminant to 0 via Math.max(0, …), which means it
+        // always returns a valid-looking lng/lat even for off-globe pixels.
+        if (!isPixelOnGlobe(viewport, pos)) {
+          return (this as any)._getUpdatedState({startPanLngLat: false});
+        }
         return (this as any)._getUpdatedState({
           startPanLngLat: (this as any)._unproject(pos)
         });
       }
 
       pan({pos, startPos}: {pos: [number, number]; startPos?: [number, number]}) {
-        const startPanLngLat =
-          (this as any).getState().startPanLngLat || (this as any)._unproject(startPos);
+        const storedStart = (this as any).getState().startPanLngLat;
+
+        // `false` means the drag was initiated outside the globe — do not rotate.
+        if (storedStart === false) {
+          return this;
+        }
+
+        const startPanLngLat = storedStart || (this as any)._unproject(startPos);
         if (!startPanLngLat) {
           return this;
         }
 
         const props = (this as any).getViewportProps();
         const viewport = (this as any).makeViewport(props);
-        const fromPosition = viewport.unproject(pos);
 
-        // Guard: pixels off the sphere silhouette unproject to NaN/undefined.
-        const valid =
-          Array.isArray(fromPosition) &&
-          Number.isFinite(fromPosition[0]) &&
-          Number.isFinite(fromPosition[1]);
-        if (!valid) {
+        // Once the cursor leaves the globe silhouette mid-drag, freeze the view.
+        // viewport.unproject() snaps off-globe pixels to the nearest limb point
+        // (via Math.max(0, …) in its ray–sphere discriminant), so without this
+        // guard the globe would keep rotating toward the edge as the cursor moves
+        // further outside.
+        if (!isPixelOnGlobe(viewport, pos)) {
           return this;
         }
+
+        const fromPosition = viewport.unproject(pos);
 
         const longitude = startPanLngLat[0] - fromPosition[0] + props.longitude;
         let latitude = startPanLngLat[1] - fromPosition[1] + props.latitude;

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -94,6 +94,16 @@ class ZoomToCursorGlobeController extends GlobeController {
     super(...args);
     const OriginalGlobeState = this.ControllerState;
 
+    // Tracks when the most recent off-globe wheel-zoom tick fired.
+    // Stored as a controller-level closure variable rather than in ViewState
+    // because deck.gl's Controller never calls zoomEnd() for wheel events —
+    // only for pinch/touch — so there is no reliable hook to clear a
+    // ViewState-based sentinel after a wheel scroll session ends.
+    // A simple timestamp lets us detect when a new scroll burst has started
+    // (> BURST_TIMEOUT_MS since the last off-globe tick) so cursor-anchored
+    // zoom can resume naturally on the next independent scroll.
+    let offGlobeZoomAt: number | null = null;
+
     // Create patched GlobeState that supports zoom-to-cursor
     this.ControllerState = class PatchedGlobeState extends OriginalGlobeState {
       // Constrain the camera target to a latitude band around the equator so the
@@ -151,21 +161,56 @@ class ZoomToCursorGlobeController extends GlobeController {
         startPos?: [number, number];
         scale: number;
       }) {
-        let {startZoom, startZoomLngLat} = (this as any).getState();
-
-        if (!startZoomLngLat) {
-          // Discrete (wheel) zoom: re-derive the anchor each tick from the current
-          // view. For pinch, startZoom/startZoomLngLat are set once by zoomStart and
-          // preserved across ticks by _getUpdatedState (which spreads getState()).
-          startZoom = (this as any).getViewportProps().zoom;
-          startZoomLngLat = (this as any)._unproject(startPos) || (this as any)._unproject(pos);
-        }
-        if (!startZoomLngLat) {
-          return this;
-        }
+        const state = (this as any).getState();
+        let {startZoom, startZoomLngLat} = state;
 
         const currentProps = (this as any).getViewportProps();
+
+        // `false` sentinel: pinch zoom started off-globe.
+        // (For wheel zoom we use the closure variable `offGlobeZoomAt` instead,
+        // because deck.gl never calls zoomEnd() for wheel events.)
+        if (startZoomLngLat === false) {
+          const zoom = (this as any)._constrainZoom(
+            (startZoom ?? currentProps.zoom) + Math.log2(scale)
+          );
+          return (this as any)._getUpdatedState({zoom, startZoomLngLat: false});
+        }
+
+        if (!startZoomLngLat) {
+          // Wheel zoom: re-derive each tick. For pinch,
+          // startZoom/startZoomLngLat are set once by zoomStart.
+          startZoom = currentProps.zoom;
+
+          const BURST_TIMEOUT_MS = 200;
+          const now = Date.now();
+          const anchorViewport = (this as any).makeViewport(currentProps);
+          const anchorPos: [number, number] = startPos || pos;
+          const onGlobe = isPixelOnGlobe(anchorViewport, anchorPos);
+
+          // Keep track of when we last saw an off-globe tick. While the session
+          // is recent (< BURST_TIMEOUT_MS), stay in center-zoom even if the
+          // cursor has since entered the globe, to prevent a snap to the edge.
+          if (!onGlobe) {
+            offGlobeZoomAt = now; // refresh the session clock
+          }
+          const inOffGlobeSession =
+            offGlobeZoomAt !== null && now - offGlobeZoomAt < BURST_TIMEOUT_MS;
+
+          if (!onGlobe || inOffGlobeSession) {
+            const zoom = (this as any)._constrainZoom(startZoom + Math.log2(scale));
+            return (this as any)._getUpdatedState({zoom});
+          }
+
+          // New burst that started on-globe — clear the session flag.
+          offGlobeZoomAt = null;
+          startZoomLngLat = (this as any)._unproject(startPos) || (this as any)._unproject(pos);
+        }
+
         const zoom = (this as any)._constrainZoom(startZoom + Math.log2(scale));
+
+        if (!startZoomLngLat) {
+          return (this as any)._getUpdatedState({zoom});
+        }
 
         // Zoom-out (scale < 1): exact cursor anchoring is unstable on a globe (the
         // geo point under an off-center pixel moves non-linearly near the limb and
@@ -209,17 +254,13 @@ class ZoomToCursorGlobeController extends GlobeController {
         //   fromPosition = viewport.unproject(pos)   // geo point now under the cursor
         //   longitude = startZoomLngLat[0] - fromPosition[0] + viewport.longitude
         //   latitude  = startZoomLngLat[1] - fromPosition[1] + viewport.latitude
-        const fromPosition = zoomedViewport.unproject(pos);
-
-        // Guard: unproject can return NaN/undefined for a pixel off the sphere
-        // silhouette; in that case just apply the new zoom about the center.
-        const anchorValid =
-          Array.isArray(fromPosition) &&
-          Number.isFinite(fromPosition[0]) &&
-          Number.isFinite(fromPosition[1]);
-        if (!anchorValid) {
+        // Guard with isPixelOnGlobe: if pos has moved off-globe since the anchor
+        // was set (e.g. during a fast pinch), just apply the zoom toward center.
+        if (!isPixelOnGlobe(zoomedViewport, pos)) {
           return (this as any)._getUpdatedState({zoom});
         }
+
+        const fromPosition = zoomedViewport.unproject(pos);
 
         return (this as any)._getUpdatedState({
           zoom,

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -2,7 +2,7 @@
 // Copyright contributors to the kepler.gl project
 
 import * as DeckCore from '@deck.gl/core';
-import {clamp} from '@math.gl/core';
+import {clamp, vec4} from '@math.gl/core';
 import {GLOBE_MAX_LATITUDE} from '@kepler.gl/constants';
 import {GLOBE_COMMON_RADIUS} from './globe-depth-disk-layer';
 
@@ -24,23 +24,20 @@ function zoomAdjust(latitude: number): number {
 }
 
 /**
- * Transform a homogeneous 4-vector by a column-major 4×4 matrix and
- * divide by w (perspective divide).  Mirrors deck.gl's transformVector().
- * Returns null when rw is zero (degenerate projection) so callers can
- * treat the pixel as off-globe rather than producing Infinity/NaN.
+ * Transform a homogeneous 4-vector by a column-major 4×4 matrix and apply
+ * the perspective divide.  Uses @math.gl/core's vec4.transformMat4 for the
+ * multiply, then divides by w.  Returns null when w is zero (degenerate
+ * projection) so callers can treat the pixel as off-globe rather than
+ * producing Infinity/NaN.
  */
-function transformVector(
+function transformAndDivide(
   matrix: number[],
   v: [number, number, number, number]
 ): [number, number, number] | null {
-  const [m0, m1, m2, m3, m4, m5, m6, m7, m8, m9, m10, m11, m12, m13, m14, m15] = matrix;
-  const [vx, vy, vz, vw] = v;
-  const rx = m0 * vx + m4 * vy + m8 * vz + m12 * vw;
-  const ry = m1 * vx + m5 * vy + m9 * vz + m13 * vw;
-  const rz = m2 * vx + m6 * vy + m10 * vz + m14 * vw;
-  const rw = m3 * vx + m7 * vy + m11 * vz + m15 * vw;
-  if (rw === 0) return null;
-  return [rx / rw, ry / rw, rz / rw];
+  const out = vec4.transformMat4([], v, matrix);
+  const w = out[3];
+  if (w === 0) return null;
+  return [out[0] / w, out[1] / w, out[2] / w];
 }
 
 /**
@@ -64,8 +61,8 @@ function isPixelOnGlobe(viewport: any, pos: [number, number]): boolean {
   if (!m) return true; // conservative: allow if matrix unavailable
 
   // Cast a ray through the pixel (near and far plane points in world space).
-  const coord0 = transformVector(m, [x, y, -1, 1]);
-  const coord1 = transformVector(m, [x, y, 1, 1]);
+  const coord0 = transformAndDivide(m, [x, y, -1, 1]);
+  const coord1 = transformAndDivide(m, [x, y, 1, 1]);
 
   // Degenerate projection — treat conservatively as on-globe.
   if (!coord0 || !coord1) return true;


### PR DESCRIPTION
## Problem

In Globe mode, clicking outside the globe and dragging would rotate the globe erratically. Also, dragging from the globe to outside the silhouette kept rotating instead of freezing.

Root cause: `GlobeViewport.unproject()` clamps the ray–sphere discriminant with `Math.max(0, …)`, so it always returns a valid `[lng, lat]` even for off-globe pixels — snapping to the limb instead of signalling a miss.

## Fix

Added `isPixelOnGlobe(viewport, pos)` — replicates the same ray–sphere math but checks the discriminant before the clamp to detect a true miss.

Used in `panStart` and `pan`:

- **`panStart` outside globe** → stores `false` sentinel; drag is ignored until cursor enters the globe.
- **`pan` while cursor is off-globe** → view freezes at its last valid position.
- **Cursor enters globe mid-drag** (from outside or after leaving) → current position is latched as the new anchor; rotation resumes naturally from there.
- **`pan` while cursor is on-globe** → normal rotation, geo point under cursor stays locked to the grab point.