### PR TITLE
fix: default datetime tooltip format instead of None

### DIFF
--- a/src/reducers/src/interaction-utils.ts
+++ b/src/reducers/src/interaction-utils.ts
@@ -38,7 +38,7 @@ export function findFieldsToShow({
   id: string;
   maxDefaultTooltips: number;
 }): {
-  [key: string]: string[];
+  [key: string]: TooltipField[];
 } {
   // first find default tooltip fields for trips
   const fieldsToShow = DEFAULT_TOOLTIP_FIELDS.reduce((prev, curr) => {
@@ -69,12 +69,22 @@ function autoFindTooltipFields(fields, maxDefaultTooltips) {
       type !== 'object'
   );
 
-  return fieldsToShow.slice(0, maxDefaultTooltips).map(({name}) => {
+  return fieldsToShow.slice(0, maxDefaultTooltips).map(({name, type}) => {
     return {
       name,
-      format: null
+      format: getDefaultTooltipFormat(type)
     };
   });
+}
+
+function getDefaultTooltipFormat(type?: string): string | null {
+  if (type === ALL_FIELD_TYPES.timestamp) {
+    return TOOLTIP_FORMATS.DATE_TIME_L_LTS[TOOLTIP_KEY];
+  }
+  if (type === ALL_FIELD_TYPES.date) {
+    return TOOLTIP_FORMATS.DATE_L[TOOLTIP_KEY];
+  }
+  return null;
 }
 
 function _mergeFieldPairs(pairs) {

--- a/test/browser-headless/component/map-container-test.js
+++ b/test/browser-headless/component/map-container-test.js
@@ -80,11 +80,7 @@ test('MapContainerFactory - display all options', t => {
   );
 
   // Attribution renders when primary=true (default); its root div has className="attrition-logo"
-  t.equal(
-    container.querySelectorAll('.attrition-logo').length,
-    1,
-    'Should display 1 Attribution'
-  );
+  t.equal(container.querySelectorAll('.attrition-logo').length, 1, 'Should display 1 Attribution');
 
   // Verify instance-level callback wiring via React ref (class component)
   const instance = containerRef.current;
@@ -172,7 +168,11 @@ test('MapContainerFactory - _renderDeckOverlay', t => {
           assert.is(hoverEvents[0].info.mapIndex, 0, 'onHover includes mapIndex value');
 
           // pixel / screen-space coords are reliable regardless of GPU picking
-          assert.deepEqual(hoverEvents[0].info.pixel, [192, 187], 'picking info.pixel should be correct');
+          assert.deepEqual(
+            hoverEvents[0].info.pixel,
+            [192, 187],
+            'picking info.pixel should be correct'
+          );
           assert.is(hoverEvents[0].info.x, 192, 'picking info.x should be correct');
           assert.is(hoverEvents[0].info.y, 187, 'picking info.y should be correct');
 
@@ -269,12 +269,11 @@ test('MapContainerFactory - MapPopover', t => {
   t.equal(rows.length, 5, 'should render 5 tooltip rows');
 
   // These field names / values come from the CSV fixture in mock-state.js.
-  // The timestamp field (gps_data.utc_timestamp) is displayed as a raw epoch
-  // millisecond string because FIELD_DISPLAY_FORMAT[timestamp] = defaultFormatter.
+  // Timestamp fields default to DATE_TIME_L_LTS ('L LTS') so hover shows a date.
   const expectedTooltips = [
-    ['gps_data.utc_timestamp', '1474071864000'],
+    ['gps_data.utc_timestamp', '09/17/2016 12:24:24 AM'],
     ['gps_data.types', 'driver_analytics'],
-    ['epoch', '1472754400000'],
+    ['epoch', '09/01/2016 6:26:40 PM'],
     ['has_result', ''],
     ['uid', '1']
   ];

--- a/test/browser/components/map/map-popover-test.js
+++ b/test/browser/components/map/map-popover-test.js
@@ -104,9 +104,9 @@ test('Map Popover - render with layerHoverProp', t => {
   const rows = table.find('.layer-hover-info__row');
   t.equal(rows.length, 5, 'should render 5 rows');
   const expectedTooltips = [
-    ['gps_data.utc_timestamp', '1474071864000'],
+    ['gps_data.utc_timestamp', '09/17/2016 12:24:24 AM'],
     ['gps_data.types', 'driver_analytics'],
-    ['epoch', '1472754400000'],
+    ['epoch', '09/01/2016 6:26:40 PM'],
     ['has_result', ''],
     ['uid', '1']
   ];

--- a/test/node/reducers/vis-state-merger-test.js
+++ b/test/node/reducers/vis-state-merger-test.js
@@ -858,7 +858,7 @@ test('VisStateMerger.v0 -> mergeInteractions -> toWorkingState', t => {
           [testCsvDataId]: [
             {
               name: 'gps_data.utc_timestamp',
-              format: null
+              format: 'L LTS'
             },
             {
               name: 'gps_data.types',
@@ -866,7 +866,7 @@ test('VisStateMerger.v0 -> mergeInteractions -> toWorkingState', t => {
             },
             {
               name: 'epoch',
-              format: null
+              format: 'L LTS'
             },
             {
               name: 'has_result',
@@ -1083,7 +1083,7 @@ test('VisStateMerger.v1 -> mergeInteractions -> toWorkingState', t => {
                 [testCsvDataId]: [
                   {
                     name: 'gps_data.utc_timestamp',
-                    format: null
+                    format: 'L LTS'
                   },
                   {
                     name: 'gps_data.types',
@@ -1091,7 +1091,7 @@ test('VisStateMerger.v1 -> mergeInteractions -> toWorkingState', t => {
                   },
                   {
                     name: 'epoch',
-                    format: null
+                    format: 'L LTS'
                   },
                   {
                     name: 'has_result',
@@ -1167,7 +1167,7 @@ test('VisStateMerger.v1 -> mergeInteractions -> toWorkingState', t => {
           [testCsvDataId]: [
             {
               name: 'gps_data.utc_timestamp',
-              format: null
+              format: 'L LTS'
             },
             {
               name: 'gps_data.types',
@@ -1175,7 +1175,7 @@ test('VisStateMerger.v1 -> mergeInteractions -> toWorkingState', t => {
             },
             {
               name: 'epoch',
-              format: null
+              format: 'L LTS'
             },
             {
               name: 'has_result',

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -3990,7 +3990,7 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_DATASET', t => {
             [testCsvDataId]: [
               {
                 name: 'gps_data.utc_timestamp',
-                format: null
+                format: 'L LTS'
               },
               {
                 name: 'gps_data.types',
@@ -3998,7 +3998,7 @@ test('#visStateReducer -> SPLIT_MAP: REMOVE_DATASET', t => {
               },
               {
                 name: 'epoch',
-                format: null
+                format: 'L LTS'
               },
               {
                 name: 'has_result',

--- a/test/node/schemas/vis-state-schema-test.js
+++ b/test/node/schemas/vis-state-schema-test.js
@@ -168,7 +168,7 @@ test('#visStateSchema -> v1 -> save load interaction', t => {
         [testCsvDataId]: [
           {
             name: 'gps_data.utc_timestamp',
-            format: null
+            format: 'L LTS'
           },
           {
             name: 'gps_data.types',
@@ -176,7 +176,7 @@ test('#visStateSchema -> v1 -> save load interaction', t => {
           },
           {
             name: 'epoch',
-            format: null
+            format: 'L LTS'
           },
           {
             name: 'has_result',

--- a/test/node/utils/interaction-utils-test.js
+++ b/test/node/utils/interaction-utils-test.js
@@ -113,6 +113,29 @@ test('interactionUtil -> autoFindTooltipFields', t => {
   t.end();
 });
 
+test('interactionUtil -> autoFindTooltipFields -> datetime default format', t => {
+  const dateTimeFields = [
+    {name: 'lat'},
+    {name: 'DateTime', type: 'timestamp'},
+    {name: 'event_date', type: 'date'},
+    {name: 'uid', type: 'integer'}
+  ];
+
+  t.deepEqual(
+    findFieldsToShow({fields: dateTimeFields, id: 'test', maxDefaultTooltips: 5}),
+    {
+      test: [
+        {name: 'DateTime', format: 'L LTS'},
+        {name: 'event_date', format: 'L'},
+        {name: 'uid', format: null}
+      ]
+    },
+    'should default timestamp and date tooltip fields to a human-readable format'
+  );
+
+  t.end();
+});
+
 test('interactionUtil -> getTooltipDisplayDeltaValue', t => {
   const tooltipConfig = StateWTooltipFormat.visState.interactionConfig.tooltip.config;
   const dataset = StateWTooltipFormat.visState.datasets[testGeoJsonDataId];


### PR DESCRIPTION
## Summary
- When a dataset is added, timestamp/datetime tooltip fields default to `L LTS` (date + time with seconds) instead of None, so hover shows a readable date rather than epoch millis.
- Date-only fields default to `L`.
- Saved maps that already set tooltip formats are unchanged.

## Test plan
- [x] Add a CSV with a DateTime column and hover a point — tooltip should show a formatted date, not a unix timestamp
- [x] Load a saved map that already has tooltip formats — those formats should be preserved
- [x] Interaction → Tooltips still lets you change or clear the format