### PR TITLE
fix(globe): layer blending and overlay blending in Globe mode

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -910,12 +910,14 @@ export default function MapContainerFactory(
 
       const isGlobeMode = mapState.globe?.enabled;
 
-      // In globe mode, forward layerBlending into mapState so individual layers
-      // can include it in their own parameters objects (the global DeckGL parameters
-      // cannot be used in globe mode because they bleed into globe system layers).
+      // In globe mode, forward pre-computed layer rendering parameters into mapState
+      // so individual layers can merge them into their own parameters objects.
+      // The global DeckGL parameters cannot be used in globe mode because they are
+      // merged into globe system layers (atmosphere, surface, etc.) and alter their
+      // carefully tuned blend/depth state.
       const deckLayersMapState =
         isGlobeMode && visState.layerBlending
-          ? {...internalMapState, layerBlending: visState.layerBlending}
+          ? {...internalMapState, layerParameters: getLayerBlendingParameters(visState.layerBlending)}
           : internalMapState;
 
       const deckGlLayers = generateDeckGLLayersMethod(

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -910,15 +910,20 @@ export default function MapContainerFactory(
 
       const isGlobeMode = mapState.globe?.enabled;
 
-      // In globe mode, forward pre-computed layer rendering parameters into mapState
-      // so individual layers can merge them into their own parameters objects.
-      // The global DeckGL parameters cannot be used in globe mode because they are
-      // merged into globe system layers (atmosphere, surface, etc.) and alter their
-      // carefully tuned blend/depth state.
-      const deckLayersMapState =
-        isGlobeMode && visState.layerBlending
-          ? {...internalMapState, layerParameters: getLayerBlendingParameters(visState.layerBlending)}
-          : internalMapState;
+      // In globe mode with a non-default blend mode, forward pre-computed layer
+      // rendering parameters into mapState so individual layers can merge them into
+      // their own parameters objects. The global DeckGL parameters cannot be used in
+      // globe mode because they are merged into globe system layers (atmosphere,
+      // surface, etc.) and alter their carefully tuned blend/depth state.
+      // 'normal' is omitted — it is the WebGL default and injecting it would
+      // override intentional blend:false settings on layers like trip/scenegraph.
+      const layerBlendingParams =
+        isGlobeMode && visState.layerBlending && visState.layerBlending !== 'normal'
+          ? getLayerBlendingParameters(visState.layerBlending)
+          : undefined;
+      const deckLayersMapState = layerBlendingParams
+        ? {...internalMapState, layerParameters: layerBlendingParams}
+        : internalMapState;
 
       const deckGlLayers = generateDeckGLLayersMethod(
         {

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -870,45 +870,6 @@ export default function MapContainerFactory(
       const {setFeatures, onLayerClick, setSelectedFeature} = visStateActions;
 
       const generateDeckGLLayersMethod = generateDeckGLLayers ?? computeDeckLayers;
-      const deckGlLayers = generateDeckGLLayersMethod(
-        {
-          visState,
-          mapState: internalMapState,
-          mapStyle
-        },
-        {
-          mapIndex: index,
-          primaryMap,
-          mapboxApiAccessToken,
-          mapboxApiUrl,
-          layersForDeck,
-          editorInfo: primaryMap
-            ? {
-                editor,
-                editorMenuActive,
-                onSetFeatures: setFeatures,
-                setSelectedFeature,
-                onApplyPolygonFilterAll: visStateActions.setPolygonFilterAllLayers,
-                // @ts-ignore Argument of type 'Readonly<MapContainerProps>' is not assignable to parameter of type 'never'
-                featureCollection: this.featureCollectionSelector(this.props),
-                selectedFeatureIndexes: this.selectedFeatureIndexArraySelector(
-                  // @ts-ignore Argument of type 'unknown' is not assignable to parameter of type 'number'.
-                  editorFeatureSelectedIndex
-                ),
-                viewport
-              }
-            : undefined
-        },
-        {
-          onLayerHover: this._onLayerHover,
-          onSetLayerDomain: this._onLayerSetDomain,
-          onFilteredItemsChange: this._onLayerFilteredItemsChange,
-          onWMSFeatureInfo: this._onWMSFeatureInfo,
-          onRedrawNeeded: this._onRedrawNeeded,
-          onFitBounds: this._onFitBounds
-        },
-        deckGlProps
-      );
 
       const extraDeckParams: {
         getTooltip?: (info: any) => object | null;
@@ -948,6 +909,54 @@ export default function MapContainerFactory(
         : [];
 
       const isGlobeMode = mapState.globe?.enabled;
+
+      // In globe mode, forward layerBlending into mapState so individual layers
+      // can include it in their own parameters objects (the global DeckGL parameters
+      // cannot be used in globe mode because they bleed into globe system layers).
+      const deckLayersMapState =
+        isGlobeMode && visState.layerBlending
+          ? {...internalMapState, layerBlending: visState.layerBlending}
+          : internalMapState;
+
+      const deckGlLayers = generateDeckGLLayersMethod(
+        {
+          visState,
+          mapState: deckLayersMapState,
+          mapStyle
+        },
+        {
+          mapIndex: index,
+          primaryMap,
+          mapboxApiAccessToken,
+          mapboxApiUrl,
+          layersForDeck,
+          editorInfo: primaryMap
+            ? {
+                editor,
+                editorMenuActive,
+                onSetFeatures: setFeatures,
+                setSelectedFeature,
+                onApplyPolygonFilterAll: visStateActions.setPolygonFilterAllLayers,
+                // @ts-ignore Argument of type 'Readonly<MapContainerProps>' is not assignable to parameter of type 'never'
+                featureCollection: this.featureCollectionSelector(this.props),
+                selectedFeatureIndexes: this.selectedFeatureIndexArraySelector(
+                  // @ts-ignore Argument of type 'unknown' is not assignable to parameter of type 'number'.
+                  editorFeatureSelectedIndex
+                ),
+                viewport
+              }
+            : undefined
+        },
+        {
+          onLayerHover: this._onLayerHover,
+          onSetLayerDomain: this._onLayerSetDomain,
+          onFilteredItemsChange: this._onLayerFilteredItemsChange,
+          onWMSFeatureInfo: this._onWMSFeatureInfo,
+          onRedrawNeeded: this._onRedrawNeeded,
+          onFitBounds: this._onFitBounds
+        },
+        deckGlProps
+      );
 
       // Follow the selected basemap style's library so the globe uses the same
       // provider as the flat 2D map (CARTO tiles for MapLibre styles, Mapbox

--- a/src/layers/src/arc-layer/arc-layer.ts
+++ b/src/layers/src/arc-layer/arc-layer.ts
@@ -20,7 +20,8 @@ import {
   hexToRgb,
   DataContainerInterface,
   maybeHexToGeo,
-  ArrowDataContainer
+  ArrowDataContainer,
+  getLayerBlendingParameters
 } from '@kepler.gl/utils';
 import ArcLayerIcon from './arc-layer-icon';
 import {isLayerHoveredFromArrow, createGeoArrowPointVector, getFilteredIndex} from '../layer-utils';
@@ -519,7 +520,8 @@ export default class ArcLayer extends Layer {
     // whole ribbon renders, without changing the global culling that the globe
     // surface relies on.
     const isGlobeMode = Boolean(mapState?.globe?.enabled);
-    const globeParameters = isGlobeMode ? {parameters: {cull: false}} : {};
+    const blendingParameters = getLayerBlendingParameters(mapState?.layerBlending);
+    const globeParameters = isGlobeMode ? {parameters: {cull: false, ...blendingParameters}} : {};
 
     const useArrowLayer = Boolean(this.geoArrowVector0);
 

--- a/src/layers/src/arc-layer/arc-layer.ts
+++ b/src/layers/src/arc-layer/arc-layer.ts
@@ -20,8 +20,7 @@ import {
   hexToRgb,
   DataContainerInterface,
   maybeHexToGeo,
-  ArrowDataContainer,
-  getLayerBlendingParameters
+  ArrowDataContainer
 } from '@kepler.gl/utils';
 import ArcLayerIcon from './arc-layer-icon';
 import {isLayerHoveredFromArrow, createGeoArrowPointVector, getFilteredIndex} from '../layer-utils';
@@ -520,7 +519,7 @@ export default class ArcLayer extends Layer {
     // whole ribbon renders, without changing the global culling that the globe
     // surface relies on.
     const isGlobeMode = Boolean(mapState?.globe?.enabled);
-    const blendingParameters = getLayerBlendingParameters(mapState?.layerBlending);
+    const blendingParameters = mapState?.layerParameters ?? {};
     const globeParameters = isGlobeMode ? {parameters: {cull: false, ...blendingParameters}} : {};
 
     const useArrowLayer = Boolean(this.geoArrowVector0);

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -77,8 +77,7 @@ import {
   getScaleFunction,
   initializeLayerColorMap,
   getCategoricalColorScale,
-  updateCustomColorRangeByColorUI,
-  getLayerBlendingParameters
+  updateCustomColorRangeByColorUI
 } from '@kepler.gl/utils';
 import memoize from 'lodash/memoize';
 import {
@@ -1532,9 +1531,7 @@ class Layer implements KeplerLayer {
     layerCallbacks: any;
     visible: boolean;
   }) {
-    const blendingParameters = mapState.layerBlending
-      ? getLayerBlendingParameters(mapState.layerBlending)
-      : {};
+    const blendingParameters = mapState.layerParameters ?? {};
     return {
       id: this.id,
       idx,
@@ -1659,7 +1656,7 @@ class Layer implements KeplerLayer {
                     background: {
                       parameters: {
                         cull: false,
-                        ...getLayerBlendingParameters(mapState?.layerBlending)
+                        ...(mapState?.layerParameters ?? {})
                       }
                     }
                   }

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -1630,7 +1630,8 @@ class Layer implements KeplerLayer {
             },
             parameters: {
               // text will always show on top of all layers
-              depthTest: false
+              depthTest: false,
+              ...(mapState?.layerParameters ?? {})
             },
 
             getFilterValue: data.getFilterValue,

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -77,7 +77,8 @@ import {
   getScaleFunction,
   initializeLayerColorMap,
   getCategoricalColorScale,
-  updateCustomColorRangeByColorUI
+  updateCustomColorRangeByColorUI,
+  getLayerBlendingParameters
 } from '@kepler.gl/utils';
 import memoize from 'lodash/memoize';
 import {
@@ -1531,13 +1532,19 @@ class Layer implements KeplerLayer {
     layerCallbacks: any;
     visible: boolean;
   }) {
+    const blendingParameters = mapState.layerBlending
+      ? getLayerBlendingParameters(mapState.layerBlending)
+      : {};
     return {
       id: this.id,
       idx,
       coordinateSystem: COORDINATE_SYSTEM.LNGLAT,
       pickable: true,
       wrapLongitude: true,
-      parameters: {depthTest: Boolean(mapState.dragRotate || this.config.visConfig.enable3d)},
+      parameters: {
+        depthTest: Boolean(mapState.dragRotate || this.config.visConfig.enable3d),
+        ...blendingParameters
+      },
       hidden: this.config.hidden,
       // visconfig
       opacity: this.config.visConfig.opacity,
@@ -1651,7 +1658,8 @@ class Layer implements KeplerLayer {
                 ? {
                     background: {
                       parameters: {
-                        cull: false
+                        cull: false,
+                        ...getLayerBlendingParameters(mapState?.layerBlending)
                       }
                     }
                   }

--- a/src/layers/src/editor-layer/editor-layer.ts
+++ b/src/layers/src/editor-layer/editor-layer.ts
@@ -14,6 +14,7 @@ import {PathStyleExtension} from '@deck.gl/extensions';
 import {EDITOR_LAYER_ID, EDITOR_MODES, EDITOR_LAYER_PICKING_RADIUS} from '@kepler.gl/constants';
 import {Viewport, Editor, Feature, FeatureSelectionContext} from '@kepler.gl/types';
 import {generateHashId} from '@kepler.gl/common-utils';
+import {getLayerBlendingParameters} from '@kepler.gl/utils';
 
 import {EDIT_TYPES} from './constants';
 import {LINE_STYLE, FEATURE_STYLE, EDIT_HANDLE_STYLE} from './feature-styles';
@@ -38,7 +39,7 @@ export type GetEditorLayerProps = {
     features: Feature[];
   };
   selectedFeatureIndexes: number[];
-  mapState?: {globe?: {enabled: boolean}};
+  mapState?: {globe?: {enabled: boolean}; layerBlending?: string};
 };
 
 /**
@@ -177,7 +178,9 @@ export function getEditorLayer({
     // Globe mode needs explicit depth testing so the editor overlay is occluded
     // by the sphere; in flat 2D/3D keep deck.gl's default (empty parameters) so
     // this matches the pre-globe behavior exactly.
-    parameters: mapState?.globe?.enabled ? {depthTest: true} : {},
+    parameters: mapState?.globe?.enabled
+      ? {depthTest: true, ...getLayerBlendingParameters(mapState?.layerBlending)}
+      : {},
     shadowEnabled: false,
     _subLayerProps: {
       geojson: {shadowEnabled: false},

--- a/src/layers/src/editor-layer/editor-layer.ts
+++ b/src/layers/src/editor-layer/editor-layer.ts
@@ -14,7 +14,6 @@ import {PathStyleExtension} from '@deck.gl/extensions';
 import {EDITOR_LAYER_ID, EDITOR_MODES, EDITOR_LAYER_PICKING_RADIUS} from '@kepler.gl/constants';
 import {Viewport, Editor, Feature, FeatureSelectionContext} from '@kepler.gl/types';
 import {generateHashId} from '@kepler.gl/common-utils';
-import {getLayerBlendingParameters} from '@kepler.gl/utils';
 
 import {EDIT_TYPES} from './constants';
 import {LINE_STYLE, FEATURE_STYLE, EDIT_HANDLE_STYLE} from './feature-styles';
@@ -39,7 +38,7 @@ export type GetEditorLayerProps = {
     features: Feature[];
   };
   selectedFeatureIndexes: number[];
-  mapState?: {globe?: {enabled: boolean}; layerBlending?: string};
+  mapState?: {globe?: {enabled: boolean}; layerParameters?: Record<string, string | boolean>};
 };
 
 /**
@@ -179,7 +178,7 @@ export function getEditorLayer({
     // by the sphere; in flat 2D/3D keep deck.gl's default (empty parameters) so
     // this matches the pre-globe behavior exactly.
     parameters: mapState?.globe?.enabled
-      ? {depthTest: true, ...getLayerBlendingParameters(mapState?.layerBlending)}
+      ? {depthTest: true, ...(mapState?.layerParameters ?? {})}
       : {},
     shadowEnabled: false,
     _subLayerProps: {

--- a/src/layers/src/flow-layer/flow-layer.ts
+++ b/src/layers/src/flow-layer/flow-layer.ts
@@ -11,7 +11,7 @@ import {FlowmapLayer, PickingType} from '@flowmap.gl/layers';
 import {format as d3Format} from 'd3-format';
 
 import {TOOLTIP_FORMATS, LAYER_VIS_CONFIGS} from '@kepler.gl/constants';
-import {DataContainerInterface, maybeHexToGeo, getPositionFromHexValue, getLayerBlendingParameters} from '@kepler.gl/utils';
+import {DataContainerInterface, maybeHexToGeo, getPositionFromHexValue} from '@kepler.gl/utils';
 import {Datasets, KeplerTable} from '@kepler.gl/table';
 import {
   ColumnLabels,
@@ -531,7 +531,7 @@ export default class FlowLayer extends Layer {
     // a top-level `parameters` won't reach them — we override via _subLayerProps, which
     // getSubLayerProps applies last. cullMode 'none' keeps both faces (arrows are flat).
     const isGlobeMode = Boolean(opts.mapState?.globe?.enabled);
-    const blendingParameters = getLayerBlendingParameters(opts.mapState?.layerBlending);
+    const blendingParameters = opts.mapState?.layerParameters ?? {};
     const globeSubLayerProps = isGlobeMode
       ? (() => {
           const depthParams = {

--- a/src/layers/src/flow-layer/flow-layer.ts
+++ b/src/layers/src/flow-layer/flow-layer.ts
@@ -11,7 +11,7 @@ import {FlowmapLayer, PickingType} from '@flowmap.gl/layers';
 import {format as d3Format} from 'd3-format';
 
 import {TOOLTIP_FORMATS, LAYER_VIS_CONFIGS} from '@kepler.gl/constants';
-import {DataContainerInterface, maybeHexToGeo, getPositionFromHexValue} from '@kepler.gl/utils';
+import {DataContainerInterface, maybeHexToGeo, getPositionFromHexValue, getLayerBlendingParameters} from '@kepler.gl/utils';
 import {Datasets, KeplerTable} from '@kepler.gl/table';
 import {
   ColumnLabels,
@@ -531,10 +531,11 @@ export default class FlowLayer extends Layer {
     // a top-level `parameters` won't reach them — we override via _subLayerProps, which
     // getSubLayerProps applies last. cullMode 'none' keeps both faces (arrows are flat).
     const isGlobeMode = Boolean(opts.mapState?.globe?.enabled);
+    const blendingParameters = getLayerBlendingParameters(opts.mapState?.layerBlending);
     const globeSubLayerProps = isGlobeMode
       ? (() => {
           const depthParams = {
-            parameters: {cull: false, depthTest: true, depthCompare: 'less-equal', cullMode: 'none'}
+            parameters: {cull: false, depthTest: true, depthCompare: 'less-equal', cullMode: 'none', ...blendingParameters}
           };
           return {
             _subLayerProps: {
@@ -572,7 +573,8 @@ export default class FlowLayer extends Layer {
         onHover: layerCallbacks.onLayerHover,
         parameters: {
           ...(cleanProps.parameters || {}),
-          cull: false
+          cull: false,
+          ...blendingParameters
         }
       })
     ];

--- a/src/layers/src/line-layer/line-layer.ts
+++ b/src/layers/src/line-layer/line-layer.ts
@@ -24,7 +24,7 @@ import {
   LayerColumn
 } from '@kepler.gl/types';
 import {default as KeplerTable} from '@kepler.gl/table';
-import {DataContainerInterface, maybeHexToGeo} from '@kepler.gl/utils';
+import {DataContainerInterface, maybeHexToGeo, getLayerBlendingParameters} from '@kepler.gl/utils';
 
 export type LineLayerVisConfigSettings = {
   opacity: VisConfigNumber;
@@ -285,6 +285,7 @@ export default class LineLayer extends ArcLayer {
     const hoveredObject = this.hasHoveredObject(objectHovered);
 
     const globeMode = mapState?.globe?.enabled;
+    const blendingParameters = getLayerBlendingParameters(mapState?.layerBlending);
 
     if (globeMode) {
       const id = `${defaultLayerProps.id}-globe`;
@@ -305,7 +306,7 @@ export default class LineLayer extends ArcLayer {
           // otherwise deck.gl defaults: depth test on + depth write on, so the
           // depth disk occludes segments on the far side of the globe).
           getHeight: 0,
-          parameters: {cull: false},
+          parameters: {cull: false, ...blendingParameters},
           // A Kepler line has a single color channel; an ArcLayer interpolates
           // between source and target colors, so feed the same color to both
           // ends (otherwise the target end falls back to deck.gl's default).
@@ -321,7 +322,7 @@ export default class LineLayer extends ArcLayer {
                 id: `${id}-hovered`,
                 data: [hoveredObject],
                 getHeight: 0,
-                parameters: {cull: false},
+                parameters: {cull: false, ...blendingParameters},
                 getSourceColor: this.config.highlightColor,
                 getTargetColor: this.config.highlightColor,
                 getWidth: data.getWidth,

--- a/src/layers/src/line-layer/line-layer.ts
+++ b/src/layers/src/line-layer/line-layer.ts
@@ -24,7 +24,7 @@ import {
   LayerColumn
 } from '@kepler.gl/types';
 import {default as KeplerTable} from '@kepler.gl/table';
-import {DataContainerInterface, maybeHexToGeo, getLayerBlendingParameters} from '@kepler.gl/utils';
+import {DataContainerInterface, maybeHexToGeo} from '@kepler.gl/utils';
 
 export type LineLayerVisConfigSettings = {
   opacity: VisConfigNumber;
@@ -285,7 +285,7 @@ export default class LineLayer extends ArcLayer {
     const hoveredObject = this.hasHoveredObject(objectHovered);
 
     const globeMode = mapState?.globe?.enabled;
-    const blendingParameters = getLayerBlendingParameters(mapState?.layerBlending);
+    const blendingParameters = mapState?.layerParameters ?? {};
 
     if (globeMode) {
       const id = `${defaultLayerProps.id}-globe`;

--- a/src/layers/src/point-layer/point-layer.ts
+++ b/src/layers/src/point-layer/point-layer.ts
@@ -20,8 +20,7 @@ import {
   hexToRgb,
   findDefaultColorField,
   DataContainerInterface,
-  ArrowDataContainer,
-  getLayerBlendingParameters
+  ArrowDataContainer
 } from '@kepler.gl/utils';
 import {default as KeplerTable} from '@kepler.gl/table';
 import PointLayerIcon from './point-layer-icon';
@@ -596,7 +595,7 @@ export default class PointLayer extends Layer {
         parameters: {
           // circles will be flat on the map when the altitude column is not used
           depthTest: (this.config.columns.altitude?.fieldIdx as number) > -1,
-          ...getLayerBlendingParameters(mapState?.layerBlending)
+          ...(mapState?.layerParameters ?? {})
         },
         lineWidthUnits: 'pixels',
         updateTriggers,

--- a/src/layers/src/point-layer/point-layer.ts
+++ b/src/layers/src/point-layer/point-layer.ts
@@ -20,7 +20,8 @@ import {
   hexToRgb,
   findDefaultColorField,
   DataContainerInterface,
-  ArrowDataContainer
+  ArrowDataContainer,
+  getLayerBlendingParameters
 } from '@kepler.gl/utils';
 import {default as KeplerTable} from '@kepler.gl/table';
 import PointLayerIcon from './point-layer-icon';
@@ -594,7 +595,8 @@ export default class PointLayer extends Layer {
         getPosition,
         parameters: {
           // circles will be flat on the map when the altitude column is not used
-          depthTest: (this.config.columns.altitude?.fieldIdx as number) > -1
+          depthTest: (this.config.columns.altitude?.fieldIdx as number) > -1,
+          ...getLayerBlendingParameters(mapState?.layerBlending)
         },
         lineWidthUnits: 'pixels',
         updateTriggers,

--- a/src/layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/src/layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -220,7 +220,7 @@ export default class ScenegraphLayer extends Layer {
         getOrientation: [angleX, adjustedAngleY, angleZ],
         getColor: DEFAULT_COLOR,
         // parameters
-        parameters: {depthTest: true, blend: false},
+        parameters: {depthTest: true, blend: false, ...(mapState?.layerParameters ?? {})},
         // update triggers
         updateTriggers: {
           getOrientation: {angleX, adjustedAngleY, angleZ},

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -826,10 +826,9 @@ export default class TripLayer extends Layer {
           _animations: {
             '*': {speed: 5}
           },
-          parameters: {depthTest: true, blend: false},
+          parameters: {depthTest: true, blend: false, ...(mapState?.layerParameters ?? {})},
           updateTriggers: {
             getTransformMatrix: {
-              ...this.config.columns,
               currentTime: animationConfig.currentTime,
               rollField,
               pitchField,

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -788,7 +788,8 @@ export default class TripLayer extends Layer {
       wrapLongitude: false,
       parameters: {
         depthTest: mapState.dragRotate,
-        depthMask: false
+        depthMask: false,
+        ...(mapState?.layerParameters ?? {})
       },
       trailLength: visConfig.trailLength * 1000,
       fadeTrail: visConfig.fadeTrail,

--- a/src/layers/src/vector-tile/vector-tile-layer.ts
+++ b/src/layers/src/vector-tile/vector-tile-layer.ts
@@ -688,7 +688,8 @@ export default class VectorTileLayer extends AbstractTileLayer<VectorTile, Featu
             'polygons-stroke': {opacity: visConfig.strokeOpacity},
             'polygons-fill': {
               parameters: {
-                cullMode: CULL_MODE.BACK
+                cullMode: CULL_MODE.BACK,
+                ...(mapState?.layerParameters ?? {})
               }
             }
           },

--- a/src/types/reducers.d.ts
+++ b/src/types/reducers.d.ts
@@ -29,8 +29,8 @@ export type MapState = {
   maxBounds?: Bounds;
   initialState?: any;
   scale?: number;
-  /** Layer blending mode forwarded from visState for use during layer rendering. */
-  layerBlending?: string;
+  /** Layer rendering parameters forwarded from visState for use during layer construction in globe mode. */
+  layerParameters?: Record<string, string | boolean>;
 
   // the following 4 properties assist with split viewports that can optionally have (un)synced viewports and zooms
   /**  Is the application split into 2 maps? */

--- a/src/types/reducers.d.ts
+++ b/src/types/reducers.d.ts
@@ -29,6 +29,8 @@ export type MapState = {
   maxBounds?: Bounds;
   initialState?: any;
   scale?: number;
+  /** Layer blending mode forwarded from visState for use during layer rendering. */
+  layerBlending?: string;
 
   // the following 4 properties assist with split viewports that can optionally have (un)synced viewports and zooms
   /**  Is the application split into 2 maps? */


### PR DESCRIPTION
## Summary

Layer blending and map overlay blending were silently ignored in Globe mode. This PR enables them while keeping globe system layers (atmosphere, surface, depth disk, basemap tiles) visually unaffected.

## Problem

In Globe mode the global DeckGL `parameters` prop was set to `{cull: true}` — back-face culling needed by the sphere surface — which completely replaced the layer blending parameters. Attempting to merge them globally failed because deck.gl **merges** global parameters into every layer, including globe system layers that have their own carefully tuned blend/depth state (`ATMOSPHERE_PARAMETERS`, `BACKGROUND_PARAMETERS`, etc.).

## Solution

Instead of applying blending globally, `map-container.tsx` computes the WebGPU blend parameters once (`getLayerBlendingParameters`) and forwards them via a new optional `MapState.layerParameters` field — but only when in Globe mode. Each user data layer reads `mapState.layerParameters` and merges it into its own `parameters` object at construction time.

- Globe system layers (`globeBaseLayers`, `globeTopLayers`) never go through `computeDeckLayers`, so they never receive `layerParameters` and are completely unaffected.
- Layers that define their own `parameters` override (arc, line, point, flow, editor, trip, scenegraph, text-label backgrounds) explicitly spread `...(mapState?.layerParameters ?? {})`.
- Layers that use `getDefaultDeckLayerProps` without override get blending automatically from `base-layer.ts`.
- In **2D mode** nothing changes — blending is still applied via the global DeckGL `parameters` as before.
- `layerParameters` is typed as `Record<string, string | boolean>` — an open-ended WebGPU parameter map, so future globe rendering parameters can be forwarded through the same field without touching layer files.

<img width="813" height="833" alt="Screenshot 2026-07-30 at 3 52 14 PM" src="https://github.com/user-attachments/assets/a4df45fe-17e2-44e9-a3e3-f67d6f26485e" />
