### PR TITLE
chore: add reduxLogLevel config to suppress noisy Redux actions in dev console

### DIFF
--- a/examples/demo-app/src/store.js
+++ b/examples/demo-app/src/store.js
@@ -6,6 +6,7 @@ import {createLogger} from 'redux-logger';
 import thunk from 'redux-thunk';
 
 import {enhanceReduxMiddleware} from '@kepler.gl/reducers';
+import {getApplicationConfig} from '@kepler.gl/utils';
 
 // eslint-disable-next-line no-unused-vars
 import Window from 'global/window';
@@ -18,14 +19,38 @@ const reducers = combineReducers({
 
 export const middlewares = enhanceReduxMiddleware([thunk]);
 
-const NOISY_ACTIONS = new Set(['@@kepler.gl/MOUSE_MOVE', '@@kepler.gl/LAYER_HOVER']);
+// Actions suppressed at each log level. Each level is a superset of the one above.
+// Set window.__KEPLER_LOG_FULL__ = true in the browser console to override and log everything.
+const LEVEL1_ACTIONS = new Set([
+  '@@kepler.gl/MOUSE_MOVE',
+  '@@kepler.gl/LAYER_HOVER',
+  '@@kepler.gl/SET_LOADING_INDICATOR',
+  '@@openassistant/SET_MAP_BOUNDARY'
+]);
 
-// Set window.__KEPLER_LOG_FULL__ = true in the console to include
-// high-frequency actions (MOUSE_MOVE, LAYER_HOVER, UPDATE_MAP).
+const LEVEL2_ACTIONS = new Set([
+  ...LEVEL1_ACTIONS,
+  '@@kepler.gl/LOAD_MAP_STYLES',
+  '@@kepler.gl/MAP_LOAD_STARTED',
+  '@@kepler.gl/LAYER_VISUAL_CHANGE',
+  '@@kepler.gl/UPDATE_MAP',
+  '@@kepler.gl/ON_MAP_CLICK',
+  '@@kepler.gl/FILTER_CHANGE'
+]);
+
+const SUPPRESSED_BY_LEVEL = [
+  new Set(),          // 0 — log everything
+  LEVEL1_ACTIONS,     // 1 — suppress UI noise (default)
+  LEVEL2_ACTIONS      // 2 — suppress UI noise + map/layer chatter
+];
+
 if (NODE_ENV === 'local') {
+  const level = getApplicationConfig().reduxLogLevel ?? 1;
+  const suppressed = SUPPRESSED_BY_LEVEL[level] ?? LEVEL1_ACTIONS;
+
   const logger = createLogger({
     collapsed: () => true,
-    predicate: (_getState, action) => Window.__KEPLER_LOG_FULL__ || !NOISY_ACTIONS.has(action.type)
+    predicate: (_getState, action) => Window.__KEPLER_LOG_FULL__ || !suppressed.has(action.type)
   });
   middlewares.push(logger);
 }
@@ -42,8 +67,10 @@ let composeEnhancers = compose;
  */
 
 if (Window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) {
+  const level = getApplicationConfig().reduxLogLevel ?? 1;
+  const suppressed = SUPPRESSED_BY_LEVEL[level] ?? LEVEL1_ACTIONS;
   composeEnhancers = Window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-    actionsBlacklist: [...NOISY_ACTIONS]
+    actionsBlacklist: [...suppressed]
   });
 }
 

