### PR TITLE
docs(skill): flow layer reference, O-D default-to-flow rule, install pin

### DIFF
--- a/bindings/python/skill/README.md
+++ b/bindings/python/skill/README.md
@@ -10,6 +10,7 @@ This directory contains the **kepler.gl** agent skill — a set of instructions 
 | [geojson-polygon-map.md](skill-references/geojson-polygon-map.md) | Polygons & lines from GeoJSON / GeoDataFrame |
 | [h3-hexagon-map.md](skill-references/h3-hexagon-map.md) | H3 spatial index hexagons |
 | [arc-line-map.md](skill-references/arc-line-map.md) | Origin–destination arcs & lines |
+| [flow-layer.md](skill-references/flow-layer.md) | Aggregated O–D flow maps (clustering, magnitude, location totals) |
 | [heatmap.md](skill-references/heatmap.md) | Density heatmap from points |
 | [hexbin-aggregation-map.md](skill-references/hexbin-aggregation-map.md) | Spatial binning into hexagons |
 | [trip-animation-map.md](skill-references/trip-animation-map.md) | Animated trips along paths |

--- a/bindings/python/skill/SKILL.md
+++ b/bindings/python/skill/SKILL.md
@@ -66,6 +66,7 @@ Read or set the map configuration dict. Use `map.config` after customizing in Ju
 ## Key Rules
 
 - **`dataId` must match the dataset `name`** — every layer and filter references a dataset by `dataId`; this must match the key in the `data` dict or the `name` passed to `add_data()`.
+- **The `flow` layer is never auto-created** — for aggregated O-D flow maps (migration, commute, trade), always pass an explicit layer config with `'type': 'flow'`; without one kepler.gl falls back to an `arc` layer. See [Flow Layer](skill-references/flow-layer.md).
 - **GeoJSON columns use `_geojson`** — when data is loaded as GeoJSON, the geometry column is internally named `_geojson` in configs.
 - **`colorField` / `colorScale` / `sizeField` / `heightField` etc. belong under `visualChannels`, NOT under `config`.** Putting them under `config` is silently ignored — the layer will render but the "Color Based On (field)" input shows empty. The layer object must have two siblings: `config` (for `dataId`, `columns`, `visConfig`, …) and `visualChannels` (for all field-to-channel mappings).
 - Columns named `latitude`/`lat`/`lng`/`longitude` are auto-detected as coordinates.
@@ -93,6 +94,7 @@ Read or set the map configuration dict. Use `map.config` after customizing in Ju
 |------------|---------------|--------------|
 | Point | `"point"` | DataFrame with lat/lng columns |
 | Arc | `"arc"` | DataFrame with origin/destination lat/lng |
+| Flow | `"flow"` | DataFrame with origin/destination lat/lng or H3 — **requires explicit config, never auto-created** |
 | Line | `"line"` | DataFrame with origin/destination lat/lng |
 | Hexbin | `"hexagon"` | DataFrame with lat/lng (aggregated spatially) |
 | Heatmap | `"heatmap"` | DataFrame with lat/lng |
@@ -146,6 +148,7 @@ For detailed per-layer-type examples with full config, see supporting files:
 - [GeoJSON / Polygon Map](skill-references/geojson-polygon-map.md) — Polygons, lines from GeoJSON or GeoDataFrame
 - [H3 Hexagon Map](skill-references/h3-hexagon-map.md) — H3 spatial index hexagons
 - [Arc / Line Map](skill-references/arc-line-map.md) — Origin-destination connections
+- [Flow Layer](skill-references/flow-layer.md) — Aggregated O-D flow maps with clustering, magnitude-proportional lines and location totals
 - [Heatmap](skill-references/heatmap.md) — Density heatmap from points
 - [Hexbin Aggregation Map](skill-references/hexbin-aggregation-map.md) — Spatial binning into hexagons
 - [Trip Animation Map](skill-references/trip-animation-map.md) — Animated trips along paths

