### PR TITLE
fix(kepler-jupyter): prepare keplergl==0.4.0rc5

### DIFF
--- a/bindings/python/keplergl/_html_export.py
+++ b/bindings/python/keplergl/_html_export.py
@@ -12,7 +12,7 @@ from typing import Optional
 import pandas as pd
 import geopandas as gpd
 
-DEFAULT_KEPLER_GL_CDN_VERSION = "3.3.0-alpha.4"
+DEFAULT_KEPLER_GL_CDN_VERSION = "3.3.0-alpha.8"
 
 REACT_VERSION = "19.1.0"
 REACT_DOM_VERSION = "19.1.0"

--- a/bindings/python/keplergl/_version.py
+++ b/bindings/python/keplergl/_version.py
@@ -3,4 +3,4 @@
 
 """Version information."""
 
-__version__ = "0.4.0rc4"
+__version__ = "0.4.0rc5"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "keplergl"
-version = "0.4.0rc4"
+version = "0.4.0rc5"
 description = "Kepler.gl Jupyter Widget"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/bindings/python/tests/test_html_export.py
+++ b/bindings/python/tests/test_html_export.py
@@ -344,8 +344,8 @@ class TestExportMapHtml:
 
     def test_default_cdn_version(self, sample_df):
         html = export_map_html(data={"test": sample_df}, config={})
-        assert "unpkg.com/kepler.gl@3.3.0-alpha.4/umd/keplergl.min.js" in html
-        assert "unpkg.com/kepler.gl@3.3.0-alpha.4/umd/keplergl.min.css" in html
+        assert "unpkg.com/kepler.gl@3.3.0-alpha.8/umd/keplergl.min.js" in html
+        assert "unpkg.com/kepler.gl@3.3.0-alpha.8/umd/keplergl.min.css" in html
 
     def test_contains_react_redux_deps(self, sample_df):
         html = export_map_html(data={"test": sample_df}, config={})
@@ -508,7 +508,7 @@ class TestSaveToHtml:
             content = f.read()
         assert "<!DOCTYPE html>" in content
         assert "cities" in content
-        assert "unpkg.com/kepler.gl@3.3.0-alpha.4/umd/keplergl.min.js" in content
+        assert "unpkg.com/kepler.gl@3.3.0-alpha.8/umd/keplergl.min.js" in content
 
     def test_saves_with_config(self, sample_df, tmp_path):
         config = {"version": "v1", "config": {"mapState": {"zoom": 5}}}


### PR DESCRIPTION
Prepare new keplergl==0.4.0rc5

- Bump the pin to `3.3.0-alpha.8`: the unknown-theme → default dark theme fallback landed in v3.3.0-alpha.7 (a0bee767, #3620)
- The UMD bundle is fetched from unpkg in the browser at open time, so this is a one-line Python template change — no JS rebuild needed
- Update the 3 version-string assertions in `tests/test_html_export.py` (88 tests pass)
- Bump `pyproject.toml` to `0.4.0rc5` so a new prerelease can be published with the fixed template

## Follow-up

Publishing still needs to be done manually: after merge, run the **Build and Publish KeplerGL Python Package** workflow via `workflow_dispatch` (prerelease checked) → PyPI `0.4.0rc5`. Users on the editable/source install are fixed immediately; PyPI users need the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)