### PR TITLE
fix: pre-seed basemap style in exported HTML map

### DIFF
--- a/src/utils/src/export-map-html.ts
+++ b/src/utils/src/export-map-html.ts
@@ -237,7 +237,12 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
           }(Redux, middleWares));
 
           const store = (function createStore(redux, enhancers) {
-            const initialState = {};
+            // Pre-seed the map style so the correct basemap is active from the
+            // very first render, avoiding a flash of the default dark basemap.
+            const savedStyleType = ${JSON.stringify(options.config?.mapStyle?.styleType ?? null)};
+            const initialState = savedStyleType
+              ? {keplerGl: {map: {mapStyle: {styleType: savedStyleType}}}}
+              : {};
 
             return redux.createStore(
               reducers,

--- a/src/utils/src/export-map-html.ts
+++ b/src/utils/src/export-map-html.ts
@@ -214,17 +214,22 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
           }
 
           /** STORE **/
-          const reducers = (function createReducers(redux, keplerGl) {
+          // Pre-seed the map style so the correct basemap is active from the
+          // very first render, avoiding a flash of the default dark basemap.
+          const savedStyleType = ${JSON.stringify(options.config?.config?.mapStyle?.styleType ?? null)};
+
+          const reducers = (function createReducers(redux, keplerGl, styleType) {
             return redux.combineReducers({
               // mount keplerGl reducer
               keplerGl: keplerGl.keplerGlReducer.initialState({
                 uiState: {
                   readOnly: ${options.mode === EXPORT_HTML_MAP_MODES.READ},
                   currentModal: null
-                }
+                },
+                ...(styleType ? {mapStyle: {styleType}} : {})
               })
             });
-          }(Redux, KeplerGl));
+          }(Redux, KeplerGl, savedStyleType));
 
           const middleWares = (function createMiddlewares(keplerGl) {
             return keplerGl.enhanceReduxMiddleware([
@@ -237,16 +242,9 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
           }(Redux, middleWares));
 
           const store = (function createStore(redux, enhancers) {
-            // Pre-seed the map style so the correct basemap is active from the
-            // very first render, avoiding a flash of the default dark basemap.
-            const savedStyleType = ${JSON.stringify(options.config?.mapStyle?.styleType ?? null)};
-            const initialState = savedStyleType
-              ? {keplerGl: {map: {mapStyle: {styleType: savedStyleType}}}}
-              : {};
-
             return redux.createStore(
               reducers,
-              initialState,
+              {},
               redux.compose(enhancers)
             );
           }(Redux, enhancers));

--- a/src/utils/src/export-map-html.ts
+++ b/src/utils/src/export-map-html.ts
@@ -214,8 +214,9 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
           }
 
           /** STORE **/
-          // Pre-seed the map style so the correct basemap is active from the
-          // very first render, avoiding a flash of the default dark basemap.
+          // Pre-seed styleType so the correct basemap fetch starts on the very
+          // first render, avoiding a flash of the default dark basemap.
+          // options.config has the versioned envelope shape: { version, config: { mapStyle, ... } }
           const savedStyleType = ${JSON.stringify(options.config?.config?.mapStyle?.styleType ?? null)};
 
           const reducers = (function createReducers(redux, keplerGl, styleType) {
@@ -406,7 +407,11 @@ export const exportMapToHTML = (options, version = KEPLER_GL_VERSION) => {
               config
             );
 
-            // For some reason Kepler overwrites the config without extra wait time
+            // The 500 ms delay is a historical workaround for a race where
+            // keplerGl re-initialises and overwrites config applied synchronously.
+            // The pre-seeded styleType above removes the basemap flash on first
+            // render; this dispatch still applies the full saved config (layers,
+            // viewport, layer groups, etc.) once the component has settled.
             window.setTimeout(() => {
               store.dispatch(
                 keplerGl.addDataToMap({


### PR DESCRIPTION
## Problem

When a map with a non-default basemap (e.g. Voyager/Positron) is exported as HTML, the exported file visibly flashes the default dark basemap (`dark-matter`) before switching to the correct one.

## Root cause

The Redux store in the exported HTML is bootstrapped with an empty initial state, so the `mapStyle` reducer starts with its hardcoded default `styleType: 'dark-matter'`. The correct basemap is only applied 500 ms later when the `addDataToMap` timeout fires and dispatches the saved config.

## Fix

At export time, `options.config.config.mapStyle.styleType` is already available. It is now injected into `keplerGlReducer.initialState()` alongside the existing `uiState` overrides. `initialState()` does a shallow merge with the reducer defaults, so all other `mapStyle` fields (`mapStyles` registry, `visibleLayerGroups`, etc.) are preserved — only `styleType` is overridden. This means the correct basemap fetch starts on the very first render cycle with no flash.