--- a/bindings/python/skill/SKILL.md
+++ b/bindings/python/skill/SKILL.md
@@ -10,10 +10,10 @@ Use the `keplergl` Python package to create standalone, interactive HTML map fil
 ## Installation
 
 ```bash
-pip install keplergl
+pip install keplergl==0.4.0rc4
 ```
 
-Requires `keplergl >= 0.4.0`. Earlier versions use a different widget/serialization API and the examples in this skill will not work. Requirements: Python >= 3.9. Dependencies (`pandas`, `geopandas`, `shapely`) are installed automatically.
+The 0.3.x releases on PyPI use a different widget/serialization API and the examples in this skill will not work with them — install the 0.4.0 release line shown above (or newer: `pip install --pre "keplergl>=0.4.0"`). Requirements: Python >= 3.9. Dependencies (`pandas`, `geopandas`, `shapely`) are installed automatically.
 
 ## Instructions
 

--- a/bindings/python/skill/SKILL.md
+++ b/bindings/python/skill/SKILL.md
@@ -105,6 +105,17 @@ Read or set the map configuration dict. Use `map.config` after customizing in Ju
 | Trip | `"trip"` | GeoJSON with LineString + timestamps |
 | S2 | `"s2"` | DataFrame with S2 token column |
 
+## Picking a Layer Type
+
+The layer `'type'` you put in the config is the only thing that determines what renders — describing a "flow map" in text does nothing.
+
+- Individual locations → `point` (`cluster` for zoomed-out density, `heatmap` for continuous intensity).
+- Density binned into cells → `hexagon`/`hexagonId` (H3) or `grid`; pre-aggregated H3 → `hexagonId`.
+- **Origin→destination requests → default to `flow`.** Any wording like "flow map", "flows", "movement between", or migration / commute / trade / supply-chain / flights-between data ⇒ `flow` — it renders fine even for a handful of pairs. Choose `arc` ONLY when the user explicitly asks for plain, unaggregated point-to-point arcs ("draw an arc from A to B", "connect each pair", "no clustering"). Do not substitute a `geojson`/`line` layer for an O-D request just because a geometry column is present.
+- Polylines / polygons → `geojson` (or `line` for straight segments).
+- Time-animated movement → `trip`.
+- Before finalizing, re-check that each layer's configured `'type'` matches what you told the user — saying "flow map" while the config says `'type': 'arc'` is the classic mismatch.
+
 ## Config Structure
 
 ```python

--- a/bindings/python/skill/skill-references/flow-layer.md
+++ b/bindings/python/skill/skill-references/flow-layer.md
@@ -1,0 +1,229 @@
+# Flow Layer
+
+Detailed column requirements and config knobs for the `flow` layer type.
+Read this before building a flow map.
+
+The flow layer visualizes origin→destination movement as **aggregated
+flows**: it clusters nearby locations at different zoom levels, draws flow
+lines with thickness proportional to magnitude, and renders location totals
+as circles sized by in/out volume. Use it for migration, commute, trade,
+supply-chain, or any O-D dataset.
+
+> **The flow layer is never auto-created.** Unlike point/arc/trip layers,
+> it has no field auto-detection — kepler.gl will not create it from
+> lat/lng columns alone. If your dataset has origin/destination columns
+> and you don't pass an explicit config, kepler.gl creates an *arc* layer
+> instead, which looks similar but is not a flow map. Always pass a full
+> layer config (below) with `'type': 'flow'`.
+
+## When to use `flow` vs `arc`
+
+| Property                     | `flow`                  | `arc`                |
+| ---------------------------- | ----------------------- | -------------------- |
+| Aggregates / clusters O-D    | yes                     | no                   |
+| Magnitude-proportional lines | yes (via `count`)       | no                   |
+| Location totals (circles)    | yes                     | no                   |
+| Animated direction lines     | yes (`animated-straight`) | no                 |
+| H3 mode                      | yes                     | no                   |
+| Per-row coloring             | no (`colorRange` only)  | yes (`targetColor`)  |
+| Best for                     | migration, commute, trade, supply chain | simple point-to-point connections |
+
+## Column modes
+
+The flow layer supports two column modes, set via the layer-level
+`columnMode` (`'LAT_LNG'` default, `'H3'`).
+
+Columns are assigned explicitly in the layer config — auto-detection does
+not apply.
+
+### Lat/Lng mode (`columnMode: 'LAT_LNG'`, default)
+
+| Config column | Required | DataFrame column                |
+| ------------- | -------- | ------------------------------- |
+| `lat0`        | yes      | origin/source latitude (float)  |
+| `lng0`        | yes      | origin/source longitude (float) |
+| `lat1`        | yes      | target/dest latitude (float)    |
+| `lng1`        | yes      | target/dest longitude (float)   |
+| `count`       | no       | flow magnitude (numeric; defaults to 1) |
+| `sourceName`  | no       | origin label shown in tooltips and location totals |
+| `targetName`  | no       | destination label shown in tooltips and location totals |
+
+When a coordinate is missing in a row, that row's flow line is skipped
+(rows render as `NaN` positions otherwise) — filter out nulls in pandas
+first with `df.dropna(subset=[...])`.
+
+### H3 mode (`columnMode: 'H3'`)
+
+| Config column | Required | DataFrame column                         |
+| ------------- | -------- | ---------------------------------------- |
+| `sourceH3`    | yes      | origin H3 index (hex string or integer)  |
+| `targetH3`    | yes      | destination H3 index (hex string or integer) |
+| `count`, `sourceName`, `targetName` | no | same as Lat/Lng mode |
+
+The H3 column must be the first one listed in the mode's required columns
+when both modes could match — pass `columnMode: 'H3'` explicitly for H3
+data.
+
+## Worked Example — 10 airports + flights (curved animated flows)
+
+```python
+import random
+import pandas as pd
+from keplergl import KeplerGl
+
+random.seed(42)
+
+airports = []
+for i in range(10):
+    airports.append({
+        'name': f'Airport {i + 1}',
+        'iata': f'AP{i + 1:02d}',
+        'lat': random.uniform(28.0, 48.0),
+        'lng': random.uniform(-122.0, -72.0),
+    })
+
+flights = []
+for _ in range(18):
+    o, d = random.sample(airports, 2)
+    flights.append({
+        'lat0': o['lat'], 'lng0': o['lng'],
+        'lat1': d['lat'], 'lng1': d['lng'],
+        'count': random.randint(1, 12),
+        'sourceName': o['name'], 'targetName': d['name'],
+    })
+
+flight_df = pd.DataFrame(flights)
+
+config = {
+    'version': 'v1',
+    'config': {
+        'visState': {
+            'layers': [{
+                'type': 'flow',
+                'config': {
+                    'dataId': 'flights',
+                    'label': 'Flight Flows',
+                    'isVisible': True,
+                    'columnMode': 'LAT_LNG',
+                    'columns': {
+                        'lat0': 'lat0',
+                        'lng0': 'lng0',
+                        'lat1': 'lat1',
+                        'lng1': 'lng1',
+                        'count': 'count',
+                        'sourceName': 'sourceName',
+                        'targetName': 'targetName'
+                    },
+                    'visConfig': {
+                        'colorRange': {
+                            'name': 'Global Warming',
+                            'type': 'sequential',
+                            'category': 'Uber',
+                            'colors': ['#5A1846', '#900C3F', '#C7001B', '#E15A17', '#FFC300']
+                        },
+                        'opacity': 1.0,
+                        'flowLinesRenderingMode': 'animated-straight',
+                        'flowLineThicknessScale': 1.0,
+                        'flowLineCurviness': 1.0,
+                        'flowAdaptiveScalesEnabled': True,
+                        'flowFadeEnabled': True,
+                        'flowFadeAmount': 50,
+                        'flowClusteringEnabled': True,
+                        'flowLocationTotalsEnabled': True,
+                        'maxTopFlowsDisplayNum': 5000
+                    }
+                }
+            }],
+            'interactionConfig': {
+                'tooltip': {
+                    'enabled': True,
+                    'fieldsToShow': {
+                        'flights': ['sourceName', 'targetName', 'count']
+                    }
+                }
+            }
+        },
+        'mapState': {
+            'latitude': 38.5,
+            'longitude': -97.0,
+            'zoom': 3.8,
+            'bearing': 0,
+            'pitch': 0,
+            'dragRotate': False
+        },
+        'mapStyle': {'styleType': 'dark-matter'}
+    }
+}
+
+map_1 = KeplerGl(data={'flights': flight_df}, config=config)
+map_1.save_to_html(file_name='flight_flow_map.html')
+```
+
+## Worked Example — H3 mode
+
+```python
+flow_df = pd.DataFrame({
+    'sourceH3': ['882a1072e9fffff', ...],
+    'targetH3': ['882a1072ffffffff', ...],
+    'count': [50, 500],
+})
+
+layer = {
+    'type': 'flow',
+    'config': {
+        'dataId': 'flows',
+        'label': 'Trade flows (H3)',
+        'isVisible': True,
+        'columnMode': 'H3',
+        'columns': {
+            'sourceH3': 'sourceH3',
+            'targetH3': 'targetH3',
+            'count': 'count'
+        },
+        'visConfig': {
+            'flowLinesRenderingMode': 'animated-straight',
+            'flowClusteringEnabled': False,
+            'flowLocationTotalsEnabled': True
+        }
+    }
+}
+```
+
+## Color
+
+FlowLayer has **no `colorField`/`colorScale` visual channel** — like
+`heatmap`, only `visConfig.colorRange` applies at render time. Do not set
+`visualChannels` on a flow layer.
+
+For a magnitude palette, pass a full `colorRange` object with explicit
+`name`, `type`, `category` and `colors` (as in the worked example) — the
+layer maps flow magnitude across that range automatically.
+
+## visConfig knobs
+
+All optional; defaults shown.
+
+| Field                        | Type      | Options / Range     | Default  | Purpose                                       |
+| ---------------------------- | --------- | ------------------- | -------- | --------------------------------------------- |
+| `flowLinesRenderingMode`     | enum      | `straight` / `curved` / `animated-straight` | `straight` | How flow lines are drawn; `animated-straight` animates direction |
+| `flowLineThicknessScale`     | number    | 0.1–5               | 1        | Line thickness multiplier                      |
+| `flowLineCurviness`          | number    | 0–2                 | 1        | Arc curvature (only visible with `curved`)     |
+| `flowAdaptiveScalesEnabled`  | boolean   | —                   | true     | Auto-adjust widths to zoom + visible data range |
+| `flowFadeEnabled`            | boolean   | —                   | true     | Fade smaller flows so larger ones stand out    |
+| `flowFadeAmount`             | number    | 0–100               | 50       | Aggressiveness of the fade                     |
+| `flowClusteringEnabled`      | boolean   | —                   | true     | Group nearby locations into clusters at low zoom; disable for small pre-aggregated O-D tables |
+| `flowLocationTotalsEnabled`  | boolean   | —                   | true     | Show circles at each location sized by total in/out volume |
+| `maxTopFlowsDisplayNum`      | number    | 0–10000             | 5000     | Limit rendering to the N largest flows (performance) |
+| `darkBaseMapEnabled`         | boolean   | —                   | (base map) | Toggle light/dark background scheme          |
+
+## Pitfalls
+
+- **Getting an arc layer instead of flow** — the flow layer is never
+  auto-created (see warning above); pass the full config with
+  `'type': 'flow'`.
+- **Blank flows** — rows with null coordinates break the accessor; drop
+  them in pandas before exporting.
+- **Clustered blobs at low zoom** — that's clustering doing its job; zoom
+  in, or set `'flowClusteringEnabled': False` for small datasets.
+- **Tooltip fields not appearing** — `fieldsToShow` names must match the
+  DataFrame columns, and the `dataId` key must match the dataset name.

--- a/bindings/python/skill/skill-references/flow-layer.md
+++ b/bindings/python/skill/skill-references/flow-layer.md
@@ -18,6 +18,15 @@ supply-chain, or any O-D dataset.
 
 ## When to use `flow` vs `arc`
 
+**O-D requests default to `flow`.** If the user asks for a "flow map", flows,
+"movement between", or names an O-D domain (migration, commute, trade,
+supply chain, shipments, flights between airports), build a `flow` layer —
+it renders fine even for a handful of pairs. Choose `arc` ONLY when the user
+explicitly asks for plain, unaggregated arcs ("draw a line/arc from A to
+B", "connect each pair", "no clustering"). Never substitute a
+`geojson`/`line` layer for an O-D request just because the data has a
+geometry column.
+
 | Property                     | `flow`                  | `arc`                |
 | ---------------------------- | ----------------------- | -------------------- |
 | Aggregates / clusters O-D    | yes                     | no                   |
@@ -198,6 +207,12 @@ FlowLayer has **no `colorField`/`colorScale` visual channel** — like
 For a magnitude palette, pass a full `colorRange` object with explicit
 `name`, `type`, `category` and `colors` (as in the worked example) — the
 layer maps flow magnitude across that range automatically.
+
+Suggested sequential palettes (dark → light reversed for magnitude maps):
+
+- YlGn (sequential green): `#ffffcc #c2e699 #78c679 #31a354 #006837 #004529`
+- OrRd (sequential red): `#fee5d9 #fcae91 #fb6a4a #de2d26 #a50f15`
+- YlGnBu (sequential blue): `#ffffcc #a1dab4 #41b6c4 #2c7fb8 #253494`
 
 ## visConfig knobs
 


