### PR TITLE
fix: Babel stops recognizing it as a super method call

### DIFF
--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -89,7 +89,10 @@ class ZoomToCursorGlobeController extends GlobeController {
       // view can't be centered on the poles. deck.gl's applyConstraints clamps
       // latitude to ~85°, which still lets the camera look straight at a pole.
       applyConstraints(props: any) {
-        const result = (super.applyConstraints as any)(props);
+        // Avoid `(super.fn as any)(args)` — Babel compiles that to a property GET
+        // (`_superPropGet(..., 1)`) that drops `this`. A direct call uses method-CALL
+        // form (`_superPropGet(..., 3)`), which preserves the binding.
+        const result = super.applyConstraints(props);
         const clampedLatitude = clamp(result.latitude, -GLOBE_MAX_LATITUDE, GLOBE_MAX_LATITUDE);
         if (clampedLatitude !== result.latitude) {
           // deck.gl couples zoom to latitude via zoomAdjust; when we further


### PR DESCRIPTION
fix: Babel stops recognizing it as a super method call