### PR TITLE
fix: polygon-filtered GeoJSON layer missing on exported HTML / map load

### DIFF
--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -93,6 +93,7 @@ import {
   EDITOR_MODES,
   FILTER_TYPES,
   FILTER_VIEW_TYPES,
+  LAYER_TYPES,
   FPS,
   LIGHT_AND_SHADOW_EFFECT,
   DISTANCE_FOG_TYPE,
@@ -3050,6 +3051,18 @@ function layerVisConfigFromAddDataOptions(
 }
 
 /**
+ * Polygon filters for these layers use centroids / dataToFeature from
+ * calculateLayerData. Other types (lat/lng points, H3, arcs) can filter
+ * from columns on the first pass and must not be recalculated here.
+ */
+function polygonFilterDependsOnLayerMeta(layer: Layer): boolean {
+  return (
+    layer.type === LAYER_TYPES.geojson ||
+    layer.config?.columnMode === 'geojson'
+  );
+}
+
+/**
  * Add new dataset to `visState`, with option to load a map config along with the datasets
  */
 function postMergeUpdater(mergedState: VisState, postMergerPayload: PostMergerPayload): VisState {
@@ -3116,6 +3129,37 @@ function postMergeUpdater(mergedState: VisState, postMergerPayload: PostMergerPa
     : uniq(Object.keys(newDataEntries).concat(datasetFiltered));
 
   let updatedState = updateAllLayerDomainData(mergedState, updatedDatasets, undefined);
+
+  // Polygon per-layer indexes need centroids / dataToFeature, which are only
+  // populated by the layer-data pass above. Skip datasets whose targeted layers
+  // already filtered from columns (e.g. lat/lng points).
+  const polygonFilters = updatedState.filters.filter(
+    f => f.type === FILTER_TYPES.polygon && f.enabled !== false
+  );
+  const polygonMetaDataIds = uniq(
+    updatedState.layers
+      .filter(
+        layer =>
+          polygonFilterDependsOnLayerMeta(layer) &&
+          polygonFilters.some(f => f.layerId?.includes(layer.id))
+      )
+      .map(layer => layer.config.dataId)
+      .filter((id): id is string => Boolean(id) && updatedDatasets.includes(id))
+  );
+  if (polygonMetaDataIds.length) {
+    updatedState = updateAllLayerDomainData(
+      {
+        ...updatedState,
+        datasets: applyFiltersToDatasets(
+          polygonMetaDataIds,
+          updatedState.datasets,
+          updatedState.filters,
+          updatedState.layers
+        )
+      },
+      polygonMetaDataIds
+    );
+  }
 
   // register layer animation domain,
   // need to be called after layer data is calculated

--- a/test/node/reducers/vis-state-merger-test.js
+++ b/test/node/reducers/vis-state-merger-test.js
@@ -105,7 +105,6 @@ import {
   mergedTripFilter,
   mergedRateFilter
 } from 'test/fixtures/geojson';
-import {mockStateWithPolygonFilter} from 'test/fixtures/points-with-polygon-filter-map';
 import {mockStateWithSyncedFilterAndTripLayer} from 'test/fixtures/synced-filter-with-trip-layer';
 
 test('VisStateMerger.v0 -> mergeFilters -> toEmptyState', t => {
@@ -1996,23 +1995,43 @@ test('VisStateMerger -> insertLayerAtRightOrder -> to empty config', t => {
 });
 
 test('VisStateMerger -> load polygon filter map', t => {
-  const oldState = mockStateWithPolygonFilter();
+  const parsedMap = processKeplerglJSON(polygonFilterMap);
+  const oldState = applyActions(coreReducer, cloneDeep(InitialState), [
+    {action: addDataToMap, payload: [parsedMap]}
+  ]);
 
   const oldFilter = oldState.visState.filters[0];
+  const filteredLayerId = oldFilter.layerId[0];
+  const oldLayerIdx = oldState.visState.layers.findIndex(l => l.id === filteredLayerId);
+  const oldLayer = oldState.visState.layers[oldLayerIdx];
+  const oldLayerDataCount = oldState.visState.layerData[oldLayerIdx]?.data?.length;
+
+  t.ok(oldFilter, 'Source map should have a polygon filter');
+  t.ok(oldLayerDataCount > 0, 'Source map should show polygon-filtered layer data');
 
   const appStateToSave = SchemaManager.save(oldState);
   const stateParsed = SchemaManager.load(appStateToSave);
   const initialState = cloneDeep(InitialState);
   const initialVisState = initialState.visState;
 
-  const visState = visStateReducer(
-    initialVisState,
-    updateVisData(stateParsed.datasets, {}, stateParsed.config)
-  );
+  const visState = applyActions(visStateReducer, initialVisState, [
+    {action: updateVisData, payload: [stateParsed.datasets, {}, stateParsed.config]}
+  ]);
 
   const newFilter = visState.filters[0];
+  const reloadedIdx = visState.layers.findIndex(l => l.id === oldLayer.id);
 
   t.deepEqual(newFilter, oldFilter, 'Should have loaded the polygon filter correctly');
+  t.equal(
+    visState.layerData[reloadedIdx].data.length,
+    oldLayerDataCount,
+    'Reloaded point layer should show polygon-filtered features without toggling the filter'
+  );
+  t.equal(
+    visState.datasets[oldLayer.config.dataId].filteredIndexByLayer[oldLayer.id].length,
+    oldLayerDataCount,
+    'Reloaded per-layer polygon index should match layer data'
+  );
   t.end();
 });
 

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -5565,6 +5565,70 @@ test('#visStateReducer -> POLYGON: delete polygon filter', t => {
   t.end();
 });
 
+test('#visStateReducer -> POLYGON: reload saved geojson map keeps filtered layer data', t => {
+  const appState = CloneDeep(StateWFiles);
+  const geojsonLayer = appState.visState.layers.find(l => l.type === 'geojson');
+  t.ok(geojsonLayer, 'should have a geojson layer');
+
+  const bounds = geojsonLayer.meta.bounds || [-122.5, 37.7, -122.3, 37.9];
+  const pad = 1;
+  const coveringPolygon = {
+    type: 'Feature',
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [bounds[0] - pad, bounds[1] - pad],
+          [bounds[0] - pad, bounds[3] + pad],
+          [bounds[2] + pad, bounds[3] + pad],
+          [bounds[2] + pad, bounds[1] - pad],
+          [bounds[0] - pad, bounds[1] - pad]
+        ]
+      ]
+    },
+    properties: {
+      renderType: 'Polygon',
+      isClosed: true,
+      isVisible: true
+    },
+    id: 'reload-polygon-filter'
+  };
+
+  const filteredState = reducer(
+    appState.visState,
+    VisStateActions.setPolygonFilterLayer(geojsonLayer, coveringPolygon)
+  );
+
+  const layerIdx = filteredState.layers.findIndex(l => l.id === geojsonLayer.id);
+  const expectedCount = filteredState.layerData[layerIdx].data.length;
+  t.ok(expectedCount > 0, 'geojson layer should have polygon-filtered features before save');
+
+  const saved = SchemaManager.save({...appState, visState: filteredState});
+  const loaded = SchemaManager.load(saved);
+
+  const reloaded = applyActions(reducer, INITIAL_VIS_STATE, [
+    {action: VisStateActions.updateVisData, payload: [loaded.datasets, {}, loaded.config]}
+  ]);
+
+  const reloadedIdx = reloaded.layers.findIndex(l => l.id === geojsonLayer.id);
+  t.ok(
+    reloaded.filters.some(f => f.type === 'polygon'),
+    'should restore the polygon filter'
+  );
+  t.equal(
+    reloaded.layerData[reloadedIdx].data.length,
+    expectedCount,
+    'reloaded geojson layer should show polygon-filtered features without toggling the filter'
+  );
+  t.equal(
+    reloaded.datasets[geojsonLayer.config.dataId].filteredIndexByLayer[geojsonLayer.id].length,
+    expectedCount,
+    'reloaded per-layer polygon index should match layer data'
+  );
+
+  t.end();
+});
+
 test('#visStateReducer -> POLYGON: setPolygonFilterLayer: H3', t => {
   const initialState = CloneDeep(StateWH3Layer).visState;
   const newState = reducer(


### PR DESCRIPTION
## Summary
- Opening exported HTML (or reloading a saved map) with an active polygon filter drew the polygon but not the filtered GeoJSON layer until the filter was toggled.
- Per-layer polygon indexes were computed before centroids / `dataToFeature` existed. After layer data is calculated, re-apply the filter only for GeoJSON layers and `columnMode: 'geojson'`. Lat/lng points, H3, and arcs keep the first pass.

## Test plan
- [x] Export HTML with a GeoJSON layer and an active polygon filter; open the file — filtered features should appear without toggling the filter
- [x] Same for Load Map from JSON
- [x] Point layer + polygon filter still filters on load
- [x] Toggle show/hide on the polygon filter still works