### PR DESCRIPTION
Stacked on #3671 (merge that first — this PR contains its commits as the base).

## What

Content updates to the kepler.gl agent skill (now at `bindings/python/skill/` after #3671), adapted from the fsq-spatial-desktop `map-visualization` skill:

1. **`skill-references/flow-layer.md` (new)** — documents the `'flow'` layer for aggregated O-D flow maps: the never-auto-created rule (a configless O-D export falls back to an `arc` layer — this is the behavior observed in testing), Lat/Lng and H3 column modes, full worked example (10 airports + flights), `flowVisConfig` knob reference, `colorRange`-only coloring, pitfalls, suggested sequential palettes.
2. **`SKILL.md`** — new "Picking a Layer Type" section with the **O-D requests default to `flow`** rule (flow renders fine even for a handful of pairs; `arc` only on explicit unaggregated request; never substitute geojson/line for an O-D request), Flow row + flow reference link + auto-creation fallback Key Rule.
3. **`SKILL.md` install fix** — `pip install keplergl==0.4.0rc4` instead of plain `pip install keplergl` (which resolves to the incompatible 0.3.x stable that fails to build on Python 3.14).

## Verification

- `FlowLayer` confirmed present in the `kepler.gl@3.3.0-alpha.8` UMD bundle, added in #3386, tagged since `v3.3.0-alpha.1`.
- The worked example was generated with `save_to_html()` and rendered headless Chrome: side panel shows a **Flow** layer with animated direction lines and location-total circles.
- The fsq skill's column-alias auto-detection (`source_lat`, `origin_h3`, …) was deliberately NOT ported — it lives in that repo's `spatial-agent` handler, not in kepler.gl core; kepler.gl reads the columns assigned in the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)