### PR TITLE
feat: copy error notifications to clipboard

### DIFF
--- a/src/components/src/notification-panel/notification-item.tsx
+++ b/src/components/src/notification-panel/notification-item.tsx
@@ -41,6 +41,11 @@ const NotificationItemContent = styled.div<NotificationItemContentProps>`
   border-radius: 4px;
   box-shadow: ${props => props.theme.boxShadow};
   cursor: pointer;
+
+  &:hover .notification-item--copy {
+    opacity: 1;
+    pointer-events: auto;
+  }
 `;
 
 const NotificationActions = styled.div.attrs({
@@ -49,14 +54,22 @@ const NotificationActions = styled.div.attrs({
   display: flex;
   flex-direction: row;
   align-items: flex-start;
-  gap: 6px;
   flex-shrink: 0;
+  position: relative;
 `;
 
-const ActionIconButton = styled.div`
+const ActionIconButton = styled.div.attrs({
+  className: 'notification-item--copy'
+})<{$copied?: boolean}>`
   display: flex;
   cursor: pointer;
   line-height: 0;
+  position: absolute;
+  right: calc(100% + 6px);
+  top: 0;
+  z-index: 1;
+  opacity: ${props => (props.$copied ? 1 : 0)};
+  pointer-events: ${props => (props.$copied ? 'auto' : 'none')};
 `;
 
 const DeleteIcon = styled(Delete)`
@@ -212,6 +225,7 @@ export default function NotificationItemFactory() {
           </NotificationMessage>
           <NotificationActions onClick={event => event.stopPropagation()}>
             <ActionIconButton
+              $copied={copied}
               data-testid={dataTestIds.copyNotificationIcon}
               title={copied ? 'Copied' : 'Copy to clipboard'}
               onClick={onCopy}

--- a/src/components/src/notification-panel/notification-item.tsx
+++ b/src/components/src/notification-panel/notification-item.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
 import styled from 'styled-components';
-import {Delete, Info, Warning, Checkmark} from '../common/icons';
+import copy from 'copy-to-clipboard';
+import {Delete, Info, Warning, Checkmark, Copy} from '../common/icons';
 import Markdown from 'markdown-to-jsx';
 import {dataTestIds} from '@kepler.gl/constants';
 import {ActionHandler, removeNotification as removeNotificationActions} from '@kepler.gl/actions';
@@ -42,7 +43,35 @@ const NotificationItemContent = styled.div<NotificationItemContentProps>`
   cursor: pointer;
 `;
 
+const NotificationActions = styled.div.attrs({
+  className: 'notification-item--action'
+})`
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 6px;
+  flex-shrink: 0;
+`;
+
+const ActionIconButton = styled.div`
+  display: flex;
+  cursor: pointer;
+  line-height: 0;
+`;
+
 const DeleteIcon = styled(Delete)`
+  cursor: pointer;
+  width: 13px;
+  height: 13px;
+`;
+
+const CopyIcon = styled(Copy)`
+  cursor: pointer;
+  width: 13px;
+  height: 13px;
+`;
+
+const CopiedIcon = styled(Checkmark)`
   cursor: pointer;
   width: 13px;
   height: 13px;
@@ -125,12 +154,32 @@ export default function NotificationItemFactory() {
     theme
   }: NotificationItemProps) {
     const [isExpanded, setIsExpanded] = useState(false);
+    const [copied, setCopied] = useState(false);
 
     useEffect(() => {
       if (initialIsExpanded) {
         setIsExpanded(true);
       }
     }, [initialIsExpanded]);
+
+    useEffect(() => {
+      if (!copied) {
+        return;
+      }
+      const timeoutId = window.setTimeout(() => setCopied(false), 1500);
+      return () => window.clearTimeout(timeoutId);
+    }, [copied]);
+
+    const onCopy = useCallback(
+      (event: React.MouseEvent) => {
+        event.stopPropagation();
+        if (notification.message) {
+          copy(notification.message);
+          setCopied(true);
+        }
+      },
+      [notification.message]
+    );
 
     return (
       <NotificationItemContentBlock isExpanded={isExpanded} theme={theme}>
@@ -140,7 +189,7 @@ export default function NotificationItemFactory() {
           </NotificationCounter>
         ) : null}
         <NotificationItemContent
-          className="notification-item"
+          className={`notification-item${isExpanded ? ' notification-item--expanded' : ''}`}
           type={notification.type}
           isExpanded={isExpanded}
           onClick={() => setIsExpanded(!isExpanded)}
@@ -161,11 +210,18 @@ export default function NotificationItemFactory() {
               {notification.message}
             </Markdown>
           </NotificationMessage>
-          {typeof removeNotification === 'function' ? (
-            <div className="notification-item--action">
+          <NotificationActions onClick={event => event.stopPropagation()}>
+            <ActionIconButton
+              data-testid={dataTestIds.copyNotificationIcon}
+              title={copied ? 'Copied' : 'Copy to clipboard'}
+              onClick={onCopy}
+            >
+              {copied ? <CopiedIcon height="10px" /> : <CopyIcon height="10px" />}
+            </ActionIconButton>
+            {typeof removeNotification === 'function' ? (
               <DeleteIcon height="10px" onClick={() => removeNotification(notification.id)} />
-            </div>
-          ) : null}
+            ) : null}
+          </NotificationActions>
         </NotificationItemContent>
       </NotificationItemContentBlock>
     );

--- a/src/constants/src/default-settings.ts
+++ b/src/constants/src/default-settings.ts
@@ -1501,6 +1501,7 @@ export const dataTestIds: Record<string, string> = {
   errorIcon: 'error-icon',
   successIcon: 'success-icon',
   checkmarkIcon: 'checkmark-icon',
+  copyNotificationIcon: 'copy-notification-icon',
   sortableLayerItem: 'sortable-layer-item',
   staticLayerItem: 'static-layer-item',
   layerTitleEditor: 'layer__title__editor',

--- a/test/browser/components/notifications/notification-item.spec.js
+++ b/test/browser/components/notifications/notification-item.spec.js
@@ -3,16 +3,23 @@
 
 import React from 'react';
 
-import {screen} from '@testing-library/react';
+import {fireEvent, screen} from '@testing-library/react';
 import {dataTestIds} from '@kepler.gl/constants';
 import {NotificationItemFactory, appInjector} from '@kepler.gl/components';
 import {createNotification} from '@kepler.gl/utils';
+import copy from 'copy-to-clipboard';
 
 import {renderWithTheme} from '../../../helpers/component-jest-utils';
+
+jest.mock('copy-to-clipboard', () => jest.fn());
 
 const NotificationItem = appInjector.get(NotificationItemFactory);
 
 describe('Notification tests', () => {
+  beforeEach(() => {
+    copy.mockClear();
+  });
+
   it('display SUCCESS notification', () => {
     const successNotification = createNotification({message: 'success', type: 'success'});
     // render the component
@@ -23,9 +30,28 @@ describe('Notification tests', () => {
 
   it('display ERROR notification', () => {
     const errorNotification = createNotification({message: 'error', type: 'error'});
-    // render the component
     renderWithTheme(<NotificationItem notification={errorNotification} />);
     const heading = screen.getByTestId(dataTestIds.errorIcon);
     expect(heading).toBeInTheDocument();
+  });
+
+  it('copies error message without collapsing the notification', () => {
+    const errorNotification = createNotification({
+      message: 'Failed to load tiles',
+      type: 'error'
+    });
+    const {container} = renderWithTheme(
+      <NotificationItem notification={errorNotification} removeNotification={() => {}} />
+    );
+
+    const notification = container.querySelector('.notification-item');
+    fireEvent.click(notification);
+    expect(notification).toHaveClass('notification-item--expanded');
+
+    fireEvent.click(screen.getByTestId(dataTestIds.copyNotificationIcon));
+
+    expect(copy).toHaveBeenCalledWith('Failed to load tiles');
+    expect(notification).toHaveClass('notification-item--expanded');
+    expect(screen.getByTitle('Copied')).toBeInTheDocument();
   });
 });

--- a/test/browser/components/notifications/notification-item.spec.js
+++ b/test/browser/components/notifications/notification-item.spec.js
@@ -48,6 +48,7 @@ describe('Notification tests', () => {
     fireEvent.click(notification);
     expect(notification).toHaveClass('notification-item--expanded');
 
+    fireEvent.mouseOver(notification);
     fireEvent.click(screen.getByTestId(dataTestIds.copyNotificationIcon));
 
     expect(copy).toHaveBeenCalledWith('Failed to load tiles');


### PR DESCRIPTION
## Summary
- Add a copy icon on top-right notifications so the full error text can be copied without collapsing the toast.

## Test plan
- [x] Trigger an error toast (Add Data with a broken `.geojson`, or dispatch `@@kepler.gl/ADD_NOTIFICATION` with `type: "error"`)
- [x] Click the copy icon: toast stays open and the message is on the clipboard
- [x] Dismiss with the X; expand/collapse still works when clicking the rest of the toast

<img width="266" height="95" alt="Screenshot 2026-08-28 at 10 42 10 PM" src="https://github.com/user-attachments/assets/f559a0f0-db5f-40de-881c-e9ce623fed3b" />
