### PR TITLE
fix: lag when hovering large GeoJSON polygons

### DIFF
--- a/src/layers/src/geojson-layer/geojson-layer.spec.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.spec.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import GeoJsonLayer from './geojson-layer';
+
+describe('GeoJsonLayer hover overlay cache', () => {
+  const polygonFeature = {
+    type: 'Feature' as const,
+    properties: {index: 0},
+    geometry: {
+      type: 'Polygon' as const,
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0]
+        ]
+      ]
+    }
+  };
+
+  const hovered = (index: number, overrides: Record<string, unknown> = {}) => ({
+    picked: true,
+    index,
+    layer: {props: {id: 'hover_geojson'}},
+    object: {...polygonFeature, properties: {index}},
+    ...overrides
+  });
+
+  test('reuses overlay data for the same feature across redraws', () => {
+    const layer = new GeoJsonLayer({id: 'hover_geojson'});
+    const first = layer._getHoverOverlayData(hovered(0));
+    const second = layer._getHoverOverlayData(hovered(0));
+
+    expect(first).toBeTruthy();
+    expect(first).toBe(second);
+    expect(first?.[0].geometry.type).toBe('MultiLineString');
+  });
+
+  test('rebuilds overlay data when the hovered feature changes', () => {
+    const layer = new GeoJsonLayer({id: 'hover_geojson'});
+    const first = layer._getHoverOverlayData(hovered(0));
+    const other = layer._getHoverOverlayData(hovered(1));
+
+    expect(first).not.toBe(other);
+    expect(other?.[0].geometry.type).toBe('MultiLineString');
+  });
+
+  test('clears overlay data when nothing is picked', () => {
+    const layer = new GeoJsonLayer({id: 'hover_geojson'});
+    layer._getHoverOverlayData(hovered(0));
+
+    expect(layer._getHoverOverlayData(hovered(0, {picked: false}))).toBeNull();
+  });
+});

--- a/src/layers/src/geojson-layer/geojson-layer.spec.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.spec.ts
@@ -20,7 +20,7 @@ describe('GeoJsonLayer hover overlay cache', () => {
     }
   };
 
