### PR TITLE
fix: Grid and Hexagon layers disappear when Light & Shadow is added

### DIFF
--- a/src/deckgl-layers/src/layer-utils/globe-cell-utils.spec.ts
+++ b/src/deckgl-layers/src/layer-utils/globe-cell-utils.spec.ts
@@ -21,7 +21,7 @@ function makeFakeCellLayerClass() {
     // deck.gl ColumnLayer recreates fillModel on extensionsChanged and does not
     // copy over the colorRange texture binding. GridCellLayer / HexagonCellLayer
     // only bind that texture when the colorRange *prop* changes.
-    updateState() {
+    updateState(_params?: unknown) {
       this.state.fillModel = {shaderInputs: {setProps: jest.fn()}};
     }
 

--- a/src/deckgl-layers/src/layer-utils/globe-cell-utils.spec.ts
+++ b/src/deckgl-layers/src/layer-utils/globe-cell-utils.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {makeGlobeCellLayerClass} from './globe-cell-utils';
+
+function makeFakeCellLayerClass() {
+  return class FakeCellLayer {
+    state: {
+      fillModel?: {shaderInputs: {setProps: jest.Mock}};
+      colorTexture?: {id: string};
+    } = {};
+    context = {viewport: {}};
+
+    getShaders() {
+      return {
+        vs: 'void main(void) { gl_Position = project_common_position_to_clipspace(geometry.position); }',
+        modules: []
+      };
+    }
+
+    // deck.gl ColumnLayer recreates fillModel on extensionsChanged and does not
+    // copy over the colorRange texture binding. GridCellLayer / HexagonCellLayer
+    // only bind that texture when the colorRange *prop* changes.
+    updateState() {
+      this.state.fillModel = {shaderInputs: {setProps: jest.fn()}};
+    }
+
+    draw(_opts?: unknown) {
+      // no-op stub so GlobeCellLayer.draw can call super.draw()
+    }
+  };
+}
+
+describe('globe-cell-utils colorRange rebind', () => {
+  test('rebinds colorRange onto a rebuilt fillModel (grid)', () => {
+    const GlobeGridCell = makeGlobeCellLayerClass(makeFakeCellLayerClass(), 'grid');
+    const layer = new GlobeGridCell();
+    layer.state.colorTexture = {id: 'color-range-tex'};
+
+    layer.updateState({
+      changeFlags: {extensionsChanged: true},
+      props: {colorRange: ['#fff']},
+      oldProps: {colorRange: ['#fff']}
+    });
+
+    expect(layer.state.fillModel?.shaderInputs.setProps).toHaveBeenCalledWith({
+      grid: {colorRange: layer.state.colorTexture}
+    });
+  });
+
+  test('rebinds colorRange onto a rebuilt fillModel (hexagon)', () => {
+    const GlobeHexCell = makeGlobeCellLayerClass(makeFakeCellLayerClass(), 'hexagon');
+    const layer = new GlobeHexCell();
+    layer.state.colorTexture = {id: 'color-range-tex'};
+
+    layer.updateState({
+      changeFlags: {extensionsChanged: true},
+      props: {colorRange: ['#fff']},
+      oldProps: {colorRange: ['#fff']}
+    });
+
+    expect(layer.state.fillModel?.shaderInputs.setProps).toHaveBeenCalledWith({
+      hexagon: {colorRange: layer.state.colorTexture}
+    });
+  });
+
+  test('draw also rebinds colorRange so the first frame after rebuild is valid', () => {
+    const GlobeGridCell = makeGlobeCellLayerClass(makeFakeCellLayerClass(), 'grid');
+    const layer = new GlobeGridCell();
+    const setProps = jest.fn();
+    layer.state.colorTexture = {id: 'color-range-tex'};
+    layer.state.fillModel = {shaderInputs: {setProps}};
+
+    layer.draw({});
+
+    expect(setProps).toHaveBeenCalledWith({
+      grid: {colorRange: layer.state.colorTexture}
+    });
+  });
+});

--- a/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
@@ -146,6 +146,27 @@ const globeCellClassCache = new WeakMap<object, object>();
 
 type LayerConstructor = {new (...args: any[]): any; layerName?: string};
 
+/**
+ * deck.gl's GridCellLayer / HexagonCellLayer bind the `colorRange` palette
+ * texture only when the `colorRange` *prop* changes. ColumnLayer (the parent)
+ * destroys and recreates `fillModel` whenever `extensionsChanged` fires —
+ * which happens when Light & Shadow registers the shadow shader module.
+ * The new model starts with empty bindings, the colorRange check is a no-op,
+ * and luma.gl skips the draw: "Binding colorRange not found in …-cells-fill-cached".
+ * Recreating the Kepler layer "fixes" it because initialize/update then sees a
+ * colorRange change against empty oldProps and binds the texture again.
+ *
+ * Re-bind the existing texture onto whatever fillModel is current. Harmless
+ * when the parent already bound it; required after a model rebuild.
+ */
+function bindColorRangeTexture(layer: {state?: any}, moduleName: string): void {
+  const model = layer.state?.fillModel;
+  const colorTexture = layer.state?.colorTexture;
+  if (model?.shaderInputs && colorTexture) {
+    model.shaderInputs.setProps({[moduleName]: {colorRange: colorTexture}});
+  }
+}
+
 export function makeGlobeCellLayerClass<T extends LayerConstructor>(
   BaseCellLayer: T,
   type: string
@@ -165,6 +186,11 @@ export function makeGlobeCellLayerClass<T extends LayerConstructor>(
       };
     }
 
+    updateState(params: any) {
+      super.updateState(params);
+      bindColorRangeTexture(this, type);
+    }
+
     draw(opts: any) {
       const globeMode = (this.context.viewport as any).resolution ? 1.0 : 0.0;
       // GridCellLayer / HexagonCellLayer render through a single fillModel and set
@@ -175,6 +201,7 @@ export function makeGlobeCellLayerClass<T extends LayerConstructor>(
       if (model?.shaderInputs) {
         model.shaderInputs.setProps({globeCell: {globeMode}});
       }
+      bindColorRangeTexture(this, type);
       super.draw(opts);
     }
   }

--- a/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/globe-cell-utils.ts
@@ -159,7 +159,7 @@ type LayerConstructor = {new (...args: any[]): any; layerName?: string};
  * Re-bind the existing texture onto whatever fillModel is current. Harmless
  * when the parent already bound it; required after a model rebuild.
  */
-function bindColorRangeTexture(layer: {state?: any}, moduleName: string): void {
+function bindColorRangeTexture(layer: any, moduleName: string): void {
   const model = layer.state?.fillModel;
   const colorTexture = layer.state?.colorTexture;
   if (model?.shaderInputs && colorTexture) {


### PR DESCRIPTION
## Summary
- Adding Light & Shadow rebuilds the Grid/Hexagon cell fill model, but deck.gl does not rebind the `colorRange` palette texture. luma.gl then skips the draw (`Binding colorRange not found`) and the layer vanishes until it is recreated.
- Rebind that texture after the model is rebuilt (and again at draw time) so extruded Grid and Hexagon cells stay visible and pick up shadows.

## Test plan
- [x] Create an extruded Grid layer, then add Light & Shadow — cells should stay visible and receive shadows without recreating the layer
- [x] Repeat with a Hexagon layer
- [x] Change the color palette after enabling shadows — colors still update