### PR TITLE
fix: GlobehexagonCellLayer crash from Babel unbound super calls

### DIFF
--- a/.cursor/rules/no-cast-super-calls.mdc
+++ b/.cursor/rules/no-cast-super-calls.mdc
@@ -1,0 +1,25 @@
+---
+description: Never cast super.method before calling — Babel drops this
+globs: **/*.{ts,tsx}
+alwaysApply: false
+---
+
+# No cast-then-call on `super` methods
+
+Do not write `(super.method as SomeType)(...)` or `(<SomeType>super.method)(...)`.
+
+Babel compiles that to an unbound `_superPropGet(..., 1)` call, so `this` is
+`undefined` and `this.props` crashes at runtime (kepler.gl #3614).
+
+```ts
+// Bad
+const shaders = (super.getShaders as () => any)();
+(super.draw as (o: any) => void)(opts);
+
+// Good
+const shaders = super.getShaders();
+super.draw(opts);
+```
+
+If TypeScript complains about the super call signature, fix the types or use a
+`// @ts-expect-error` on the call line — do not cast the method reference.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,26 +61,7 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         // TODO: Enable this rule and provide description or fix the errors
         '@typescript-eslint/ban-ts-comment': 'off',
-        '@typescript-eslint/no-var-requires': 'off',
-        // Casting `super.method` then calling it makes Babel emit an unbound
-        // `_superPropGet(..., 1)` call that drops `this` (see #3614).
-        'no-restricted-syntax': [
-          'error',
-          {
-            selector:
-              "CallExpression[callee.type='TSAsExpression'][callee.expression.type='MemberExpression'][callee.expression.object.type='Super']",
-            message:
-              'Do not cast `super.method` before calling it (e.g. `(super.foo as any)()`). ' +
-              'Babel drops `this` on that form. Call `super.foo(...)` directly instead.'
-          },
-          {
-            selector:
-              "CallExpression[callee.type='TSTypeAssertion'][callee.expression.type='MemberExpression'][callee.expression.object.type='Super']",
-            message:
-              'Do not cast `super.method` before calling it (e.g. `(<any>super.foo)()`). ' +
-              'Babel drops `this` on that form. Call `super.foo(...)` directly instead.'
-          }
-        ]
+        '@typescript-eslint/no-var-requires': 'off'
       }
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,26 @@ module.exports = {
         '@typescript-eslint/no-explicit-any': 'off',
         // TODO: Enable this rule and provide description or fix the errors
         '@typescript-eslint/ban-ts-comment': 'off',
-        '@typescript-eslint/no-var-requires': 'off'
+        '@typescript-eslint/no-var-requires': 'off',
+        // Casting `super.method` then calling it makes Babel emit an unbound
+        // `_superPropGet(..., 1)` call that drops `this` (see #3614).
+        'no-restricted-syntax': [
+          'error',
+          {
+            selector:
+              "CallExpression[callee.type='TSAsExpression'][callee.expression.type='MemberExpression'][callee.expression.object.type='Super']",
+            message:
+              'Do not cast `super.method` before calling it (e.g. `(super.foo as any)()`). ' +
+              'Babel drops `this` on that form. Call `super.foo(...)` directly instead.'
+          },
+          {
+            selector:
+              "CallExpression[callee.type='TSTypeAssertion'][callee.expression.type='MemberExpression'][callee.expression.object.type='Super']",
+            message:
+              'Do not cast `super.method` before calling it (e.g. `(<any>super.foo)()`). ' +
+              'Babel drops `this` on that form. Call `super.foo(...)` directly instead.'
+          }
+        ]
       }
     },
     {

--- a/src/deckgl-layers/src/globe/globe-view.ts
+++ b/src/deckgl-layers/src/globe/globe-view.ts
@@ -89,9 +89,6 @@ class ZoomToCursorGlobeController extends GlobeController {
       // view can't be centered on the poles. deck.gl's applyConstraints clamps
       // latitude to ~85°, which still lets the camera look straight at a pole.
       applyConstraints(props: any) {
-        // Avoid `(super.fn as any)(args)` — Babel compiles that to a property GET
-        // (`_superPropGet(..., 1)`) that drops `this`. A direct call uses method-CALL
-        // form (`_superPropGet(..., 3)`), which preserves the binding.
         const result = super.applyConstraints(props);
         const clampedLatitude = clamp(result.latitude, -GLOBE_MAX_LATITUDE, GLOBE_MAX_LATITUDE);
         if (clampedLatitude !== result.latitude) {

--- a/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
@@ -157,7 +157,11 @@ export function makeGlobeCellLayerClass<T extends LayerConstructor>(
 
   class GlobeCellLayer extends (BaseCellLayer as {new (...args: any[]): any}) {
     getShaders() {
-      const shaders = (super.getShaders as () => any)();
+      // Avoid `(super.fn as any)()` — Babel compiles that to a property GET
+      // (`_superPropGet(..., 1)`) that drops `this`. A direct call uses method-CALL
+      // form (`_superPropGet(..., 3)`), which preserves the binding.
+      // See https://github.com/keplergl/kepler.gl/issues/3614.
+      const shaders = super.getShaders();
       return {
         ...shaders,
         vs: addGlobeCellProjection(shaders.vs, type),
@@ -175,7 +179,7 @@ export function makeGlobeCellLayerClass<T extends LayerConstructor>(
       if (model?.shaderInputs) {
         model.shaderInputs.setProps({globeCell: {globeMode}});
       }
-      (super.draw as (o: any) => void)(opts);
+      super.draw(opts);
     }
   }
   (GlobeCellLayer as unknown as {layerName: string}).layerName = `Globe${type}CellLayer`;

--- a/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
@@ -157,10 +157,6 @@ export function makeGlobeCellLayerClass<T extends LayerConstructor>(
 
   class GlobeCellLayer extends (BaseCellLayer as {new (...args: any[]): any}) {
     getShaders() {
-      // Avoid `(super.fn as any)()` — Babel compiles that to a property GET
-      // (`_superPropGet(..., 1)`) that drops `this`. A direct call uses method-CALL
-      // form (`_superPropGet(..., 3)`), which preserves the binding.
-      // See https://github.com/keplergl/kepler.gl/issues/3614.
       const shaders = super.getShaders();
       return {
         ...shaders,


### PR DESCRIPTION
## Summary
- Fix `GlobehexagonCellLayer` crashing when casting `super.method` before calling it — Babel drops `this`, so `this.props` is undefined (#3614).
- Call `super.getShaders()` / `super.draw()` directly in `makeGlobeCellLayerClass`.
- Add a Cursor rule so agents avoid reintroducing the anti-pattern.

## Test plan
- [x] Load a map with a hexagon aggregation layer (e.g. `examples/custom-reducer`) and confirm no deck.gl `GlobehexagonCellLayer` / `reading 'props'` errors
- [x] Confirm hexagon cells render in 2D

Closes #3614