### PR TITLE
fix(video-export): keep globe scatterplot size constant on zoom

### DIFF
--- a/src/components/src/modals/globe-export-video-container.tsx
+++ b/src/components/src/modals/globe-export-video-container.tsx
@@ -535,6 +535,7 @@ export class GlobeExportVideoPanelContainer extends Component<
             saving={saving}
             durationMs={durationMs}
             deckProps={deckProps}
+            mapProps={this.props.mapProps}
             backgroundColor={this.getBackgroundColor()}
           />
           <SwipeExportSettings

--- a/src/components/src/modals/globe-export-video-preview.tsx
+++ b/src/components/src/modals/globe-export-video-preview.tsx
@@ -7,7 +7,7 @@ import type {Deck, DeckProps, MapViewState} from '@deck.gl/core';
 import styled from 'styled-components';
 
 import {DeckAdapter} from '@hubble.gl/core';
-import {EXPORT_DECK_DEVICE_PROPS} from './hubble-utils';
+import {EXPORT_DECK_DEVICE_PROPS, getGlobeExportLayers} from './hubble-utils';
 
 const PreviewContainer = styled.div<{$width: number; $height: number; $background: string}>`
   width: ${props => props.$width}px;
@@ -29,6 +29,7 @@ export type GlobeExportVideoPreviewProps = {
   durationMs: number;
   /** CSS color string for the area the globe does not cover. */
   backgroundColor: string;
+  mapProps?: Record<string, any>;
 };
 
 /**
@@ -67,19 +68,36 @@ export class GlobeExportVideoPreview extends Component<GlobeExportVideoPreviewPr
   }
 
   render() {
-    const {adapter, deckProps, viewState, setViewState, resolution, exportVideoWidth, backgroundColor} =
-      this.props;
+    const {
+      adapter,
+      deckProps,
+      viewState,
+      setViewState,
+      resolution,
+      exportVideoWidth,
+      backgroundColor,
+      mapData,
+      mapProps
+    } = this.props;
     const {width, height} = this._getContainer();
     const deck = this.deckRef.current;
 
+    // Rebuild layers from the animated camera (hubble 2D: createKeplerLayers(mapData, viewState)).
+    const layers = getGlobeExportLayers(mapData, {
+      mapIndex: 0,
+      mapboxApiAccessToken: mapProps?.mapboxApiAccessToken,
+      mapboxApiUrl: mapProps?.mapboxApiUrl,
+      viewState
+    });
+
     // adapter.getProps injects `_animate` (and toggles `controller` off while
-    // recording) so hubble's KeplerAnimation can drive the camera. Layers,
-    // views, controller bounds and initialViewState come from `deckProps`
+    // recording) so hubble's KeplerAnimation can drive the camera. Views,
+    // controller bounds and initialViewState come from `deckProps`
     // (see getHubbleDeckGlProps). A controlled `viewState` keeps the preview in
     // sync with the animated camera and prevents the GlobeState assert.
     const adapterProps = adapter.getProps({
       deck: deck as any,
-      extraProps: deckProps as any
+      extraProps: {...deckProps, layers} as any
     }) as any;
 
     // Render the drawing buffer at the true export resolution regardless of the

--- a/src/components/src/modals/hubble-utils.ts
+++ b/src/components/src/modals/hubble-utils.ts
@@ -313,8 +313,14 @@ export function getGlobeExportLayers(
   {
     mapIndex,
     mapboxApiAccessToken,
-    mapboxApiUrl
-  }: {mapIndex: number; mapboxApiAccessToken?: string; mapboxApiUrl?: string}
+    mapboxApiUrl,
+    viewState
+  }: {
+    mapIndex: number;
+    mapboxApiAccessToken?: string;
+    mapboxApiUrl?: string;
+    viewState?: MapViewState;
+  }
 ) {
   const globe = keplerState.mapState?.globe;
   const globeBaseLayers = getGlobeBaseLayers({
@@ -323,12 +329,19 @@ export function getGlobeExportLayers(
     mapStyleType: keplerState.mapStyle?.styleType
   });
   const globeTopLayers = getGlobeTopLayers({globe});
-  const dataLayers = computeDeckLayers(keplerState, {
-    mapIndex,
-    primaryMap: mapIndex === 0,
-    mapboxApiAccessToken,
-    mapboxApiUrl
-  });
+  // Same as hubble createKeplerLayers: fold the animated camera into mapState so
+  // zoom-dependent props (scatterplot radiusScale) update each frame.
+  const dataLayers = computeDeckLayers(
+    viewState
+      ? {...keplerState, mapState: {...keplerState.mapState, ...viewState}}
+      : keplerState,
+    {
+      mapIndex,
+      primaryMap: mapIndex === 0,
+      mapboxApiAccessToken,
+      mapboxApiUrl
+    }
+  );
   return [...globeBaseLayers, ...dataLayers, ...globeTopLayers];
 }
 

--- a/src/components/src/modals/swipe-export-video-preview.tsx
+++ b/src/components/src/modals/swipe-export-video-preview.tsx
@@ -232,7 +232,8 @@ export class SwipeExportVideoPreview extends Component<
       return getGlobeExportLayers(mapData, {
         mapIndex,
         mapboxApiAccessToken: mapProps?.mapboxApiAccessToken,
-        mapboxApiUrl: mapProps?.mapboxApiUrl
+        mapboxApiUrl: mapProps?.mapboxApiUrl,
+        viewState
       });
     }
 


### PR DESCRIPTION
## Summary
Globe video export baked scatterplot `radiusScale` at the opening zoom, so points grew when the camera zoomed in. Rebuild layers each frame with the animated viewState, same as 2D `createKeplerLayers`.

## Test plan
- [x] Globe mode + video export, camera preset **Zoom In**: points keep screen size in the preview and the exported video
- [x] 2D video export is unchanged