### PR TITLE
fix: heatmap centroids from point and line geometries

### DIFF
--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -18,7 +18,8 @@ import {
   DEFAULT_AGGREGATION,
   AGGREGATION_TYPES,
   ALL_FIELD_TYPES,
-  GEOJSON_FIELDS
+  GEOJSON_FIELDS,
+  GEOARROW_METADATA_KEY
 } from '@kepler.gl/constants';
 import {ColorRange, Field, LayerColumn, Merge} from '@kepler.gl/types';
 import {KeplerTable, Datasets} from '@kepler.gl/table';
@@ -28,7 +29,11 @@ import {point as turfPoint} from '@turf/helpers';
 import {Feature, Polygon} from 'geojson';
 
 import {getGeoArrowPointLayerProps, FindDefaultLayerPropsReturnValue} from './layer-utils';
-import {parseGeoJsonRawFeature} from './geojson-layer/geojson-utils';
+import {
+  parseGeoJsonRawFeature,
+  getCentroidFromGeometry,
+  getAllPositions
+} from './geojson-layer/geojson-utils';
 
 type AggregationLayerColumns = {
   lat: LayerColumn;
@@ -128,53 +133,6 @@ function wrapOrdinalAccessor(
 const getLayerColorRange = (colorRange: ColorRange) => colorRange.colors.map(hexToRgb);
 
 export const aggregateRequiredColumns: ['lat', 'lng'] = ['lat', 'lng'];
-
-/**
- * Compute the centroid [lng, lat] of a GeoJSON geometry.
- * For Point returns the coordinate directly; for complex geometries
- * averages all vertex positions into a single representative point.
- */
-function getCentroidFromGeometry(geometry: any): number[] | null {
-  if (!geometry) return null;
-  const positions = getAllPositions(geometry);
-  if (positions.length === 0) return null;
-  if (positions.length === 1) return positions[0];
-
-  let sumLng = 0;
-  let sumLat = 0;
-  let count = 0;
-  for (const pos of positions) {
-    if (Number.isFinite(pos[0]) && Number.isFinite(pos[1])) {
-      sumLng += pos[0];
-      sumLat += pos[1];
-      count++;
-    }
-  }
-  return count > 0 ? [sumLng / count, sumLat / count] : null;
-}
-
-/**
- * Extract all vertex [lng, lat] coordinates from a GeoJSON geometry.
- */
-function getAllPositions(geometry: any): number[][] {
-  if (!geometry) return [];
-  switch (geometry.type) {
-    case 'Point':
-      return [geometry.coordinates];
-    case 'MultiPoint':
-    case 'LineString':
-      return geometry.coordinates;
-    case 'MultiLineString':
-    case 'Polygon':
-      return geometry.coordinates.flat();
-    case 'MultiPolygon':
-      return geometry.coordinates.flat(2);
-    case 'GeometryCollection':
-      return (geometry.geometries || []).flatMap(getAllPositions);
-    default:
-      return [];
-  }
-}
 
 export type AggregationLayerVisualChannelConfig = LayerColorConfig & LayerSizeConfig;
 export type AggregationLayerConfig = Merge<LayerBaseConfig, {columns: AggregationLayerColumns}> &
@@ -500,7 +458,12 @@ export default class AggregationLayer extends Layer {
 
     if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
       const getFeature = this.getPositionAccessor(dataContainer);
-      this._buildGeojsonDataToFeature(dataContainer, getFeature);
+      const geoField = dataset.fields?.[this.config.columns.geojson.fieldIdx];
+      const encoding =
+        geoField?.metadata && typeof (geoField.metadata as Map<string, string>).get === 'function'
+          ? (geoField.metadata as Map<string, string>).get(GEOARROW_METADATA_KEY)
+          : (geoField?.metadata as Record<string, string> | undefined)?.[GEOARROW_METADATA_KEY];
+      this._buildGeojsonDataToFeature(dataContainer, getFeature, encoding);
       this.updateMeta({bounds: this._geojsonBounds});
     } else {
       this.dataToFeature = [];
@@ -513,7 +476,11 @@ export default class AggregationLayer extends Layer {
     }
   }
 
-  private _buildGeojsonDataToFeature(dataContainer: DataContainerInterface, getFeature: any) {
+  private _buildGeojsonDataToFeature(
+    dataContainer: DataContainerInterface,
+    getFeature: any,
+    geoArrowEncoding?: string | null
+  ) {
     const fieldIdx = this.config.columns.geojson.fieldIdx;
     if (
       this.dataToFeature.length === dataContainer.numRows() &&
@@ -533,7 +500,7 @@ export default class AggregationLayer extends Layer {
 
     for (let i = 0; i < dataContainer.numRows(); i++) {
       const rawFeature = getFeature({index: i});
-      const feature = parseGeoJsonRawFeature(rawFeature);
+      const feature = parseGeoJsonRawFeature(rawFeature, geoArrowEncoding);
       this.dataToFeature[i] = feature;
       this.centroids[i] = feature?.geometry ? getCentroidFromGeometry(feature.geometry) : null;
 
@@ -598,12 +565,13 @@ export default class AggregationLayer extends Layer {
 
     for (let i = 0; i < filteredIndex.length; i++) {
       const index = filteredIndex[i];
-      const feature = this.dataToFeature[index];
-      if (!feature?.geometry) continue;
-
-      const centroid = getCentroidFromGeometry(feature.geometry);
-      if (centroid) {
-        data.push({index, position: centroid});
+      const centroid =
+        this.centroids[index] ||
+        (this.dataToFeature[index]?.geometry
+          ? getCentroidFromGeometry(this.dataToFeature[index].geometry)
+          : null);
+      if (centroid && Number.isFinite(centroid[0]) && Number.isFinite(centroid[1])) {
+        data.push({index, position: [centroid[0], centroid[1]]});
       }
     }
 

--- a/src/layers/src/geojson-layer/geojson-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.ts
@@ -371,7 +371,7 @@ function parseGeometryFromString(geoString: string): Feature | null {
       // try parse as WKB hex string
       try {
         const buffer = Buffer.from(geoString, 'hex');
-        parsedGeo = convertWKBToGeometry(toArrayBuffer(new Uint8Array(buffer)));
+        parsedGeo = convertWKBToGeometry(toArrayBuffer(buffer));
       } catch (e) {
         return null;
       }

--- a/src/layers/src/geojson-layer/geojson-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.ts
@@ -9,8 +9,8 @@ import {ascending} from 'd3-array';
 import {center} from '@turf/center';
 import {AllGeoJSON} from '@turf/helpers';
 import {parseSync} from '@loaders.gl/core';
-import {WKBLoader, WKTLoader} from '@loaders.gl/wkt';
-import {convertBinaryGeometryToGeometry} from '@loaders.gl/gis';
+import {WKTLoader} from '@loaders.gl/wkt';
+import {convertWKBToGeometry, convertGeoArrowGeometryToGeoJSON} from '@loaders.gl/gis';
 import {BinaryFeatureCollection} from '@loaders.gl/schema';
 import {DataContainerInterface, getSampleData} from '@kepler.gl/utils';
 import {ALL_FIELD_TYPES} from '@kepler.gl/constants';
@@ -53,56 +53,168 @@ export function fieldIsGeoArrow(geoField?: ProtoDatasetField | null): boolean {
   return Boolean(geoField?.metadata?.get('ARROW:extension:name'));
 }
 
-export function parseGeoJsonRawFeature(rawFeature: unknown): Feature | null {
+function toArrayBuffer(
+  rawFeature: ArrayBuffer | {buffer: ArrayBufferLike; byteOffset: number; byteLength: number}
+): ArrayBuffer {
+  if (rawFeature instanceof ArrayBuffer) {
+    return rawFeature;
+  }
+  return rawFeature.buffer.slice(
+    rawFeature.byteOffset,
+    rawFeature.byteOffset + rawFeature.byteLength
+  ) as ArrayBuffer;
+}
+
+function isBinaryGeometry(value: unknown): value is Uint8Array | ArrayBuffer {
+  if (value instanceof ArrayBuffer) {
+    return true;
+  }
+  // Uint8Array, Buffer, and other byte views (Arrow Binary .get())
+  return ArrayBuffer.isView(value) && (value as Uint8Array).BYTES_PER_ELEMENT === 1;
+}
+
+function isLngLat(pos: unknown): pos is number[] {
+  const values = pos as {length?: number; 0?: unknown; 1?: unknown} | null;
+  return (
+    Boolean(values) &&
+    (Array.isArray(pos) || ArrayBuffer.isView(pos)) &&
+    (values as {length: number}).length >= 2 &&
+    Number.isFinite(Number(values?.[0])) &&
+    Number.isFinite(Number(values?.[1]))
+  );
+}
+
+/**
+ * Extract all vertex [lng, lat] coordinates from a GeoJSON geometry.
+ * Recurses through any nesting so Point, LineString, Polygon, and multi-
+ * variants all yield a flat list of positions.
+ */
+export function getAllPositions(geometry: any): number[][] {
+  if (!geometry) return [];
+  if (geometry.type === 'GeometryCollection') {
+    return (geometry.geometries || []).flatMap(getAllPositions);
+  }
+  const positions: number[][] = [];
+  collectPositions(geometry.coordinates, positions);
+  return positions;
+}
+
+function collectPositions(node: unknown, out: number[][]): void {
+  if (isLngLat(node)) {
+    out.push([Number(node[0]), Number(node[1])]);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      collectPositions(child, out);
+    }
+  }
+}
+
+/**
+ * Compute the centroid [lng, lat] of a GeoJSON geometry.
+ * For Point returns the coordinate directly; for complex geometries
+ * averages all vertex positions into a single representative point.
+ */
+export function getCentroidFromGeometry(geometry: any): number[] | null {
+  if (!geometry) return null;
+  const positions = getAllPositions(geometry);
+  if (positions.length === 0) return null;
+  if (positions.length === 1) return positions[0];
+
+  let sumLng = 0;
+  let sumLat = 0;
+  let count = 0;
+  for (const pos of positions) {
+    sumLng += pos[0];
+    sumLat += pos[1];
+    count++;
+  }
+  return count > 0 ? [sumLng / count, sumLat / count] : null;
+}
+
+function featureFromGeometry(parsedGeo: unknown, properties: null): Feature | null {
+  const normalized = normalize(parsedGeo);
+  if (!normalized || !Array.isArray(normalized.features) || !normalized.features.length) {
+    return null;
+  }
+  return {properties, ...normalized.features[0]};
+}
+
+/**
+ * Parse a raw cell value into a GeoJSON Feature.
+ * @param rawFeature Feature / geometry object, WKT/GeoJSON string, WKB bytes, or coordinate array
+ * @param geoArrowEncoding Optional ARROW:extension:name (e.g. geoarrow.wkb, geoarrow.point)
+ */
+export function parseGeoJsonRawFeature(
+  rawFeature: unknown,
+  geoArrowEncoding?: string | null
+): Feature | null {
   const properties = null; // help ensure that properties is present on the returned geojson feature
-  // Support WKB geometry provided as binary (e.g., from Parquet/GeoParquet)
-  if (rawFeature instanceof Uint8Array || rawFeature instanceof ArrayBuffer) {
+
+  if (rawFeature == null) {
+    return null;
+  }
+
+  // GeoArrow / GeoParquet cell (WKB, WKT, or native point/linestring/polygon)
+  if (geoArrowEncoding) {
     try {
-      const binaryInput =
-        rawFeature instanceof ArrayBuffer
-          ? rawFeature
-          : (rawFeature as Uint8Array).buffer.slice(
-              (rawFeature as Uint8Array).byteOffset,
-              (rawFeature as Uint8Array).byteOffset + (rawFeature as Uint8Array).byteLength
-            );
-      const binaryGeo = parseSync(binaryInput as ArrayBuffer, WKBLoader);
-      // @ts-expect-error loaders.gl binary type to GeoJSON geometry
-      const parsedGeo = convertBinaryGeometryToGeometry(binaryGeo);
-      const normalized = normalize(parsedGeo);
-      if (!normalized || !Array.isArray(normalized.features) || !normalized.features.length) {
-        return null;
+      const geometry = convertGeoArrowGeometryToGeoJSON(
+        rawFeature,
+        geoArrowEncoding as Parameters<typeof convertGeoArrowGeometryToGeoJSON>[1]
+      );
+      if (geometry) {
+        return {type: 'Feature', geometry, properties};
       }
-      return {properties, ...normalized.features[0]};
+    } catch (e) {
+      // fall through to generic parsers
+    }
+  }
+
+  // Support WKB geometry provided as binary (e.g., from Parquet/GeoParquet/DuckDB)
+  if (isBinaryGeometry(rawFeature)) {
+    try {
+      const parsedGeo = convertWKBToGeometry(toArrayBuffer(rawFeature));
+      return featureFromGeometry(parsedGeo, properties);
     } catch (e) {
       return null;
     }
   }
-  if (typeof rawFeature === 'object') {
-    // Support GeoJson feature as object
-    // probably need to normalize it as well
-    const normalized = normalize(rawFeature);
-    if (!normalized || !Array.isArray(normalized.features) || !normalized.features.length) {
-      // fail to normalize GeoJson
-      return null;
-    }
 
-    return {properties, ...normalized.features[0]};
-  } else if (typeof rawFeature === 'string') {
+  // Coordinate arrays: Point [lng, lat] or LineString [[lat, lng], ...]
+  // Must run before `typeof === 'object'` because arrays are objects.
+  if (Array.isArray(rawFeature)) {
+    if (isLngLat(rawFeature)) {
+      return {
+        type: 'Feature',
+        geometry: {type: 'Point', coordinates: rawFeature},
+        properties
+      };
+    }
+    if (Array.isArray(rawFeature[0])) {
+      // Support GeoJson LineString as an array of points stored as [lat, lng]
+      return {
+        type: 'Feature',
+        geometry: {
+          coordinates: rawFeature.map((pts: number[]) => [pts[1], pts[0]]),
+          type: 'LineString'
+        },
+        properties
+      };
+    }
+    return null;
+  }
+
+  if (typeof rawFeature === 'object') {
+    // Support GeoJson feature or geometry as object
+    return featureFromGeometry(rawFeature, properties);
+  }
+
+  if (typeof rawFeature === 'string') {
     const parsedGeometry = parseGeometryFromString(rawFeature);
     if (!parsedGeometry) return null;
     // @ts-expect-error verify whether parsedGeometry always contains properties
     return {properties, ...parsedGeometry};
-  } else if (Array.isArray(rawFeature)) {
-    // Support GeoJson  LineString as an array of points
-    return {
-      type: 'Feature',
-      geometry: {
-        // why do we need to flip it...
-        coordinates: rawFeature.map(pts => [pts[1], pts[0]]),
-        type: 'LineString'
-      },
-      properties
-    };
   }
 
   return null;
@@ -259,9 +371,7 @@ function parseGeometryFromString(geoString: string): Feature | null {
       // try parse as WKB hex string
       try {
         const buffer = Buffer.from(geoString, 'hex');
-        const binaryGeo = parseSync(buffer, WKBLoader);
-        // @ts-expect-error
-        parsedGeo = convertBinaryGeometryToGeometry(binaryGeo);
+        parsedGeo = convertWKBToGeometry(toArrayBuffer(new Uint8Array(buffer)));
       } catch (e) {
         return null;
       }

--- a/src/layers/src/heatmap-layer/heatmap-layer.ts
+++ b/src/layers/src/heatmap-layer/heatmap-layer.ts
@@ -2,7 +2,12 @@
 // Copyright contributors to the kepler.gl project
 
 import KeplerHeatmapLayer from './deck-heatmap-layer';
-import {CHANNEL_SCALES, ALL_FIELD_TYPES, GEOJSON_FIELDS} from '@kepler.gl/constants';
+import {
+  CHANNEL_SCALES,
+  ALL_FIELD_TYPES,
+  GEOJSON_FIELDS,
+  GEOARROW_METADATA_KEY
+} from '@kepler.gl/constants';
 import Layer, {LayerBaseConfigPartial, LayerWeightConfig, VisualChannels} from '../base-layer';
 import HeatmapLayerIcon from './heatmap-layer-icon';
 import {
@@ -27,7 +32,11 @@ import {Feature, Polygon} from 'geojson';
 
 import {getGeoArrowPointLayerProps, FindDefaultLayerPropsReturnValue} from '../layer-utils';
 import {getFilterDataFunc} from '../aggregation-layer';
-import {parseGeoJsonRawFeature} from '../geojson-layer/geojson-utils';
+import {
+  parseGeoJsonRawFeature,
+  getCentroidFromGeometry,
+  getAllPositions
+} from '../geojson-layer/geojson-utils';
 
 export type HeatmapLayerVisConfigSettings = {
   opacity: VisConfigNumber;
@@ -87,54 +96,6 @@ export const geojsonAccessor =
   (dc: DataContainerInterface) =>
   (d: {index: number}) =>
     dc.valueAt(d.index, geojson.fieldIdx);
-
-/**
- * Compute the centroid [lng, lat] of a GeoJSON geometry.
- * For Point returns the coordinate directly; for complex geometries
- * averages all vertex positions into a single representative point.
- */
-function getCentroidFromGeometry(geometry: any): number[] | null {
-  if (!geometry) return null;
-  const positions = getAllPositions(geometry);
-  if (positions.length === 0) return null;
-  if (positions.length === 1) return positions[0];
-
-  let sumLng = 0;
-  let sumLat = 0;
-  let count = 0;
-  for (const pos of positions) {
-    if (Number.isFinite(pos[0]) && Number.isFinite(pos[1])) {
-      sumLng += pos[0];
-      sumLat += pos[1];
-      count++;
-    }
-  }
-  return count > 0 ? [sumLng / count, sumLat / count] : null;
-}
-
-/**
- * Extract all vertex [lng, lat] coordinates from a GeoJSON geometry.
- * Used internally for bounds computation and centroid calculation.
- */
-function getAllPositions(geometry: any): number[][] {
-  if (!geometry) return [];
-  switch (geometry.type) {
-    case 'Point':
-      return [geometry.coordinates];
-    case 'MultiPoint':
-    case 'LineString':
-      return geometry.coordinates;
-    case 'MultiLineString':
-    case 'Polygon':
-      return geometry.coordinates.flat();
-    case 'MultiPolygon':
-      return geometry.coordinates.flat(2);
-    case 'GeometryCollection':
-      return (geometry.geometries || []).flatMap(getAllPositions);
-    default:
-      return [];
-  }
-}
 
 export const pointColResolver = (
   {lat, lng, geoarrow, geojson}: HeatmapLayerColumnsConfig,
@@ -422,7 +383,12 @@ class HeatmapLayer extends Layer {
 
     if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
       const getFeature = this.getPositionAccessor(dataContainer);
-      this._buildGeojsonDataToFeature(dataContainer, getFeature);
+      const geoField = dataset.fields?.[this.config.columns.geojson.fieldIdx];
+      const encoding =
+        geoField?.metadata && typeof (geoField.metadata as Map<string, string>).get === 'function'
+          ? (geoField.metadata as Map<string, string>).get(GEOARROW_METADATA_KEY)
+          : (geoField?.metadata as Record<string, string> | undefined)?.[GEOARROW_METADATA_KEY];
+      this._buildGeojsonDataToFeature(dataContainer, getFeature, encoding);
       this.updateMeta({bounds: this._geojsonBounds});
     } else {
       this.dataToFeature = [];
@@ -437,7 +403,11 @@ class HeatmapLayer extends Layer {
    * Parse raw GeoJSON values into Feature objects and store them.
    * Re-parses when the data container size changes (new data load or column switch).
    */
-  private _buildGeojsonDataToFeature(dataContainer: DataContainerInterface, getFeature: any) {
+  private _buildGeojsonDataToFeature(
+    dataContainer: DataContainerInterface,
+    getFeature: any,
+    geoArrowEncoding?: string | null
+  ) {
     const fieldIdx = this.config.columns.geojson.fieldIdx;
     if (
       this.dataToFeature.length === dataContainer.numRows() &&
@@ -457,7 +427,7 @@ class HeatmapLayer extends Layer {
 
     for (let i = 0; i < dataContainer.numRows(); i++) {
       const rawFeature = getFeature({index: i});
-      const feature = parseGeoJsonRawFeature(rawFeature);
+      const feature = parseGeoJsonRawFeature(rawFeature, geoArrowEncoding);
       this.dataToFeature[i] = feature;
       this.centroids[i] = feature?.geometry ? getCentroidFromGeometry(feature.geometry) : null;
 
@@ -500,20 +470,22 @@ class HeatmapLayer extends Layer {
   }
 
   /**
-   * For GeoJSON mode, compute the centroid of each feature's geometry
-   * and emit a single heatmap data entry per feature.
+   * For GeoJSON mode, emit a single heatmap data entry per feature
+   * at the geometry centroid (Point coordinates, or vertex average for
+   * LineString / Polygon).
    */
   private _calculateGeojsonDataAttribute(filteredIndex: number[]) {
     const data: {index: number; position: number[]}[] = [];
 
     for (let i = 0; i < filteredIndex.length; i++) {
       const index = filteredIndex[i];
-      const feature = this.dataToFeature[index];
-      if (!feature?.geometry) continue;
-
-      const centroid = getCentroidFromGeometry(feature.geometry);
-      if (centroid) {
-        data.push({index, position: centroid});
+      const centroid =
+        this.centroids[index] ||
+        (this.dataToFeature[index]?.geometry
+          ? getCentroidFromGeometry(this.dataToFeature[index].geometry)
+          : null);
+      if (centroid && Number.isFinite(centroid[0]) && Number.isFinite(centroid[1])) {
+        data.push({index, position: [centroid[0], centroid[1]]});
       }
     }
 

--- a/src/layers/src/trip-layer/trip-utils.ts
+++ b/src/layers/src/trip-layer/trip-utils.ts
@@ -45,7 +45,7 @@ export function isTripGeoJsonField(dataContainer: DataContainerInterface, field:
 
   const features: Feature<Geometry, GeoJsonProperties>[] = sampleRawFeatures
     .mapIndex(field.valueAccessor)
-    .map(parseGeoJsonRawFeature)
+    .map(rawFeature => parseGeoJsonRawFeature(rawFeature))
     .filter(notNullorUndefined);
   const featureTypes = getGeojsonFeatureTypes(features);
 

--- a/test/browser/layer-tests/aggregation-layer-geojson-specs.js
+++ b/test/browser/layer-tests/aggregation-layer-geojson-specs.js
@@ -3,11 +3,7 @@
 
 import test from 'tape';
 
-import {
-  testFormatLayerDataCases,
-  prepareGeojsonDataset,
-  dataId
-} from 'test/helpers/layer-utils';
+import {testFormatLayerDataCases, prepareGeojsonDataset, dataId} from 'test/helpers/layer-utils';
 
 import {KeplerGlLayers} from '@kepler.gl/layers';
 const {GridLayer, HexagonLayer, ClusterLayer} = KeplerGlLayers;
@@ -455,6 +451,10 @@ test('#AggregationLayer -> geojson mode handles Point, LineString, Polygon geome
   t.ok(minLat <= 37.8, 'minLat should include southernmost point');
   t.ok(maxLat >= 37.9, 'maxLat should include northernmost point');
 
+  const data = layer.calculateDataAttribute(mockDataset, null);
+  t.equal(data.length, 3, 'should emit a bin point for Point, LineString, and Polygon');
+  t.deepEqual(data[0].position, [-122.4, 37.8], 'Point position should be the point');
+
   t.end();
 });
 
@@ -467,11 +467,7 @@ test('#AggregationLayer -> isInPolygon with geojson mode', t => {
   });
 
   // Set up centroids manually
-  layer.centroids = [
-    [-122.4, 37.8],
-    [-122.5, 37.9],
-    null
-  ];
+  layer.centroids = [[-122.4, 37.8], [-122.5, 37.9], null];
 
   // Create a polygon that contains the first centroid but not the second
   const filterPolygon = {
@@ -494,22 +490,10 @@ test('#AggregationLayer -> isInPolygon with geojson mode', t => {
     }
   };
 
-  t.ok(
-    layer.isInPolygon(null, 0, filterPolygon),
-    'first point should be inside polygon'
-  );
-  t.notOk(
-    layer.isInPolygon(null, 1, filterPolygon),
-    'second point should be outside polygon'
-  );
-  t.notOk(
-    layer.isInPolygon(null, 2, filterPolygon),
-    'null centroid should return false'
-  );
-  t.notOk(
-    layer.isInPolygon(null, 99, filterPolygon),
-    'out-of-bounds index should return false'
-  );
+  t.ok(layer.isInPolygon(null, 0, filterPolygon), 'first point should be inside polygon');
+  t.notOk(layer.isInPolygon(null, 1, filterPolygon), 'second point should be outside polygon');
+  t.notOk(layer.isInPolygon(null, 2, filterPolygon), 'null centroid should return false');
+  t.notOk(layer.isInPolygon(null, 99, filterPolygon), 'out-of-bounds index should return false');
 
   t.end();
 });

--- a/test/browser/layer-tests/heatmap-layer-specs.js
+++ b/test/browser/layer-tests/heatmap-layer-specs.js
@@ -15,6 +15,7 @@ import {gpsPointBounds} from 'test/fixtures/test-csv-data';
 
 import {KeplerGlLayers} from '@kepler.gl/layers';
 import {copyTableAndUpdate} from '@kepler.gl/table';
+import {convertGeometryToWKB} from '@loaders.gl/gis';
 
 const {HeatmapLayer} = KeplerGlLayers;
 
@@ -375,6 +376,111 @@ test('#HeatmapLayer -> geojson mode handles Point, LineString, Polygon geometrie
   t.ok(minLat <= 37.8, 'minLat should include southernmost point');
   t.ok(maxLat >= 37.9, 'maxLat should include northernmost point');
 
+  const data = layer.calculateDataAttribute(mockDataset, null);
+  t.equal(data.length, 3, 'should emit a heatmap point for Point, LineString, and Polygon');
+  t.deepEqual(data[0].position, [-122.4, 37.8], 'Point heatmap position should be the point');
+  t.ok(Number.isFinite(data[1].position[0]), 'LineString heatmap position should be finite');
+  t.ok(Number.isFinite(data[2].position[0]), 'Polygon heatmap position should be finite');
+
+  t.end();
+});
+
+function createHeatmapGeojsonLayer(values) {
+  const layer = new HeatmapLayer({
+    dataId: 'test',
+    label: 'test',
+    columns: {geojson: {value: '_geojson', fieldIdx: 0}},
+    columnMode: 'geojson'
+  });
+  layer.config.columns = {
+    lat: {value: null, fieldIdx: -1},
+    lng: {value: null, fieldIdx: -1},
+    geoarrow: {value: null, fieldIdx: -1},
+    geojson: {value: '_geojson', fieldIdx: 0}
+  };
+  layer.config.columnMode = 'geojson';
+
+  const mockDataset = {
+    dataContainer: {
+      numRows: () => values.length,
+      valueAt: index => values[index]
+    },
+    filteredIndex: values.map((_, i) => i),
+    id: 'test'
+  };
+  layer.updateLayerMeta(mockDataset);
+  return {layer, mockDataset};
+}
+
+test('#HeatmapLayer -> geojson mode parses Feature objects, WKT, and WKB', t => {
+  const point = {
+    type: 'Feature',
+    geometry: {type: 'Point', coordinates: [-122.4, 37.8]},
+    properties: {}
+  };
+  const line = {
+    type: 'Feature',
+    geometry: {
+      type: 'LineString',
+      coordinates: [
+        [-122.4, 37.8],
+        [-122.5, 37.9]
+      ]
+    },
+    properties: {}
+  };
+  const polygon = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [-122.4, 37.8],
+          [-122.5, 37.8],
+          [-122.5, 37.9],
+          [-122.4, 37.9],
+          [-122.4, 37.8]
+        ]
+      ]
+    },
+    properties: {}
+  };
+
+  // Feature objects (how processGeojson stores rows)
+  const fromObjects = createHeatmapGeojsonLayer([point, line, polygon]);
+  t.equal(
+    fromObjects.layer.calculateDataAttribute(fromObjects.mockDataset, null).length,
+    3,
+    'Feature objects should produce heatmap points for Point, LineString, and Polygon'
+  );
+  t.deepEqual(fromObjects.layer.centroids[0], [-122.4, 37.8], 'Point Feature centroid');
+
+  // WKT strings (CSV / PostGIS geometry columns)
+  const fromWkt = createHeatmapGeojsonLayer([
+    'POINT (-122.4 37.8)',
+    'LINESTRING (-122.4 37.8, -122.5 37.9)',
+    'POLYGON ((-122.4 37.8, -122.5 37.8, -122.5 37.9, -122.4 37.9, -122.4 37.8))'
+  ]);
+  t.equal(
+    fromWkt.layer.calculateDataAttribute(fromWkt.mockDataset, null).length,
+    3,
+    'WKT strings should produce heatmap points for POINT, LINESTRING, and POLYGON'
+  );
+  t.deepEqual(fromWkt.layer.centroids[0], [-122.4, 37.8], 'WKT POINT centroid');
+
+  // WKB bytes (DuckDB / GeoParquet geometry columns)
+  const fromWkb = createHeatmapGeojsonLayer([
+    new Uint8Array(convertGeometryToWKB(point.geometry)),
+    new Uint8Array(convertGeometryToWKB(line.geometry)),
+    new Uint8Array(convertGeometryToWKB(polygon.geometry))
+  ]);
+  t.equal(
+    fromWkb.layer.calculateDataAttribute(fromWkb.mockDataset, null).length,
+    3,
+    'WKB bytes should produce heatmap points for Point, LineString, and Polygon'
+  );
+  t.deepEqual(fromWkb.layer.centroids[0], [-122.4, 37.8], 'WKB Point centroid');
+
   t.end();
 });
 
@@ -387,11 +493,7 @@ test('#HeatmapLayer -> isInPolygon with geojson mode', t => {
   });
 
   // Set up centroids manually
-  layer.centroids = [
-    [-122.4, 37.8],
-    [-122.5, 37.9],
-    null
-  ];
+  layer.centroids = [[-122.4, 37.8], [-122.5, 37.9], null];
 
   // Rectangle polygon that contains the first centroid but not the second
   const filterPolygon = {
@@ -414,22 +516,10 @@ test('#HeatmapLayer -> isInPolygon with geojson mode', t => {
     }
   };
 
-  t.ok(
-    layer.isInPolygon(null, 0, filterPolygon),
-    'first point should be inside polygon'
-  );
-  t.notOk(
-    layer.isInPolygon(null, 1, filterPolygon),
-    'second point should be outside polygon'
-  );
-  t.notOk(
-    layer.isInPolygon(null, 2, filterPolygon),
-    'null centroid should return false'
-  );
-  t.notOk(
-    layer.isInPolygon(null, 99, filterPolygon),
-    'out-of-bounds index should return false'
-  );
+  t.ok(layer.isInPolygon(null, 0, filterPolygon), 'first point should be inside polygon');
+  t.notOk(layer.isInPolygon(null, 1, filterPolygon), 'second point should be outside polygon');
+  t.notOk(layer.isInPolygon(null, 2, filterPolygon), 'null centroid should return false');
+  t.notOk(layer.isInPolygon(null, 99, filterPolygon), 'out-of-bounds index should return false');
 
   t.end();
 });


### PR DESCRIPTION
## Summary
- Heatmap (and hex/grid/cluster) GeoJSON mode rendered polygon centroids but produced nothing for Point and LineString geometries.
- Geometry parsing now handles WKB, WKT, Feature objects, `[lng, lat]` arrays, and GeoArrow encodings so every type yields a centroid.

## Test plan
- [x] Load point GeoJSON/WKT/WKB and switch to Heatmap — density should appear at the points.
- [x] Repeat with LineString data — heatmap at line centroids.
- [x] Confirm polygons still render at centroids.

<img width="723" height="714" alt="Screenshot 2026-08-16 at 9 10 37 AM" src="https://github.com/user-attachments/assets/2a56a6b6-12d3-40fb-8b47-9efb5e5f9739" />
