### PR TITLE
chore: run Vite example typecheck after npm publish

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,21 +69,3 @@ jobs:
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  typecheck-examples:
-    name: Typecheck ${{ matrix.example }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        example: [get-started-vite, duckdb-vite]
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: volta-cli/action@v4
-
-      - name: Install and typecheck
-        working-directory: examples/${{ matrix.example }}
-        run: |
-          yarn install
-          yarn tsc -b --pretty false --noEmit

--- a/.github/workflows/typecheck-vite-examples.yml
+++ b/.github/workflows/typecheck-vite-examples.yml
@@ -1,0 +1,54 @@
+# Vite examples live outside the Yarn workspace and depend on published
+# @kepler.gl/* packages, not this checkout. Run after npm publish (and on
+# manual dispatch), not on every PR.
+name: Typecheck Vite examples
+
+on:
+  workflow_run:
+    workflows: [Node.js Package]
+    types: [completed]
+  workflow_dispatch:
+
+jobs:
+  wait-for-published-version:
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Wait until this version is on npm
+        if: github.event_name == 'workflow_run'
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "Waiting for @kepler.gl/components@$VERSION"
+          for _ in $(seq 1 24); do
+            if npm view "@kepler.gl/components@$VERSION" version; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Timed out waiting for @kepler.gl/components@$VERSION on npm"
+          exit 1
+
+  typecheck-examples:
+    name: Typecheck ${{ matrix.example }}
+    needs: wait-for-published-version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        example: [get-started-vite, duckdb-vite]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: volta-cli/action@v4
+
+      - name: Enable Yarn 4
+        run: corepack enable && corepack prepare yarn@4.4.0 --activate
+
+      - name: Install and typecheck
+        working-directory: examples/${{ matrix.example }}
+        run: |
+          touch yarn.lock
+          yarn install
+          yarn tsc -b --pretty false

--- a/.github/workflows/typecheck-vite-examples.yml
+++ b/.github/workflows/typecheck-vite-examples.yml
@@ -1,7 +1,5 @@
-# Vite examples live outside the Yarn workspace and depend on published
-# @kepler.gl/* packages, not this checkout. Run after npm publish (and on
-# manual dispatch), not on every PR.
-name: Typecheck Vite examples
+# Run after npm publish (and on manual dispatch), not on every PR.
+name: Typecheck examples
 
 on:
   workflow_run:


### PR DESCRIPTION
## Summary
- Remove the Vite example typecheck jobs from Node CI so `master` is not red on every push. Those jobs never used this checkout: they install published `@kepler.gl/*` from npm and then fail on Yarn 1 vs Yarn 4 in the example directories.
- Move the check to a separate workflow that runs after a successful npm publish (or via workflow dispatch), waits for the new version on the registry, then typechecks `get-started-vite` and `duckdb-vite` with Yarn 4.

## Test plan
- [x] Confirm Node.js CI on this PR is green (no `Typecheck get-started-vite` / `Typecheck duckdb-vite` jobs).
- [ ] After merge, `master` Node CI should pass without those jobs.
- [ ] After the next GitHub Release publish (or a manual **Run workflow** on `Typecheck examples`), confirm the example jobs install and `tsc -b` succeed.