-  const hovered = (index: number, overrides: Record<string, unknown> = {}) => ({
+  const hovered = (index: number, overrides: {picked?: boolean} = {}) => ({
     picked: true,
     index,
     layer: {props: {id: 'hover_geojson'}},

--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -186,7 +186,8 @@ type ObjectInfo = {
   index: number;
   object?: Feature | undefined;
   picked: boolean;
-  layer: Layer;
+  // deck.gl picking info; only `props.id` is read for hover matching
+  layer: {props: {id: string}};
   radius?: number;
   id?: string;
 };

--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -26,7 +26,8 @@ import {
   detectTableColumns,
   COLUMN_MODE_GEOJSON,
   applyFiltersToTableColumns,
-  fieldIsGeoArrow
+  fieldIsGeoArrow,
+  featureToHoverOutline
 } from './geojson-utils';
 import {
   getGeojsonLayerMetaFromArrow,
@@ -256,6 +257,9 @@ export default class GeoJsonLayer extends Layer {
   filteredIndex: Uint8ClampedArray | null = null;
   filteredIndexTrigger: number[] | null = null;
   centroids: Array<number[] | null> = [];
+  // Stable hover overlay data so deck.gl does not re-parse the feature every redraw.
+  _hoverOverlayIndex: number | null = null;
+  _hoverOverlayData: Feature[] | null = null;
 
   _layerInfoModal: {
     [COLUMN_MODE_TABLE]: () => React.JSX.Element;
@@ -740,6 +744,34 @@ export default class GeoJsonLayer extends Layer {
       : super.hasHoveredObject(objectInfo);
   }
 
+  /**
+   * Memoized hover overlay features. Rebuilding `data: [hoveredObject]` on every
+   * pan/zoom frame makes deck.gl re-convert (and tessellate) huge polygons.
+   */
+  _getHoverOverlayData(objectInfo: ObjectInfo | null | undefined): Feature[] | null {
+    if (!objectInfo || !this.isLayerHovered(objectInfo)) {
+      this._hoverOverlayIndex = null;
+      this._hoverOverlayData = null;
+      return null;
+    }
+
+    const {index} = objectInfo;
+    if (Number.isFinite(index) && this._hoverOverlayData && this._hoverOverlayIndex === index) {
+      return this._hoverOverlayData;
+    }
+
+    const hoveredObject = this.hasHoveredObject(objectInfo);
+    if (!hoveredObject) {
+      this._hoverOverlayIndex = null;
+      this._hoverOverlayData = null;
+      return null;
+    }
+
+    this._hoverOverlayIndex = index;
+    this._hoverOverlayData = [featureToHoverOutline(hoveredObject)];
+    return this._hoverOverlayData;
+  }
+
   getElevationZoomFactor({zoom, zoomOffset = 0}) {
     return this.config.visConfig.fixedHeight ? 1 : Math.pow(2, Math.max(8 - zoom + zoomOffset, 0));
   }
@@ -773,7 +805,7 @@ export default class GeoJsonLayer extends Layer {
     };
 
     const pickable = interactionConfig.tooltip.enabled && visConfig.allowHover;
-    const hoveredObject = this.hasHoveredObject(objectHovered);
+    const hoverOverlayData = visConfig.enable3d ? null : this._getHoverOverlayData(objectHovered);
 
     const {data, ...props} = dataProps;
 
@@ -824,14 +856,14 @@ export default class GeoJsonLayer extends Layer {
     return [
       ...deckLayers,
       // hover layer
-      ...(hoveredObject && !visConfig.enable3d
+      ...(hoverOverlayData
         ? [
             new DeckGLGeoJsonLayer({
               ...this.getDefaultHoverLayerProps(),
               ...layerProps,
               visible: defaultLayerProps.visible,
               wrapLongitude: false,
-              data: [hoveredObject] as Feature[],
+              data: hoverOverlayData,
               getLineWidth: props.getLineWidth,
               getPointRadius: props.getPointRadius,
               getElevation: props.getElevation,

--- a/src/layers/src/geojson-layer/geojson-utils.spec.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.spec.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {Feature} from 'geojson';
+import {featureToHoverOutline} from './geojson-utils';
+
+describe('featureToHoverOutline', () => {
+  test('converts Polygon rings to MultiLineString so hover overlay skips fill tessellation', () => {
+    const coordinates = [
+      [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 0]
+      ]
+    ];
+    const feature: Feature = {
+      type: 'Feature',
+      properties: {index: 0},
+      geometry: {
+        type: 'Polygon',
+        coordinates
+      }
+    };
+
+    expect(featureToHoverOutline(feature)).toEqual({
+      ...feature,
+      geometry: {
+        type: 'MultiLineString',
+        coordinates
+      }
+    });
+  });
+
+  test('flattens MultiPolygon rings into a MultiLineString', () => {
+    const rings = [
+      [
+        [0, 0],
+        [1, 0],
+        [1, 1],
+        [0, 0]
+      ],
+      [
+        [2, 2],
+        [3, 2],
+        [3, 3],
+        [2, 2]
+      ]
+    ];
+    const feature: Feature = {
+      type: 'Feature',
+      properties: {index: 1},
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [[rings[0]], [rings[1]]]
+      }
+    };
+
+    expect(featureToHoverOutline(feature).geometry).toEqual({
+      type: 'MultiLineString',
+      coordinates: rings
+    });
+  });
+
+  test('leaves point and line features unchanged', () => {
+    const point: Feature = {
+      type: 'Feature',
+      properties: {},
+      geometry: {type: 'Point', coordinates: [1, 2]}
+    };
+    const line: Feature = {
+      type: 'Feature',
+      properties: {},
+      geometry: {
+        type: 'LineString',
+        coordinates: [
+          [0, 0],
+          [1, 1]
+        ]
+      }
+    };
+
+    expect(featureToHoverOutline(point)).toBe(point);
+    expect(featureToHoverOutline(line)).toBe(line);
+  });
+});

--- a/src/layers/src/geojson-layer/geojson-utils.ts
+++ b/src/layers/src/geojson-layer/geojson-utils.ts
@@ -142,6 +142,38 @@ function featureFromGeometry(parsedGeo: unknown, properties: null): Feature | nu
 }
 
 /**
+ * Convert a hovered feature to outline-only geometry for the hover overlay.
+ * The overlay is stroked and not filled, so polygon tessellation (earcut) is wasted
+ * work — and for high-vertex polygons it is expensive enough to stall pan/zoom
+ * if it runs again on every redraw.
+ */
+export function featureToHoverOutline(feature: Feature): Feature {
+  const {geometry} = feature;
+  if (!geometry) {
+    return feature;
+  }
+  if (geometry.type === 'Polygon') {
+    return {
+      ...feature,
+      geometry: {
+        type: 'MultiLineString',
+        coordinates: geometry.coordinates
+      }
+    };
+  }
+  if (geometry.type === 'MultiPolygon') {
+    return {
+      ...feature,
+      geometry: {
+        type: 'MultiLineString',
+        coordinates: geometry.coordinates.flat()
+      }
+    };
+  }
+  return feature;
+}
+
+/**
  * Parse a raw cell value into a GeoJSON Feature.
  * @param rawFeature Feature / geometry object, WKT/GeoJSON string, WKB bytes, or coordinate array
  * @param geoArrowEncoding Optional ARROW:extension:name (e.g. geoarrow.wkb, geoarrow.point)

--- a/test/browser/layer-tests/geojson-layer-specs.js
+++ b/test/browser/layer-tests/geojson-layer-specs.js
@@ -674,3 +674,95 @@ test('#GeojsonLayer -> renderLayer', t => {
   testRenderLayerCases(t, GeojsonLayer, TEST_CASES);
   t.end();
 });
+
+test('#GeojsonLayer -> hover overlay caches outline data', t => {
+  const layer = new GeojsonLayer({id: 'hover_geojson'});
+  const polygonFeature = {
+    type: 'Feature',
+    properties: {index: 0},
+    geometry: {
+      type: 'Polygon',
+      coordinates: [
+        [
+          [0, 0],
+          [1, 0],
+          [1, 1],
+          [0, 0]
+        ]
+      ]
+    }
+  };
+  const objectHovered = {
+    picked: true,
+    index: 0,
+    layer: {props: {id: 'hover_geojson'}},
+    object: polygonFeature
+  };
+
+  const first = layer._getHoverOverlayData(objectHovered);
+  const second = layer._getHoverOverlayData({...objectHovered});
+
+  t.ok(first, 'should create hover overlay data');
+  t.equal(first, second, 'should reuse hover overlay data for the same feature across redraws');
+  t.equal(
+    first[0].geometry.type,
+    'MultiLineString',
+    'should stroke polygons as lines so hover overlay skips fill tessellation'
+  );
+  t.deepEqual(
+    first[0].geometry.coordinates,
+    polygonFeature.geometry.coordinates,
+    'should keep polygon rings as line coordinates'
+  );
+
+  const other = layer._getHoverOverlayData({
+    ...objectHovered,
+    index: 1,
+    object: {...polygonFeature, properties: {index: 1}}
+  });
+  t.notEqual(first, other, 'should rebuild hover overlay data when the hovered feature changes');
+
+  const multi = layer._getHoverOverlayData({
+    picked: true,
+    index: 2,
+    layer: {props: {id: 'hover_geojson'}},
+    object: {
+      type: 'Feature',
+      properties: {index: 2},
+      geometry: {
+        type: 'MultiPolygon',
+        coordinates: [
+          [
+            [
+              [0, 0],
+              [1, 0],
+              [1, 1],
+              [0, 0]
+            ]
+          ],
+          [
+            [
+              [2, 2],
+              [3, 2],
+              [3, 3],
+              [2, 2]
+            ]
+          ]
+        ]
+      }
+    }
+  });
+  t.equal(
+    multi[0].geometry.type,
+    'MultiLineString',
+    'should flatten MultiPolygon rings into lines'
+  );
+  t.equal(multi[0].geometry.coordinates.length, 2, 'should keep one line per polygon ring');
+
+  t.equal(
+    layer._getHoverOverlayData({...objectHovered, picked: false}),
+    null,
+    'should clear hover overlay data when nothing is picked'
+  );
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Cache the 2D GeoJSON hover overlay by feature index so pan/zoom no longer rebuilds and tessellates the hovered polygon on every frame.
- Draw polygon hover outlines as `MultiLineString`s (the overlay is stroked, not filled), which skips earcut for high-vertex features.

## Test plan
- [x] Load a GeoJSON/Parquet layer with a mix of small and very large polygons.
- [x] Hover a large polygon and pan/zoom — map interaction should stay smooth.
- [x] Hover a small polygon, a polygon with holes, and a point/line feature — highlight still looks correct.
- [x] Click a feature to pin the highlight, then move the mouse away.

<img width="672" height="536" alt="Screenshot 2026-08-29 at 3 27 50 PM" src="https://github.com/user-attachments/assets/4c24976e-c686-4201-a64e-1aa88811fd2a" />
