### PR TITLE
fix(globe): fade atmosphere halo & day/night effect on zoom in

### DIFF
--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -968,11 +968,14 @@ export default function MapContainerFactory(
               // Use the live (internal) latitude so the tile LOD compensation
               // stays in sync with the deck viewport during a drag; mapState
               // latitude lags behind while rotating.
-              latitude: internalMapState.latitude
+              latitude: internalMapState.latitude,
+              zoom: internalMapState.zoom
             })
           : [];
       const globeTopLayers =
-        isGlobeMode && mapState.globe ? getGlobeTopLayers({globe: mapState.globe}) : [];
+        isGlobeMode && mapState.globe
+          ? getGlobeTopLayers({globe: mapState.globe, zoom: internalMapState.zoom})
+          : [];
       const finalDeckGlLayers = isGlobeMode
         ? [...globeBaseLayers, ...deckGlLayers, ...globeTopLayers]
         : deckGlLayers;

--- a/src/deckgl-layers/src/globe/atmosphere-layer.ts
+++ b/src/deckgl-layers/src/globe/atmosphere-layer.ts
@@ -45,10 +45,6 @@ const NUM_SAMPLE_RAYS = 3;
  * Zoom range over which the atmosphere effect fades out.
  * Below ATMOSPHERE_FADE_ZOOM_START the effect is fully visible.
  * Above ATMOSPHERE_FADE_ZOOM_END the effect is completely hidden.
- * This mirrors Google Maps globe behaviour: the atmospheric halo and day/night
- * shading are only meaningful when the full globe is in view; once the user has
- * zoomed in past continent-level the effect becomes a flat colour wash that
- * obscures the map detail, so we fade it to zero.
  */
 const ATMOSPHERE_FADE_ZOOM_START = 3.5;
 const ATMOSPHERE_FADE_ZOOM_END = 6;

--- a/src/deckgl-layers/src/globe/atmosphere-layer.ts
+++ b/src/deckgl-layers/src/globe/atmosphere-layer.ts
@@ -101,7 +101,7 @@ export class AtmosphereLayerRealistic extends SimpleMeshLayer<any, AtmosphereLay
         ...ATMOSPHERE_UNIFORMS,
         fTerminatorOpacityFactor: config.terminator ? config.terminatorOpacity : 0,
         v3SunPos: config.azimuth ? angleToSunPos(toRadians(config.azimuthAngle)) : v3SunPosNow,
-        fAtmosphereZoomFade: zoomFade ?? 1
+        fAtmosphereZoomFade: zoomFade
       };
     }
     super.draw({uniforms});
@@ -229,7 +229,7 @@ export class AtmosphereSkyLayerRealistic extends SimpleMeshLayer<any, Atmosphere
         ...(model as any).props.uniforms,
         ...ATMOSPHERE_UNIFORMS,
         v3SunPos: config.azimuth ? angleToSunPos(toRadians(config.azimuthAngle)) : v3SunPosNow,
-        fAtmosphereZoomFade: zoomFade ?? 1
+        fAtmosphereZoomFade: zoomFade
       };
     }
     super.draw({uniforms});

--- a/src/deckgl-layers/src/globe/atmosphere-layer.ts
+++ b/src/deckgl-layers/src/globe/atmosphere-layer.ts
@@ -41,6 +41,32 @@ const v3SunPosNow = angleToSunPos(sunPosNow.azimuth + Math.PI);
 
 const NUM_SAMPLE_RAYS = 3;
 
