### PR TITLE
chore(docker): shrink build context and cache yarn installs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,43 @@
-dist/
-.venv/
-.conda/
-node_modules/
-__pycache__/
-build/
-.git/
-website/
-bindings/
-test/
-docs/
-*.log
+# Nested installs are not matched by a root-only `node_modules/` pattern.
+**/node_modules
+**/.yarn
+**/.pnp.*
+
+# Build artifacts
+**/dist
+**/build
+**/umd
+**/coverage
+**/*-coverage
+**/.nyc_output
+**/*.tsbuildinfo
+**/__pycache__
+**/*.log
+**/.DS_Store
+
+# VCS and local tooling
+.git
+.github
+.cursor
+.vscode
+.idea
+.history
+.venv
+.conda
+.netlify
+
+# Not used by the demo-app image
+bindings
+website
+test
+docs
+screenshots
+skill
+contributing
+typedoc
+docker
+
+# Other examples (keep demo-app only)
+examples/*
+!examples/demo-app
+!examples/demo-app/**

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20-alpine AS builder
 
 WORKDIR /app
@@ -12,8 +13,9 @@ COPY --parents src/*/package.json ./
 COPY --parents examples/demo-app/package.json examples/demo-app/yarn.lock examples/demo-app/.yarnrc.yml ./
 
 # Skip all postinstall scripts to avoid building the gl native package (GPU headers not available)
-RUN yarn config set enableScripts false && \
-    yarn install && \
+RUN --mount=type=cache,id=kepler-yarn,target=/yarn-cache \
+    yarn config set enableScripts false && \
+    YARN_CACHE_FOLDER=/yarn-cache yarn install && \
     yarn config set enableScripts true
 
 # Selectively run esbuild postinstall (needed for the correct platform binary)
@@ -27,7 +29,8 @@ RUN yarn workspaces foreach -At run stab
 
 WORKDIR /app/examples/demo-app
 
-RUN yarn install
+RUN --mount=type=cache,id=kepler-yarn,target=/yarn-cache \
+    YARN_CACHE_FOLDER=/yarn-cache yarn install
 RUN yarn build
 
 FROM node:20-alpine AS runtime

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:20-alpine
 
 WORKDIR /app
@@ -15,8 +16,9 @@ COPY --parents src/*/package.json ./
 COPY --parents examples/demo-app/package.json examples/demo-app/yarn.lock examples/demo-app/.yarnrc.yml ./
 
 # Skip all postinstall scripts to avoid building the gl native package (GPU headers not available)
-RUN yarn config set enableScripts false && \
-    yarn install && \
+RUN --mount=type=cache,id=kepler-yarn,target=/yarn-cache \
+    yarn config set enableScripts false && \
+    YARN_CACHE_FOLDER=/yarn-cache yarn install && \
     yarn config set enableScripts true
 
 # Selectively run esbuild postinstall (needed for the correct platform binary)
@@ -30,7 +32,8 @@ RUN yarn workspaces foreach -At run stab
 
 WORKDIR /app/examples/demo-app
 
-RUN yarn install
+RUN --mount=type=cache,id=kepler-yarn,target=/yarn-cache \
+    YARN_CACHE_FOLDER=/yarn-cache yarn install
 
 EXPOSE 8080
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,6 +30,12 @@ docker compose -f docker/docker-compose.yml up kepler-prod
 
 Then open http://localhost:8080.
 
+Once the image exists, omit `--build` so Compose reuses it and start is seconds, not minutes. Pass `--build` only after source, Dockerfile, or `.env` changes. If Compose still starts a build, force the existing image with `--no-build`:
+
+```bash
+docker compose -f docker/docker-compose.yml up --no-build kepler-prod
+```
+
 To rebuild after code changes on the host:
 
 ```bash
@@ -59,7 +65,7 @@ docker run -p 8080:8080 kepler-prod
 ## Notes
 
 - The build context must be the repository root (both Dockerfiles reference `src/`, `scripts/`, etc.).
-- The `.dockerignore` at the root excludes `node_modules/`, `.git/`, `website/`, `bindings/`, `test/`, and `docs/` to keep the build context small.
+- The `.dockerignore` at the root excludes nested `node_modules/`, other examples, `.git/`, `website/`, `bindings/`, `test/`, and `docs/` to keep the build context small. Yarn installs use a BuildKit cache mount so lockfile rebuilds reuse downloaded packages.
 - All postinstall scripts are disabled during `yarn install` to avoid building the `gl` native package (requires GPU headers, only used for tests). The `esbuild` platform binary is then installed selectively since it's required for bundling.
 - Environment variables like `MapboxAccessToken` are read from the `.env` file copied into the build context. Rebuild the image to change them.
 - The dev image provides a no-op `xdg-open` to prevent the server from crashing when it tries to open a browser.

--- a/docker/README.md
+++ b/docker/README.md
@@ -30,7 +30,7 @@ docker compose -f docker/docker-compose.yml up kepler-prod
 
 Then open http://localhost:8080.
 
-Once the image exists, omit `--build` so Compose reuses it and start is seconds, not minutes. Pass `--build` only after source, Dockerfile, or `.env` changes. If Compose still starts a build, force the existing image with `--no-build`:
+Once the image exists, omit `--build` so Compose reuses it and starts in seconds, not minutes. Pass `--build` only after source, Dockerfile, or `.env` changes. If Compose still starts a build, force the existing image with `--no-build`:
 
 ```bash
 docker compose -f docker/docker-compose.yml up --no-build kepler-prod
@@ -65,7 +65,7 @@ docker run -p 8080:8080 kepler-prod
 ## Notes
 
 - The build context must be the repository root (both Dockerfiles reference `src/`, `scripts/`, etc.).
-- The `.dockerignore` at the root excludes nested `node_modules/`, other examples, `.git/`, `website/`, `bindings/`, `test/`, and `docs/` to keep the build context small. Yarn installs use a BuildKit cache mount so lockfile rebuilds reuse downloaded packages.
+- The `.dockerignore` at the root excludes nested `node_modules/`, other examples, `.git/`, `website/`, `bindings/`, `test/`, and `docs/` to keep the build context small. Yarn installs use a BuildKit cache mount so lockfile rebuilds reuse downloaded packages. Docker Desktop and Compose v2 enable BuildKit by default; if `docker build` fails on `--mount`, run it with `DOCKER_BUILDKIT=1`.
 - All postinstall scripts are disabled during `yarn install` to avoid building the `gl` native package (requires GPU headers, only used for tests). The `esbuild` platform binary is then installed selectively since it's required for bundling.
 - Environment variables like `MapboxAccessToken` are read from the `.env` file copied into the build context. Rebuild the image to change them.
 - The dev image provides a no-op `xdg-open` to prevent the server from crashing when it tries to open a browser.


### PR DESCRIPTION
## Summary
- Ignore nested `node_modules`, unused examples, and build artifacts so the Docker context drops from ~10GB to ~25MB.
- Cache Yarn installs with a BuildKit mount so lockfile rebuilds reuse downloaded packages.
- Document that `docker compose up` without `--build` reuses the existing image (use `--no-build` if Compose still rebuilds).

## Test plan
- [x] `docker compose -f docker/docker-compose.yml up --build kepler-prod` — context transfer should be tens of MB, not GB
- [x] Confirm http://localhost:8080 serves the demo app
- [x] `docker compose -f docker/docker-compose.yml up --no-build kepler-prod` starts in seconds