### PR TITLE
fix: compact Export Map modal so footer stays visible

### DIFF
--- a/src/components/src/modals/export-map-modal/components.tsx
+++ b/src/components/src/modals/export-map-modal/components.tsx
@@ -3,10 +3,39 @@
 
 import React from 'react';
 import styled from 'styled-components';
-import {StyledExportSection} from '../../common/styled-components';
+import {media} from '@kepler.gl/styles';
+import {StyledExportSection, StyledModalContent} from '../../common/styled-components';
+
+export const StyledExportMapModalContent = styled(StyledModalContent)`
+  padding-top: 12px;
+  padding-bottom: 12px;
+
+  ${media.portable`
+    padding-top: 8px;
+    padding-bottom: 8px;
+  `};
+`;
 
 export const StyledExportMapSection = styled(StyledExportSection)`
-  margin-top: ${props => props.theme.exportIntraSectionMargin}px;
+  margin: 8px 0 12px;
+`;
+
+export const StyledExportMapNote = styled.p`
+  color: ${props => props.theme.textColorLT};
+  font-size: 12px;
+  line-height: 1.4;
+  margin: 0 0 8px;
+`;
+
+export const StyledExportMapFormatPanels = styled.div`
+  display: grid;
+`;
+
+export const StyledExportMapFormatPanel = styled.div<{$active: boolean}>`
+  grid-area: 1 / 1;
+  overflow: hidden;
+  visibility: ${props => (props.$active ? 'visible' : 'hidden')};
+  pointer-events: ${props => (props.$active ? 'auto' : 'none')};
 `;
 
 export const StyledWarning = styled.span`

--- a/src/components/src/modals/export-map-modal/export-html-map.tsx
+++ b/src/components/src/modals/export-map-modal/export-html-map.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import {StyledExportSection, StyledType, CheckMark} from '../../common/styled-components';
-import {StyledExportMapSection, StyledWarning, ExportMapLink} from './components';
+import {StyledExportMapNote, StyledWarning, ExportMapLink} from './components';
 import {
   EXPORT_HTML_MAP_MODE_OPTIONS,
   EXPORT_HTML_MAP_DOC,
@@ -17,10 +17,17 @@ import {IntlShape} from 'react-intl';
 import {setUserMapboxAccessToken, setExportHTMLMapMode, ActionHandler} from '@kepler.gl/actions';
 
 const ExportMapStyledExportSection = styled(StyledExportSection)`
+  margin: 8px 0 12px;
+
+  &.export-map-modal__html-options {
+    margin-top: 20px;
+  }
+
   .disclaimer {
     font-size: ${props => props.theme.inputFontSize};
     color: ${props => props.theme.inputColor};
-    margin-top: 12px;
+    line-height: 1.35;
+    margin-top: 8px;
   }
 `;
 
@@ -47,9 +54,15 @@ const StyledInput = styled.input<StyledInputProps>`
 const BigStyledTile = styled(StyledType)`
   height: unset;
   width: unset;
+  padding: 6px;
   img {
-    width: 180px;
-    height: 120px;
+    width: 120px;
+    height: 80px;
+  }
+  p {
+    font-size: 11px;
+    line-height: 1.3;
+    margin: 6px 0 0;
   }
 `;
 