+/**
+ * Zoom range over which the atmosphere effect fades out.
+ * Below ATMOSPHERE_FADE_ZOOM_START the effect is fully visible.
+ * Above ATMOSPHERE_FADE_ZOOM_END the effect is completely hidden.
+ * This mirrors Google Maps globe behaviour: the atmospheric halo and day/night
+ * shading are only meaningful when the full globe is in view; once the user has
+ * zoomed in past continent-level the effect becomes a flat colour wash that
+ * obscures the map detail, so we fade it to zero.
+ */
+const ATMOSPHERE_FADE_ZOOM_START = 3.5;
+const ATMOSPHERE_FADE_ZOOM_END = 6;
+
+/**
+ * Convert a mapState zoom level to a [0, 1] atmosphere opacity multiplier.
+ * Returns 1 (fully visible) below ATMOSPHERE_FADE_ZOOM_START, smoothly
+ * interpolates to 0 between the two thresholds, and returns 0 above
+ * ATMOSPHERE_FADE_ZOOM_END.
+ */
+export function atmosphereZoomFade(zoom: number): number {
+  if (zoom <= ATMOSPHERE_FADE_ZOOM_START) return 1;
+  if (zoom >= ATMOSPHERE_FADE_ZOOM_END) return 0;
+  const t = (zoom - ATMOSPHERE_FADE_ZOOM_START) / (ATMOSPHERE_FADE_ZOOM_END - ATMOSPHERE_FADE_ZOOM_START);
+  // Smooth-step for a perceptually gentle transition.
+  return 1 - t * t * (3 - 2 * t);
+}
+
 const ATMOSPHERE_UNIFORMS = {
   v3SunPos: v3SunPosNow,
   exposure: 2,
@@ -59,20 +85,23 @@ const ATMOSPHERE_UNIFORMS = {
 
 type AtmosphereLayerProps = {
   config: GlobeConfig;
+  /** Pre-computed [0, 1] zoom-fade multiplier; 1 = fully visible, 0 = hidden. */
+  zoomFade: number;
 };
 
 export class AtmosphereLayerRealistic extends SimpleMeshLayer<any, AtmosphereLayerProps> {
   static layerName = 'AtmosphereLayerRealistic';
 
   draw({uniforms}: {uniforms: object}): void {
-    const {config} = this.props;
+    const {config, zoomFade} = this.props;
     const model = this.state.model;
     if (model) {
       (model as any).props.uniforms = {
         ...(model as any).props.uniforms,
         ...ATMOSPHERE_UNIFORMS,
         fTerminatorOpacityFactor: config.terminator ? config.terminatorOpacity : 0,
-        v3SunPos: config.azimuth ? angleToSunPos(toRadians(config.azimuthAngle)) : v3SunPosNow
+        v3SunPos: config.azimuth ? angleToSunPos(toRadians(config.azimuthAngle)) : v3SunPosNow,
+        fAtmosphereZoomFade: zoomFade ?? 1
       };
     }
     super.draw({uniforms});
@@ -100,6 +129,7 @@ export class AtmosphereLayerRealistic extends SimpleMeshLayer<any, AtmosphereLay
 
           uniform float fTerminatorAttenuateFactor;
           uniform float fTerminatorOpacityFactor;
+          uniform float fAtmosphereZoomFade;
 
           const int nSamples = ${NUM_SAMPLE_RAYS};
 
@@ -176,6 +206,11 @@ export class AtmosphereLayerRealistic extends SimpleMeshLayer<any, AtmosphereLay
           // reaches full darkening on the night side (<= -0.2).
           float fNightMask = smoothstep(0.2, -0.2, fLightAngle);
           fragColor.a *= fNightMask;
+
+          // Fade out the entire day/night shading effect as the user zooms in.
+          // At zoom levels above ATMOSPHERE_FADE_ZOOM_END the effect is invisible,
+          // so it doesn't obscure map detail at street/city scale.
+          fragColor.a *= fAtmosphereZoomFade;
         `,
         'fs:DECKGL_FILTER_COLOR': ``
       }
@@ -187,13 +222,14 @@ export class AtmosphereSkyLayerRealistic extends SimpleMeshLayer<any, Atmosphere
   static layerName = 'AtmosphereSkyLayerRealistic';
 
   draw({uniforms}: {uniforms: object}): void {
-    const {config} = this.props;
+    const {config, zoomFade} = this.props;
     const model = this.state.model;
     if (model) {
       (model as any).props.uniforms = {
         ...(model as any).props.uniforms,
         ...ATMOSPHERE_UNIFORMS,
-        v3SunPos: config.azimuth ? angleToSunPos(toRadians(config.azimuthAngle)) : v3SunPosNow
+        v3SunPos: config.azimuth ? angleToSunPos(toRadians(config.azimuthAngle)) : v3SunPosNow,
+        fAtmosphereZoomFade: zoomFade ?? 1
       };
     }
     super.draw({uniforms});
@@ -218,6 +254,7 @@ export class AtmosphereSkyLayerRealistic extends SimpleMeshLayer<any, Atmosphere
           uniform float fKr4PI;
           uniform float fKm4PI;
           uniform float fScaleDepth;
+          uniform float fAtmosphereZoomFade;
 
           const int nSamples = ${NUM_SAMPLE_RAYS};
 
@@ -295,6 +332,9 @@ export class AtmosphereSkyLayerRealistic extends SimpleMeshLayer<any, Atmosphere
 
           fragColor = vec4(skyColor, 1.0);
           fragColor.a = fragColor.b;
+
+          // Fade the sky halo out as the user zooms in past continent scale.
+          fragColor.a *= fAtmosphereZoomFade;
         `,
         'fs:DECKGL_FILTER_COLOR': ``
       }
@@ -315,11 +355,13 @@ const ATMOSPHERE_SKY_PARAMETERS = {
   blendEquation: [0x8006, 0x8006]
 };
 
-export const getGlobeAtmosphereLayer = ({config}: {config: GlobeConfig}) => {
+export const getGlobeAtmosphereLayer = ({config, zoom}: {config: GlobeConfig; zoom?: number}) => {
+  const zoomFade = atmosphereZoomFade(zoom ?? 0);
   return new AtmosphereLayerRealistic({
     id: 'atmosphere',
     data: [[0, 0, 0]],
     config,
+    zoomFade,
     coordinateOrigin: [0, 0, 0],
     coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
     getPosition: ((d: number[]) => d) as any,
@@ -329,11 +371,13 @@ export const getGlobeAtmosphereLayer = ({config}: {config: GlobeConfig}) => {
   });
 };
 
-export const getGlobeAtmosphereSkyLayer = ({config}: {config: GlobeConfig}) => {
+export const getGlobeAtmosphereSkyLayer = ({config, zoom}: {config: GlobeConfig; zoom?: number}) => {
+  const zoomFade = atmosphereZoomFade(zoom ?? 0);
   return new AtmosphereSkyLayerRealistic({
     id: 'atmosphere-sky',
     data: [[0, 0, 0]],
     config,
+    zoomFade,
     coordinateOrigin: [0, 0, 0],
     coordinateSystem: COORDINATE_SYSTEM.CARTESIAN,
     getPosition: ((d: number[]) => d) as any,

--- a/src/deckgl-layers/src/globe/globe-layers.ts
+++ b/src/deckgl-layers/src/globe/globe-layers.ts
@@ -500,7 +500,8 @@ export const getGlobeBaseLayers = ({
   globe,
   mapStyleType,
   basemapProvider,
-  latitude
+  latitude,
+  zoom
 }: {
   mapboxApiAccessToken: string;
   globe: Globe;
@@ -516,6 +517,11 @@ export const getGlobeBaseLayers = ({
    * omitted, no latitude compensation is applied (equator behavior).
    */
   latitude?: number;
+  /**
+   * Current map zoom level. Used to fade the atmosphere effects out when the user
+   * zooms in past a certain threshold (mirrors Google Maps globe behaviour).
+   */
+  zoom?: number;
 }): Layer[] => {
   const {config} = globe;
 
@@ -534,7 +540,7 @@ export const getGlobeBaseLayers = ({
   const hasTileAccess = useCarto || Boolean(mapboxApiAccessToken);
 
   return [
-    config.atmosphere ? getGlobeAtmosphereSkyLayer({config}) : null,
+    config.atmosphere ? getGlobeAtmosphereSkyLayer({config, zoom}) : null,
 
     // Depth-only cross-section disk: writes depth at the globe's silhouette so
     // far-side geometry (arcs/lines) is occluded by the planet.
@@ -678,7 +684,7 @@ export const getGlobeBaseLayers = ({
   ].filter(Boolean) as Layer[];
 };
 
-export const getGlobeTopLayers = ({globe}: {globe: Globe}): Layer[] => {
+export const getGlobeTopLayers = ({globe, zoom}: {globe: Globe; zoom?: number}): Layer[] => {
   const {config} = globe;
-  return [config.atmosphere ? getGlobeAtmosphereLayer({config}) : null].filter(Boolean) as Layer[];
+  return [config.atmosphere ? getGlobeAtmosphereLayer({config, zoom}) : null].filter(Boolean) as Layer[];
 };


### PR DESCRIPTION
## Problem

The atmosphere halo and day/night terminator are only meaningful when the full globe is visible on screen. Once the user zooms past continent level both effects become a flat colour wash that obscures map detail — they are never disabled, even at city/street zoom. Google Maps hides these effects at the same point.

## Solution

Introduce a smooth-step zoom-fade multiplier (`fAtmosphereZoomFade`) computed in JS and passed as a GLSL uniform to both atmosphere shaders. It is multiplied into `fragColor.a` as the very last step in both fragment shaders, so it gates the entire effect without interfering with the existing scattering or night-mask logic.

| Zoom | Opacity |
|------|---------|
| ≤ 3.5 | 100% — full effect (whole globe in view) |
| 3.5 – 6 | smooth-step fade 100% → 0% |
| ≥ 6 | 0% — completely hidden |

## Changes

- **`atmosphere-layer.ts`** — `atmosphereZoomFade(zoom)` helper; `zoomFade` prop on both layer classes; `fAtmosphereZoomFade` uniform declared and applied in both fragment shaders.
- **`globe-layers.ts`** — `getGlobeBaseLayers` and `getGlobeTopLayers` accept an optional `zoom` parameter and forward it to the atmosphere layer factories.
- **`map-container.tsx`** — both call sites pass `internalMapState.zoom` (live viewport state, same source as the existing latitude LOD compensation).

## Testing

1. Enable Globe mode.
2. Zoom out fully (zoom ≤ 3.5) — atmosphere halo and night terminator fully visible.
3. Zoom in slowly — both effects fade together between zoom 3.5 and 6.
4. At zoom ≥ 6 — both effects are gone; map detail is unobscured.
5. Zoom back out — effects smoothly reappear.
6. Toggle atmosphere off in the Globe config panel — no atmosphere at any zoom (unchanged behaviour).