### PR TITLE
fix: custom basemap attribution and style dropdown thumbnail

### DIFF
--- a/src/components/src/common/styled-components.tsx
+++ b/src/components/src/common/styled-components.tsx
@@ -557,11 +557,13 @@ export const StyledMapContainer = styled.div`
 export type StyledAttributionProps = {
   mapLibCssClass: string;
   mapLibAttributionCssClass: string;
+  showLogo?: boolean;
 };
 
 export const StyledAttribution = styled.div
   .withConfig({
-    shouldForwardProp: prop => !['mapLibCssClass', 'mapLibAttributionCssClass'].includes(prop)
+    shouldForwardProp: prop =>
+      !['mapLibCssClass', 'mapLibAttributionCssClass', 'showLogo'].includes(prop)
   })
   .attrs<StyledAttributionProps>(props => ({
     className: props.mapLibAttributionCssClass
@@ -585,7 +587,7 @@ export const StyledAttribution = styled.div
 
     .basemap-attribution {
       display: inline-block;
-      max-width: 220px;
+      max-width: ${props => (props.showLogo === false ? '320px' : '220px')};
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
@@ -639,7 +641,7 @@ export const StyledAttribution = styled.div
     }
 
     .basemap-attribution {
-      max-width: 140px;
+      max-width: ${(props: StyledAttributionProps) => (props.showLogo === false ? '220px' : '140px')};
     }
   `};
 `;

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -288,10 +288,11 @@ export default function MapContainerFactory(
     }
 
     state = {
-      // true only when the basemap uses Mapbox-hosted tiles (mapbox:// sources).
-      // For any other provider (CARTO, OpenFreeMap, OSM …) MapLibre is merely the
-      // rendering engine, not the tile provider, so the "Basemap by: MapLibre" logo
-      // should not appear.
+      // true for built-in kepler.gl styles (dark-matter, positron, …) and when the
+      // basemap uses Mapbox-hosted tiles (mapbox:// sources).
+      // For user-added custom styles (OpenFreeMap, CARTO self-hosted, …) MapLibre is
+      // merely the rendering engine, not the tile provider, so the logo is hidden and
+      // the basemap's own TileJSON attribution is shown instead.
       showBaseMapLibLogo: false,
       // attribution strings collected from the resolved map sources (e.g. CARTO,
       // OpenFreeMap).  Populated after TileJSON resolves.
@@ -309,7 +310,7 @@ export default function MapContainerFactory(
       if (this._map) {
         this._map.off(MAPBOXGL_STYLE_UPDATE, this._onMapboxStyleUpdate);
         this._map.off(MAPBOXGL_RENDER, this._onMapRender);
-        this._removeOsmSourceDataListener();
+        this._removeBasemapAttributionListeners();
       }
       if (!this._ref.current) {
         return;
@@ -319,7 +320,7 @@ export default function MapContainerFactory(
 
     componentDidUpdate(prevProps) {
       if (prevProps.mapStyle.styleType !== this.props.mapStyle.styleType) {
-        this._removeOsmSourceDataListener();
+        this._removeBasemapAttributionListeners();
         if (this.props.mapStyle.styleType === NO_MAP_ID) {
           this.setState({
             showBaseMapLibLogo: false,
@@ -335,8 +336,8 @@ export default function MapContainerFactory(
     _map: GetMapRef | null = null;
     _ref = createRef<HTMLDivElement>();
     _deckGLErrorsElapsed: {[id: string]: number} = {};
-    _osmSourceDataListener: ((e: any) => void) | null = null;
-    _osmIdleListener: (() => void) | null = null;
+    _basemapSourceDataListener: ((e: any) => void) | null = null;
+    _basemapIdleListener: (() => void) | null = null;
 
     _onMapRender = () => {
       if (typeof this.props.onMapRender === 'function') {
@@ -530,7 +531,7 @@ export default function MapContainerFactory(
     };
 
     _updateAttribution = (update?: any) => {
-      this._removeOsmSourceDataListener();
+      this._removeBasemapAttributionListeners();
 
       let styleObj = update?.style || null;
       if (!styleObj && this._map) {
@@ -577,24 +578,24 @@ export default function MapContainerFactory(
       // after style.load.  Start a listener so we can update basemapAttributions
       // as soon as the sources resolve their TileJSON.
       if (!usesMapbox) {
-        this._checkOsmAttributionOnSourceLoad();
+        this._collectBasemapAttributions();
       }
     };
 
-    _removeOsmSourceDataListener = () => {
-      if (this._osmSourceDataListener && this._map) {
-        this._map.off('sourcedata', this._osmSourceDataListener);
-        this._osmSourceDataListener = null;
+    _removeBasemapAttributionListeners = () => {
+      if (this._basemapSourceDataListener && this._map) {
+        this._map.off('sourcedata', this._basemapSourceDataListener);
+        this._basemapSourceDataListener = null;
       }
-      if (this._osmIdleListener && this._map) {
-        this._map.off('idle', this._osmIdleListener);
-        this._osmIdleListener = null;
+      if (this._basemapIdleListener && this._map) {
+        this._map.off('idle', this._basemapIdleListener);
+        this._basemapIdleListener = null;
       }
     };
 
-    _checkOsmAttributionOnSourceLoad = () => {
+    _collectBasemapAttributions = () => {
       if (!this._map) return;
-      this._removeOsmSourceDataListener();
+      this._removeBasemapAttributionListeners();
       let attempts = 0;
       // Cap retries so a style that never yields attributions doesn't leave a
       // permanent sourcedata listener attached.
@@ -605,7 +606,7 @@ export default function MapContainerFactory(
         // source's metadata is available so custom basemap attributions are not lost.
         const basemapAttributions = getBaseMapAttributions(this._map);
         if (basemapAttributions.length) {
-          this._removeOsmSourceDataListener();
+          this._removeBasemapAttributionListeners();
           // Don't change showBaseMapLibLogo here — it is fixed at style.load time
           // based on whether the style uses Mapbox tiles.  We only update the
           // provider attributions collected from the resolved TileJSON.
@@ -626,7 +627,7 @@ export default function MapContainerFactory(
         attempts++;
         tryCollect();
         if (attempts >= MAX_ATTEMPTS) {
-          this._removeOsmSourceDataListener();
+          this._removeBasemapAttributionListeners();
         }
       };
 
@@ -636,15 +637,15 @@ export default function MapContainerFactory(
       // one-shot fallback that catches cases where the sourcedata metadata
       // events are missed or the source never reaches isSourceLoaded.
       const onIdle = () => {
-        this._removeOsmSourceDataListener();
+        this._removeBasemapAttributionListeners();
         const basemapAttributions = getBaseMapAttributions(this._map);
         if (basemapAttributions.length) {
           this.setState({basemapAttributions});
         }
       };
 
-      this._osmSourceDataListener = onSourceData;
-      this._osmIdleListener = onIdle;
+      this._basemapSourceDataListener = onSourceData;
+      this._basemapIdleListener = onIdle;
       this._map.on('sourcedata', onSourceData);
       this._map.on('idle', onIdle);
     };
@@ -656,7 +657,7 @@ export default function MapContainerFactory(
         if (map && this._map !== map) {
           this._map.off(MAPBOXGL_STYLE_UPDATE, this._onMapboxStyleUpdate);
           this._map.off(MAPBOXGL_RENDER, this._onMapRender);
-          this._removeOsmSourceDataListener();
+          this._removeBasemapAttributionListeners();
           this._map = null;
         }
       }

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -288,8 +288,13 @@ export default function MapContainerFactory(
     }
 
     state = {
-      showBaseMapAttribution: true,
-      // attribution strings declared by custom basemap styles (e.g. OpenFreeMap)
+      // true only when the basemap uses Mapbox-hosted tiles (mapbox:// sources).
+      // For any other provider (CARTO, OpenFreeMap, OSM …) MapLibre is merely the
+      // rendering engine, not the tile provider, so the "Basemap by: MapLibre" logo
+      // should not appear.
+      showBaseMapLibLogo: false,
+      // attribution strings collected from the resolved map sources (e.g. CARTO,
+      // OpenFreeMap).  Populated after TileJSON resolves.
       basemapAttributions: [] as string[]
     };
 
@@ -317,7 +322,7 @@ export default function MapContainerFactory(
         this._removeOsmSourceDataListener();
         if (this.props.mapStyle.styleType === NO_MAP_ID) {
           this.setState({
-            showBaseMapAttribution: false,
+            showBaseMapLibLogo: false,
             basemapAttributions: []
           });
         } else {
@@ -331,6 +336,7 @@ export default function MapContainerFactory(
     _ref = createRef<HTMLDivElement>();
     _deckGLErrorsElapsed: {[id: string]: number} = {};
     _osmSourceDataListener: ((e: any) => void) | null = null;
+    _osmIdleListener: (() => void) | null = null;
 
     _onMapRender = () => {
       if (typeof this.props.onMapRender === 'function') {
@@ -540,23 +546,37 @@ export default function MapContainerFactory(
       const usesMapbox = styleObj ? isStyleUsingMapboxTiles(styleObj) : false;
       const usesOsm = styleObj ? isStyleUsingOpenStreetMapTiles(styleObj) : false;
       const basemapAttributions = getBaseMapAttributions(this._map);
-      // if OSM tiles are detected but no source-level attribution string was
-      // collected, fold in the canonical OSM attribution so the render path
-      // stays uniform (no separate hardcoded fallback link)
+
+      // if OSM tiles are detected in the raw style but no source-level attribution
+      // string was collected yet, fold in the canonical OSM attribution so the
+      // render path stays uniform (no separate hardcoded fallback link)
       if (usesOsm && !basemapAttributions.length) {
         basemapAttributions.push(OSM_ATTRIBUTION_HTML);
       }
 
-      if (usesMapbox || usesOsm || basemapAttributions.length) {
-        this.setState({
-          showBaseMapAttribution: true,
-          basemapAttributions
-        });
-      } else {
-        this.setState({
-          showBaseMapAttribution: false,
-          basemapAttributions
-        });
+      // Determine whether to show the "Basemap by: MapLibre/Mapbox" logo:
+      //  - Always show for built-in kepler.gl styles (dark-matter, positron, …):
+      //    they don't carry their own "provider" branding so the rendering-engine
+      //    logo acts as the basemap credit.
+      //  - Always show when Mapbox tiles are in use (mapbox:// sources): Mapbox
+      //    attribution is required.
+      //  - Hide for custom user-added styles (custom === 'LOCAL' | 'MANAGED'):
+      //    those styles supply their own TileJSON attribution (e.g. OpenFreeMap),
+      //    so showing "Basemap by: MapLibre" would be misleading.
+      const styleType = this.props.mapStyle?.styleType;
+      const currentStyle = this.props.mapStyle?.mapStyles?.[styleType];
+      const isUserCustomStyle = Boolean(currentStyle?.custom);
+      const showBaseMapLibLogo = usesMapbox || !isUserCustomStyle;
+
+      this.setState({
+        showBaseMapLibLogo,
+        basemapAttributions
+      });
+
+      // For non-Mapbox styles, TileJSON attribution resolves asynchronously
+      // after style.load.  Start a listener so we can update basemapAttributions
+      // as soon as the sources resolve their TileJSON.
+      if (!usesMapbox) {
         this._checkOsmAttributionOnSourceLoad();
       }
     };
@@ -565,6 +585,10 @@ export default function MapContainerFactory(
       if (this._osmSourceDataListener && this._map) {
         this._map.off('sourcedata', this._osmSourceDataListener);
         this._osmSourceDataListener = null;
+      }
+      if (this._osmIdleListener && this._map) {
+        this._map.off('idle', this._osmIdleListener);
+        this._osmIdleListener = null;
       }
     };
 
@@ -575,27 +599,54 @@ export default function MapContainerFactory(
       // Cap retries so a style that never yields attributions doesn't leave a
       // permanent sourcedata listener attached.
       const MAX_ATTEMPTS = 50;
-      const onSourceData = (e: any) => {
-        if (!e?.isSourceLoaded) return;
-        attempts++;
+
+      const tryCollect = () => {
         // TileJSON resolves asynchronously; re-collect attributions once a
-        // source is loaded so custom basemap attributions are not lost.
-        // (Unlike the sync path, OSM detection here reads the same resolved
-        // sources as getBaseMapAttributions, so a separate OSM fold-in is
-        // unreachable — any OSM string would already be in the collected list.)
+        // source's metadata is available so custom basemap attributions are not lost.
         const basemapAttributions = getBaseMapAttributions(this._map);
         if (basemapAttributions.length) {
           this._removeOsmSourceDataListener();
-          this.setState({
-            showBaseMapAttribution: true,
-            basemapAttributions
-          });
-        } else if (attempts >= MAX_ATTEMPTS) {
+          // Don't change showBaseMapLibLogo here — it is fixed at style.load time
+          // based on whether the style uses Mapbox tiles.  We only update the
+          // provider attributions collected from the resolved TileJSON.
+          this.setState({basemapAttributions});
+          return true;
+        }
+        return false;
+      };
+
+      const onSourceData = (e: any) => {
+        // Collect attributions when:
+        //   (a) a source's TileJSON has just been fetched (sourceDataType === 'metadata') —
+        //       this is the earliest moment the `attribution` property is available on the
+        //       resolved source object, or
+        //   (b) a source is fully loaded (isSourceLoaded === true) — fallback for raster
+        //       sources or styles that set attribution inline rather than via TileJSON.
+        if (!e?.isSourceLoaded && e?.sourceDataType !== 'metadata') return;
+        attempts++;
+        tryCollect();
+        if (attempts >= MAX_ATTEMPTS) {
           this._removeOsmSourceDataListener();
         }
       };
+
+      // The `idle` event fires when the map has finished loading all pending
+      // resources (tiles, TileJSON, sprites). At that point attributions from
+      // all sources are guaranteed to be resolved, so this is a reliable
+      // one-shot fallback that catches cases where the sourcedata metadata
+      // events are missed or the source never reaches isSourceLoaded.
+      const onIdle = () => {
+        this._removeOsmSourceDataListener();
+        const basemapAttributions = getBaseMapAttributions(this._map);
+        if (basemapAttributions.length) {
+          this.setState({basemapAttributions});
+        }
+      };
+
       this._osmSourceDataListener = onSourceData;
+      this._osmIdleListener = onIdle;
       this._map.on('sourcedata', onSourceData);
+      this._map.on('idle', onIdle);
     };
 
     _setMapRef = mapRef => {
@@ -1449,7 +1500,7 @@ export default function MapContainerFactory(
           ) : null}
           {this.props.primary ? (
             <Attribution
-              showBaseMapLibLogo={this.state.showBaseMapAttribution}
+              showBaseMapLibLogo={this.state.showBaseMapLibLogo}
               basemapAttributions={this.state.basemapAttributions}
               datasetAttributions={datasetAttributions}
               baseMapLibraryConfig={baseMapLibraryConfig}

--- a/src/components/src/map/attribution.tsx
+++ b/src/components/src/map/attribution.tsx
@@ -355,7 +355,7 @@ export const Attribution: React.FC<AttributionProps> = ({
         <StyledAttribution
           mapLibCssClass={baseMapLibraryConfig.mapLibCssClass}
           mapLibAttributionCssClass={baseMapLibraryConfig.mapLibAttributionCssClass}
-          showLogo={false}
+          showLogo={globeAttributions.length > 0}
         >
           <EndHorizontalFlexbox>
             <DatasetAttributions datasetAttributions={datasetAttributions} isPalm={isPalm} />

--- a/src/components/src/map/attribution.tsx
+++ b/src/components/src/map/attribution.tsx
@@ -355,6 +355,7 @@ export const Attribution: React.FC<AttributionProps> = ({
         <StyledAttribution
           mapLibCssClass={baseMapLibraryConfig.mapLibCssClass}
           mapLibAttributionCssClass={baseMapLibraryConfig.mapLibAttributionCssClass}
+          showLogo={false}
         >
           <EndHorizontalFlexbox>
             <DatasetAttributions datasetAttributions={datasetAttributions} isPalm={isPalm} />
@@ -382,6 +383,7 @@ export const Attribution: React.FC<AttributionProps> = ({
       <StyledAttribution
         mapLibCssClass={baseMapLibraryConfig.mapLibCssClass}
         mapLibAttributionCssClass={baseMapLibraryConfig.mapLibAttributionCssClass}
+        showLogo={true}
       >
         <EndHorizontalFlexbox>
           <DatasetAttributions datasetAttributions={datasetAttributions} isPalm={isPalm} />

--- a/src/components/src/modals/add-map-style-modal.tsx
+++ b/src/components/src/modals/add-map-style-modal.tsx
@@ -148,15 +148,28 @@ function AddMapStyleModalFactory() {
       if (map && mapRef.current !== map) {
         mapRef.current = map;
 
-        map.on('style.load', () => {
+        // Keep a reference to the pending onIdle listener so it can be removed
+        // before registering a new one when style.load fires again (e.g. the
+        // user edits the URL while the same map instance is reused).
+        let pendingOnIdle: (() => void) | null = null;
+
+        const onStyleLoad = () => {
+          // Cancel any previous idle capture that hasn't fired yet.
+          if (pendingOnIdle) {
+            map.off('idle', pendingOnIdle);
+            pendingOnIdle = null;
+          }
+
           const style = map.getStyle();
           loadCustomMapStyleRef.current({style, error: false});
+
           // Capture a thumbnail once the map finishes its first full render
           // (tiles loaded + painted).  We use a one-shot `idle` listener so we
           // get a real screenshot instead of a blank canvas.
           // preserveDrawingBuffer is set to true on this map instance, so
           // getCanvas().toDataURL() is safe to call synchronously here.
           const onIdle = () => {
+            pendingOnIdle = null;
             map.off('idle', onIdle);
             try {
               const icon = map.getCanvas().toDataURL('image/png');
@@ -167,8 +180,11 @@ function AddMapStyleModalFactory() {
               // stays and is good enough.
             }
           };
+          pendingOnIdle = onIdle;
           map.on('idle', onIdle);
-        });
+        };
+
+        map.on('style.load', onStyleLoad);
 
         map.on('error', () => {
           loadCustomMapStyleRef.current({error: true});

--- a/src/components/src/modals/add-map-style-modal.tsx
+++ b/src/components/src/modals/add-map-style-modal.tsx
@@ -151,6 +151,23 @@ function AddMapStyleModalFactory() {
         map.on('style.load', () => {
           const style = map.getStyle();
           loadCustomMapStyleRef.current({style, error: false});
+          // Capture a thumbnail once the map finishes its first full render
+          // (tiles loaded + painted).  We use a one-shot `idle` listener so we
+          // get a real screenshot instead of a blank canvas.
+          // preserveDrawingBuffer is set to true on this map instance, so
+          // getCanvas().toDataURL() is safe to call synchronously here.
+          const onIdle = () => {
+            map.off('idle', onIdle);
+            try {
+              const icon = map.getCanvas().toDataURL('image/png');
+              loadCustomMapStyleRef.current({icon});
+            } catch {
+              // toDataURL can fail if the canvas is cross-origin tainted; in
+              // that case the no-icon placeholder set by inputMapStyleAction
+              // stays and is good enough.
+            }
+          };
+          map.on('idle', onIdle);
         });
 
         map.on('error', () => {

--- a/src/components/src/modals/add-map-style-modal.tsx
+++ b/src/components/src/modals/add-map-style-modal.tsx
@@ -90,10 +90,6 @@ const InlineLink = styled.a`
   }
 `;
 
-const nop = () => {
-  return;
-};
-
 interface AddMapStyleModalProps {
   inputMapStyle: ActionHandler<typeof inputMapStyle>;
   inputStyle: InputStyle;
@@ -124,6 +120,11 @@ function AddMapStyleModalFactory() {
     const [reRenderKey, setReRenderKey] = useState(0);
     const [previousToken, setPreviousToken] = useState<string | null>(null);
     const mapRef = useRef<MapInstance | null>(null);
+    const mapListenersRef = useRef<{
+      onStyleLoad?: () => void;
+      onError?: () => void;
+      pendingOnIdle?: (() => void) | null;
+    }>({});
     const loadCustomMapStyleRef = useRef(loadCustomMapStyleAction);
     loadCustomMapStyleRef.current = loadCustomMapStyleAction;
 
@@ -135,11 +136,20 @@ function AddMapStyleModalFactory() {
     }, [inputStyle?.accessToken, previousToken]);
 
     const setMapRefCallback = useCallback((mapRefInstance: MapRef | null) => {
+      // Remove listeners from the previous map instance
       if (mapRef.current && mapRefInstance) {
         const map = mapRefInstance.getMap();
         if (map && mapRef.current !== map) {
-          mapRef.current.off('style.load', nop);
-          mapRef.current.off('error', nop);
+          if (mapListenersRef.current.onStyleLoad) {
+            mapRef.current.off('style.load', mapListenersRef.current.onStyleLoad);
+          }
+          if (mapListenersRef.current.onError) {
+            mapRef.current.off('error', mapListenersRef.current.onError);
+          }
+          if (mapListenersRef.current.pendingOnIdle) {
+            mapRef.current.off('idle', mapListenersRef.current.pendingOnIdle);
+          }
+          mapListenersRef.current = {};
           mapRef.current = null;
         }
       }
@@ -148,16 +158,11 @@ function AddMapStyleModalFactory() {
       if (map && mapRef.current !== map) {
         mapRef.current = map;
 
-        // Keep a reference to the pending onIdle listener so it can be removed
-        // before registering a new one when style.load fires again (e.g. the
-        // user edits the URL while the same map instance is reused).
-        let pendingOnIdle: (() => void) | null = null;
-
         const onStyleLoad = () => {
           // Cancel any previous idle capture that hasn't fired yet.
-          if (pendingOnIdle) {
-            map.off('idle', pendingOnIdle);
-            pendingOnIdle = null;
+          if (mapListenersRef.current.pendingOnIdle) {
+            map.off('idle', mapListenersRef.current.pendingOnIdle);
+            mapListenersRef.current.pendingOnIdle = null;
           }
 
           const style = map.getStyle();
@@ -169,7 +174,7 @@ function AddMapStyleModalFactory() {
           // preserveDrawingBuffer is set to true on this map instance, so
           // getCanvas().toDataURL() is safe to call synchronously here.
           const onIdle = () => {
-            pendingOnIdle = null;
+            mapListenersRef.current.pendingOnIdle = null;
             map.off('idle', onIdle);
             try {
               const icon = map.getCanvas().toDataURL('image/png');
@@ -180,15 +185,19 @@ function AddMapStyleModalFactory() {
               // stays and is good enough.
             }
           };
-          pendingOnIdle = onIdle;
+          mapListenersRef.current.pendingOnIdle = onIdle;
           map.on('idle', onIdle);
         };
 
-        map.on('style.load', onStyleLoad);
-
-        map.on('error', () => {
+        const onError = () => {
           loadCustomMapStyleRef.current({error: true});
-        });
+        };
+
+        mapListenersRef.current.onStyleLoad = onStyleLoad;
+        mapListenersRef.current.onError = onError;
+
+        map.on('style.load', onStyleLoad);
+        map.on('error', onError);
       }
     }, []);
 


### PR DESCRIPTION
## What changed

**Attribution** (closes #3515)
- Hide "Basemap by: MapLibre" logo for custom user-added styles — MapLibre is just the renderer, not the tile provider; the basemap's own TileJSON attribution is shown instead
- Built-in styles (dark-matter, positron, voyager) and Mapbox-tile styles keep the logo as before
- Fix attribution collection to trigger on `sourcedata(metadata)` and `idle` events, not only `isSourceLoaded`, so TileJSON attributions (CARTO, OpenFreeMap, etc.) are captured reliably
- Widen `.basemap-attribution` max-width when the logo is absent so long attribution strings are no longer clipped

**Custom basemap thumbnail**
- Capture a canvas screenshot (`toDataURL`) on the map `idle` event inside the Add Custom Style dialog and store it as the style icon, so the Map Style dropdown shows a real preview instead of a black square