@@ -79,12 +92,9 @@ function ExportHtmlMapFactory(): React.ComponentType<ExportHtmlMapProps> {
     intl
   }) => (
     <div>
-      <StyledExportMapSection>
-        <div className="description" />
-        <div className="selection">
-          <FormattedMessage id={'modal.exportMap.html.selection'} />
-        </div>
-      </StyledExportMapSection>
+      <StyledExportMapNote>
+        <FormattedMessage id={'modal.exportMap.html.selection'} />
+      </StyledExportMapNote>
       <ExportMapStyledExportSection className="export-map-modal__html-options">
         <div className="description">
           <div className="title">

--- a/src/components/src/modals/export-map-modal/export-json-map.tsx
+++ b/src/components/src/modals/export-map-modal/export-json-map.tsx
@@ -6,11 +6,13 @@ import JSONPretty from 'react-json-pretty';
 import {ADD_DATA_TO_MAP_DOC} from '@kepler.gl/constants';
 import styled from 'styled-components';
 import {StyledExportSection, Button} from '../../common/styled-components';
-import {StyledExportMapSection, StyledWarning, ExportMapLink} from './components';
+import {StyledExportMapNote, StyledWarning, ExportMapLink} from './components';
 import {FormattedMessage} from '@kepler.gl/localization';
 import {CopyToClipboard} from 'react-copy-to-clipboard';
 
 const StyledJsonExportSection = styled(StyledExportSection)`
+  margin: 8px 0 12px;
+
   .note {
     color: ${props => props.theme.errorColor};
     font-size: 11px;
@@ -27,9 +29,9 @@ const StyledJsonExportSection = styled(StyledExportSection)`
     padding: 0.5em 3.5em 0.5em 1em;
     margin: 0;
     box-sizing: border-box;
-    height: 180px;
+    height: 120px;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     overflow-x: auto;
     white-space: pre-wrap;
     word-wrap: break-word;
@@ -52,12 +54,9 @@ const ExportJsonMapUnmemoized = ({config = {}}: ExportJsonPropTypes) => {
   const [copied, setCopy] = useState(false);
   return (
     <div>
-      <StyledExportMapSection>
-        <div className="description" />
-        <div className="selection">
-          <FormattedMessage id={'modal.exportMap.json.selection'} />
-        </div>
-      </StyledExportMapSection>
+      <StyledExportMapNote>
+        <FormattedMessage id={'modal.exportMap.json.selection'} />
+      </StyledExportMapNote>
       <StyledJsonExportSection className="export-map-modal__json-options">
         <div className="description">
           <div className="title">

--- a/src/components/src/modals/export-map-modal/export-map-modal.tsx
+++ b/src/components/src/modals/export-map-modal/export-map-modal.tsx
@@ -2,11 +2,17 @@
 // Copyright contributors to the kepler.gl project
 
 import React from 'react';
+import styled from 'styled-components';
 
 import {FileType} from '../../common/icons';
-import {StyledModalContent, StyledType, CheckMark} from '../../common/styled-components';
+import {StyledType, CheckMark} from '../../common/styled-components';
 import {EXPORT_MAP_FORMATS, EXPORT_MAP_FORMAT_OPTIONS} from '@kepler.gl/constants';
-import {StyledExportMapSection} from './components';
+import {
+  StyledExportMapModalContent,
+  StyledExportMapSection,
+  StyledExportMapFormatPanels,
+  StyledExportMapFormatPanel
+} from './components';
 import ExportHtmlMapFactory from './export-html-map';
 import ExportJsonMapFactory from './export-json-map';
 import {FormattedMessage} from '@kepler.gl/localization';
@@ -23,6 +29,12 @@ interface ExportMapModalFactoryProps {
 
 const style = {width: '100%'};
 
+const CompactType = styled(StyledType)`
+  height: 64px;
+  width: 64px;
+  padding: 4px;
+`;
+
 const NO_OP = () => ({} as any);
 
 ExportMapModalFactory.deps = [ExportHtmlMapFactory, ExportJsonMapFactory];
@@ -38,7 +50,7 @@ function ExportMapModalFactory(
     onEditUserMapboxAccessToken = NO_OP,
     options = {format: ''}
   }: ExportMapModalFactoryProps) => (
-    <StyledModalContent className="export-map-modal">
+    <StyledExportMapModalContent className="export-map-modal">
       <div style={style}>
         <StyledExportMapSection>
           <div className="description">
@@ -51,35 +63,38 @@ function ExportMapModalFactory(
           </div>
           <div className="selection">
             {EXPORT_MAP_FORMAT_OPTIONS.map(op => (
-              <StyledType
+              <CompactType
                 key={op.id}
                 selected={options.format === op.id}
                 onClick={() => op.available && onChangeExportMapFormat(op.id)}
               >
-                <FileType ext={op.label} height="80px" fontSize="11px" />
+                <FileType ext={op.label} height="48px" fontSize="10px" />
 
                 {options.format === op.id && <CheckMark />}
-              </StyledType>
+              </CompactType>
             ))}
           </div>
         </StyledExportMapSection>
-        {
-          {
-            [EXPORT_MAP_FORMATS.HTML]: (
-              <ExportHtmlMap
-                onChangeExportMapHTMLMode={onChangeExportMapHTMLMode}
-                onEditUserMapboxAccessToken={onEditUserMapboxAccessToken}
-                options={options[options.format]}
-              />
-            ),
-            [EXPORT_MAP_FORMATS.JSON]: <ExportJsonMap config={config} />
-          }[
-            // @ts-ignore
-            options.format
-          ]
-        }
+        <StyledExportMapFormatPanels>
+          <StyledExportMapFormatPanel
+            $active={options.format === EXPORT_MAP_FORMATS.HTML}
+            aria-hidden={options.format !== EXPORT_MAP_FORMATS.HTML}
+            inert={options.format !== EXPORT_MAP_FORMATS.HTML ? true : undefined}
+          >
+            <ExportHtmlMap
+              onChangeExportMapHTMLMode={onChangeExportMapHTMLMode}
+              onEditUserMapboxAccessToken={onEditUserMapboxAccessToken}
+              options={options[EXPORT_MAP_FORMATS.HTML]}
+            />
+          </StyledExportMapFormatPanel>
+          {options.format === EXPORT_MAP_FORMATS.JSON ? (
+            <StyledExportMapFormatPanel $active>
+              <ExportJsonMap config={config} />
+            </StyledExportMapFormatPanel>
+          ) : null}
+        </StyledExportMapFormatPanels>
       </div>
-    </StyledModalContent>
+    </StyledExportMapModalContent>
   );
 
   ExportMapModalUnmemoized.displayName = 'ExportMapModal';


### PR DESCRIPTION
## Summary
On laptop-sized screens the Export Map dialog was too tall, so Cancel / Export sat below the fold.

This keeps the change isolated to the Export Map modal:
- Tighter spacing, smaller format tiles, and smaller HTML mode previews
- Extra space above the Mapbox access token section
- HTML/JSON switch keeps a stable dialog height without leaving the JSON Copy button on the HTML view

## Test plan
- [x] Open Share → Export Map on a laptop-sized viewport and confirm Cancel / Export are visible without scrolling
- [x] Switch between HTML and JSON and confirm the dialog height stays stable
- [x] Confirm the JSON Copy button disappears immediately when switching back to HTML