--- a/src/utils/src/application-config.ts
+++ b/src/utils/src/application-config.ts
@@ -50,6 +50,28 @@ export type BaseMapLibraryConfig = {
  * A mechanism to override default Kepler values/settings so that we
  * without having to make application-specific changes to the kepler repo.
  */
+/**
+ * Controls which Redux actions are suppressed by the dev-mode Redux logger.
+ * Mirrors the `log.level` convention used by luma.gl / deck.gl.
+ *
+ * - `0` — log every action (no filtering)
+ * - `1` — suppress the highest-frequency UI noise:
+ *          MOUSE_MOVE, LAYER_HOVER, SET_MAP_BOUNDARY, SET_LOADING_INDICATOR
+ * - `2` — suppress everything in level 1 plus map/layer update chatter:
+ *          LOAD_MAP_STYLES, UPDATE_MAP, LAYER_VISUAL_CHANGE,
+ *          ON_MAP_CLICK, FILTER_CHANGE, MAP_LOAD_STARTED
+ *
+ * Only has an effect when NODE_ENV === 'local' (i.e. `yarn start`).
+ * Default: `1`
+ *
+ * @example
+ * ```ts
+ * initApplicationConfig({ reduxLogLevel: 2 }); // quieter dev console
+ * initApplicationConfig({ reduxLogLevel: 0 }); // see every action
+ * ```
+ */
+export type ReduxLogLevel = 0 | 1 | 2;
+
 export type KeplerApplicationConfig = {
   /** Default name of export HTML file, can be overridden by user */
   defaultHtmlName?: string;
@@ -169,6 +191,9 @@ export type KeplerApplicationConfig = {
    * ```
    */
   customIconUrl?: string;
+
+  /** Controls Redux action logging verbosity in dev mode. See {@link ReduxLogLevel}. */
+  reduxLogLevel?: ReduxLogLevel;
 };
 
 const DEFAULT_APPLICATION_CONFIG: Required<KeplerApplicationConfig> = {
@@ -249,7 +274,9 @@ const DEFAULT_APPLICATION_CONFIG: Required<KeplerApplicationConfig> = {
 
   customIcons: [],
 
-  customIconUrl: ''
+  customIconUrl: '',
+
+  reduxLogLevel: 1
 };
 
 const applicationConfig: Required<KeplerApplicationConfig> = DEFAULT_APPLICATION_CONFIG;

--- a/src/utils/src/application-config.ts
+++ b/src/utils/src/application-config.ts
@@ -61,7 +61,11 @@ export type BaseMapLibraryConfig = {
  *          LOAD_MAP_STYLES, UPDATE_MAP, LAYER_VISUAL_CHANGE,
  *          ON_MAP_CLICK, FILTER_CHANGE, MAP_LOAD_STARTED
  *
- * Only has an effect when NODE_ENV === 'local' (i.e. `yarn start`).
+ * Effects by context:
+ * - **redux-logger** (console output): only active when `NODE_ENV === 'local'` (i.e. `yarn start`)
+ * - **Redux DevTools** (`actionsBlacklist`): active whenever the browser extension is present,
+ *   regardless of `NODE_ENV`
+ *
  * Default: `1`
  *
  * @example

--- a/src/utils/src/index.ts
+++ b/src/utils/src/index.ts
@@ -186,7 +186,8 @@ export type {
   BaseMapLibraryConfig,
   MapLibInstance,
   GetMapRef,
-  SvgIcon
+  SvgIcon,
+  ReduxLogLevel
 } from './application-config';
 export type {DatabaseAdapter, DatabaseConnection} from './application-config-types';
 


### PR DESCRIPTION
## What

Adds a `reduxLogLevel` setting to `KeplerApplicationConfig` that controls which Redux actions are suppressed by the dev-mode Redux logger (`yarn start`).

## Why

During development, high-frequency actions like `MOUSE_MOVE`, `LAYER_HOVER`, `SET_LOADING_INDICATOR`, and `SET_MAP_BOUNDARY` flood the console and make it hard to track meaningful state changes.

## How

- New `reduxLogLevel: 0 | 1 | 2` field in `KeplerApplicationConfig` (mirrors the `log.level` convention from luma.gl / deck.gl)
- Default is `1` — suppresses the noisiest actions out of the box without any extra configuration
- `examples/demo-app/src/store.js` reads the level from `getApplicationConfig()` and passes a matching `predicate` to `redux-logger` and `actionsBlacklist` to Redux DevTools

| Level | Suppressed actions |
|---|---|
| `0` | nothing — log everything |
| `1` *(default)* | `MOUSE_MOVE`, `LAYER_HOVER`, `SET_LOADING_INDICATOR`, `@@openassistant/SET_MAP_BOUNDARY` |
| `2` | everything in level 1 + `LOAD_MAP_STYLES`, `UPDATE_MAP`, `LAYER_VISUAL_CHANGE`, `ON_MAP_CLICK`, `FILTER_CHANGE`, `MAP_LOAD_STARTED` |

The browser console escape hatch is preserved: `window.__KEPLER_LOG_FULL__ = true` overrides the level and logs everything.

## Usage

```ts
initApplicationConfig({ reduxLogLevel: 2 }); // quietest
initApplicationConfig({ reduxLogLevel: 0 }); // see every action
```