### PR TITLE
fix: dropbox full logout; error on stale access token

### DIFF
--- a/examples/demo-app/src/cloud-providers/dropbox/dropbox-provider.js
+++ b/examples/demo-app/src/cloud-providers/dropbox/dropbox-provider.js
@@ -227,13 +227,9 @@ export default class DropboxProvider extends Provider {
         await this._dropbox.authTokenRevoke();
       }
     } catch (err) {
-      // Ignore revoke failures (e.g. already-invalid token)
+      // Ignore revoke failures (e.g. already-invalid/expired token)
     }
-    if (Window.localStorage) {
-      Window.localStorage.removeItem('dropbox');
-    }
-    // re instantiate dropbox
-    this._initializeDropbox();
+    this._clearAuth();
   }
 
   isEnabled() {
@@ -306,6 +302,27 @@ export default class DropboxProvider extends Provider {
     this._dropbox.setClientId(this.clientId);
   }
 
+  _clearAuth() {
+    if (Window.localStorage) {
+      Window.localStorage.removeItem('dropbox');
+    }
+    this._initializeDropbox();
+  }
+
+  _getErrorSummary(error) {
+    return (
+      (error && error.error && error.error.error_summary) ||
+      (typeof error?.message === 'string' ? error.message : '') ||
+      ''
+    );
+  }
+
+  _isInvalidTokenError(error) {
+    const summary = this._getErrorSummary(error);
+    // Dropbox may return invalid_access_token or expired_access_token
+    return typeof summary === 'string' && /(invalid|expired)_access_token/i.test(summary);
+  }
+
   async getUser() {
     const token = this.getAccessToken();
     if (!token) {
@@ -315,21 +332,18 @@ export default class DropboxProvider extends Provider {
       const response = await this._dropbox.usersGetCurrentAccount();
       return this._getUserFromAccount(response);
     } catch (error) {
+      // Stale token in localStorage — treat as logged out so the tile shows Login
+      if (this._isInvalidTokenError(error)) {
+        this._clearAuth();
+        return null;
+      }
       throw this._handleDropboxError(error);
     }
   }
 
   _handleDropboxError(error) {
-    const summary =
-      (error && error.error && error.error.error_summary) ||
-      (typeof error?.message === 'string' ? error.message : '');
-
-    // Stale / revoked token left in localStorage — clear so Login is shown again
-    if (typeof summary === 'string' && /invalid_access_token/i.test(summary)) {
-      if (Window.localStorage) {
-        Window.localStorage.removeItem('dropbox');
-      }
-      this._initializeDropbox();
+    if (this._isInvalidTokenError(error)) {
+      this._clearAuth();
       return new Error('Dropbox session expired. Please log in again.');
     }
 
@@ -409,10 +423,14 @@ export default class DropboxProvider extends Provider {
    * @param {string} path
    */
   _authLink(path = 'auth') {
-    return this._dropbox.getAuthenticationUrl(
+    const url = this._dropbox.getAuthenticationUrl(
       `${Window.location.origin}/${path}`,
       btoa(JSON.stringify({handler: 'dropbox', origin: Window.location.origin}))
     );
+    // SDK has no force_reauthentication option; without it Dropbox may silently
+    // re-authorize the same browser session after Kepler logout.
+    const sep = String(url).includes('?') ? '&' : '?';
+    return `${url}${sep}force_reauthentication=true`;
   }
 
   /**

--- a/examples/demo-app/src/cloud-providers/dropbox/dropbox-provider.js
+++ b/examples/demo-app/src/cloud-providers/dropbox/dropbox-provider.js
@@ -58,45 +58,85 @@ export default class DropboxProvider extends Provider {
   async login() {
     return new Promise((resolve, reject) => {
       const link = this._authLink();
-
       const authWindow = Window.open(link, '_blank', 'width=1024,height=716');
 
+      if (!authWindow) {
+        reject(new Error('Dropbox login popup was blocked'));
+        return;
+      }
+
+      let settled = false;
+      let closePoll = null;
+
+      const cleanup = () => {
+        Window.removeEventListener('message', handleToken);
+        if (closePoll !== null) {
+          Window.clearInterval(closePoll);
+          closePoll = null;
+        }
+      };
+
+      const settleReject = err => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        reject(err instanceof Error ? err : new Error(String(err)));
+      };
+
       const handleToken = async event => {
-        // if user has dev tools this will skip all the react-devtools events
-        if (!event.data.token) {
+        // Skip react-devtools / cross-origin noise
+        if (event.origin !== Window.location.origin || !event.data?.token) {
+          return;
+        }
+        if (settled) {
           return;
         }
 
-        if (authWindow) {
+        // Mark settled before closing the popup so the close poll does not treat
+        // a successful login as a cancel.
+        settled = true;
+        cleanup();
+        try {
           authWindow.close();
-          Window.removeEventListener('message', handleToken);
+        } catch (err) {
+          // ignore
         }
 
         const {token} = event.data;
-
         if (!token) {
-          reject('Failed to login to Dropbox');
+          reject(new Error('Failed to login to Dropbox'));
           return;
         }
 
-        this._dropbox.setAccessToken(token);
-        // save user name
-        const user = await this.getUser();
+        try {
+          this._dropbox.setAccessToken(token);
+          const user = await this.getUser();
 
-        if (Window.localStorage) {
-          Window.localStorage.setItem(
-            'dropbox',
-            JSON.stringify({
-              // dropbox token doesn't expire unless revoked by the user
-              token,
-              user,
-              timestamp: new Date()
-            })
-          );
+          if (Window.localStorage) {
+            Window.localStorage.setItem(
+              'dropbox',
+              JSON.stringify({
+                // dropbox token doesn't expire unless revoked by the user
+                token,
+                user,
+                timestamp: new Date()
+              })
+            );
+          }
+
+          resolve(user);
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
         }
-
-        resolve(user);
       };
+
+      closePoll = Window.setInterval(() => {
+        if (!settled && authWindow.closed) {
+          settleReject(new Error('Dropbox login was cancelled'));
+        }
+      }, 500);
 
       Window.addEventListener('message', handleToken);
     });

--- a/examples/demo-app/src/cloud-providers/foursquare/foursquare-provider.js
+++ b/examples/demo-app/src/cloud-providers/foursquare/foursquare-provider.js
@@ -94,11 +94,14 @@ export default class FoursquareProvider extends Provider {
   }
 
   async getUser() {
-    return this._auth0.getUser();
+    const user = await this._auth0.getUser();
+    return this._mapAuth0User(user);
   }
 
   async login() {
-    return this._auth0.loginWithPopup(undefined, {popup: openPopup()});
+    await this._auth0.loginWithPopup(undefined, {popup: openPopup()});
+    // CloudTile expects a user object; Auth0 loginWithPopup resolves to void.
+    return this.getUser();
   }
 
   async logout() {
@@ -106,6 +109,17 @@ export default class FoursquareProvider extends Provider {
       // this make sure after logging out the sdk will not redirect the user
       openUrl: false
     });
+  }
+
+  _mapAuth0User(user) {
+    if (!user) {
+      return null;
+    }
+    return {
+      name: user.name || user.nickname || user.email || 'Foursquare User',
+      email: user.email || '',
+      thumbnail: user.picture
+    };
   }
 
   async uploadMap({mapData, options = {}}) {

--- a/examples/demo-app/src/cloud-providers/index.js
+++ b/examples/demo-app/src/cloud-providers/index.js
@@ -31,11 +31,11 @@ export const CLOUD_PROVIDERS = [
     userMapsURL: FOURSQUARE_USER_MAPS_URL
   }),
   new DropboxProvider(DROPBOX_CLIENT_ID, DROPBOX_CLIENT_NAME),
-  new CartoProvider(CARTO_CLIENT_ID),
   new GoogleDriveProvider({
     clientId: GOOGLE_DRIVE_CLIENT_ID,
     appName: GOOGLE_DRIVE_APP_NAME
-  })
+  }),
+  new CartoProvider(CARTO_CLIENT_ID)
 ];
 
 export function getCloudProvider(providerName) {

--- a/src/components/src/modals/cloud-tile.tsx
+++ b/src/components/src/modals/cloud-tile.tsx
@@ -186,6 +186,7 @@ const CloudTile: React.FC<CloudTileProps> = ({provider, actionName}) => {
 
   const onLogout = useCallback(async () => {
     setIsLoading(true);
+    setError(null);
     try {
       await provider.logout();
     } catch (error) {


### PR DESCRIPTION
## Summary
- Treat Dropbox `expired_access_token` (not only `invalid_access_token`) as logged out: clear stored auth and show Login instead of a red tile error on Load from Storage.
- Clear CloudTile error state on logout so a prior stale-token warning does not stick after Logout.
- Force Dropbox re-authentication on login (`force_reauthentication=true`) so logout → login can switch accounts instead of silently reusing the browser Dropbox session.
- Fix Dropbox login hang when the OAuth popup is closed or blocked (poll `authWindow.closed`, reject, and clean up the message listener); ignore cross-origin `postMessage` noise.
- Fix Foursquare login: return a mapped user after Auth0 popup so CloudTile keeps the provider selected and opens storage.
- Move Google Drive ahead of Carto in the demo-app provider list.

## Test plan
- [x] Open Load from Storage with a stale/expired Dropbox token → Dropbox tile shows Login (no `expired_access_token` error)
- [x] Log out of Dropbox → error banner clears; Login is shown
- [x] Log in again → Dropbox prompts for sign-in / account choice (can switch users)
- [x] Close Dropbox OAuth popup without finishing → tile leaves Loading and shows an error (does not hang)
- [x] Foursquare login → user name shown; storage list opens
- [x] Successful Dropbox login still lists and opens saved maps
- [x] Provider order: Foursquare, Dropbox, Google Drive, Carto