### PR TITLE
fix: globe crashes in dev mode

### DIFF
--- a/src/components/src/modals/globe-export-video-preview.tsx
+++ b/src/components/src/modals/globe-export-video-preview.tsx
@@ -7,6 +7,7 @@ import type {Deck, DeckProps, MapViewState} from '@deck.gl/core';
 import styled from 'styled-components';
 
 import {DeckAdapter} from '@hubble.gl/core';
+import {EXPORT_DECK_DEVICE_PROPS} from './hubble-utils';
 
 const PreviewContainer = styled.div<{$width: number; $height: number; $background: string}>`
   width: ${props => props.$width}px;
@@ -97,7 +98,7 @@ export class GlobeExportVideoPreview extends Component<GlobeExportVideoPreviewPr
           ref={ref => {
             this.deckRef.current = (ref?.deck as any) || null;
           }}
-          deviceProps={{type: 'webgl', webgl: {preserveDrawingBuffer: true}}}
+          deviceProps={EXPORT_DECK_DEVICE_PROPS}
           {...adapterProps}
           viewState={viewState}
           onViewStateChange={({viewState: vs}: any) => setViewState(vs)}

--- a/src/components/src/modals/hubble-utils.ts
+++ b/src/components/src/modals/hubble-utils.ts
@@ -28,6 +28,27 @@ type MapboxLayerRef = {
   id: string;
 } & Record<string, any>;
 
+// luma.gl defaults `debug` to true whenever NODE_ENV !== 'production', which
+// instruments every render pass with a TIME_ELAPSED_EXT timer query. WebGL2 only
+// allows one such query to be active at a time, and the globe export renders
+// several passes per frame, so the debug context throws INVALID_OPERATION and
+// takes the whole export modal down. Export previews are throwaway render
+// targets that don't need the validation layer.
+
+/** Device props for export previews that own their canvas and read pixels back off it. */
+export const EXPORT_DECK_DEVICE_PROPS = {
+  type: 'webgl' as const,
+  webgl: {preserveDrawingBuffer: true},
+  debug: false
+};
+
+/** Device props for export previews that draw as an overlay on top of a basemap. */
+export const EXPORT_OVERLAY_DEVICE_PROPS = {
+  type: 'webgl' as const,
+  webgl: {stencil: true},
+  debug: false
+};
+
 const linear: (p: number) => number = p => p;
 const hold: (p: number) => number = p => (p === 1 ? 1 : 0);
 

--- a/src/components/src/modals/swipe-export-video-preview.tsx
+++ b/src/components/src/modals/swipe-export-video-preview.tsx
@@ -13,7 +13,11 @@ import styled from 'styled-components';
 import {DeckAdapter} from '@hubble.gl/core';
 import {createKeplerLayers} from '@hubble.gl/react';
 import {compositeSwipeFrame, getSwipePercentageAtTime, SwipeEasing} from './swipe-composite-utils';
-import {getGlobeExportLayers} from './hubble-utils';
+import {
+  EXPORT_DECK_DEVICE_PROPS,
+  EXPORT_OVERLAY_DEVICE_PROPS,
+  getGlobeExportLayers
+} from './hubble-utils';
 
 function setRef<T>(ref: React.Ref<T> | React.MutableRefObject<T>, value: T) {
   if (typeof ref === 'function') {
@@ -316,7 +320,7 @@ export class SwipeExportVideoPreview extends Component<
         <MapLayer $width={width} $height={height}>
           <DeckGL
             ref={ref => setRef(deckRef, ref?.deck as any)}
-            deviceProps={{type: 'webgl', webgl: {preserveDrawingBuffer: true}}}
+            deviceProps={EXPORT_DECK_DEVICE_PROPS}
             {...adapterProps}
             viewState={viewState}
             onViewStateChange={({viewState: vs}: any) => this.props.setViewState(vs)}
@@ -353,7 +357,7 @@ export class SwipeExportVideoPreview extends Component<
         >
           <DeckGLOverlay
             ref={deckRef}
-            deviceProps={{type: 'webgl', webgl: {stencil: true}}}
+            deviceProps={EXPORT_OVERLAY_DEVICE_PROPS}
             {...adapter.getProps({deck: deck as any, extraProps: {...deckProps, layers: keplerLayers}})}
           />
         </ReactMapGL>


### PR DESCRIPTION
- Add `debug: false `for device props