### PR TITLE
fix: Light & Shadow layer order shading and top-view occlusion

### DIFF
--- a/src/effects/src/custom-deck-lighting-effect.spec.ts
+++ b/src/effects/src/custom-deck-lighting-effect.spec.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {patchShadowPassDepth} from './custom-deck-lighting-effect';
+
+describe('patchShadowPassDepth', () => {
+  test('forces WebGL depth writes and disables polygon offset', () => {
+    const pass = {
+      getLayerParameters: () => ({
+        depthTest: true,
+        depthMask: false,
+        blend: true
+      })
+    };
+
+    patchShadowPassDepth(pass as Parameters<typeof patchShadowPassDepth>[0]);
+
+    expect(pass.getLayerParameters({} as any, 0, null)).toMatchObject({
+      blend: false,
+      depthTest: true,
+      depthMask: true,
+      depthWriteEnabled: true,
+      depthCompare: 'less-equal',
+      polygonOffsetFill: false,
+      polygonOffset: [0, 0]
+    });
+  });
+});

--- a/src/effects/src/custom-deck-lighting-effect.spec.ts
+++ b/src/effects/src/custom-deck-lighting-effect.spec.ts
@@ -16,11 +16,8 @@ describe('patchShadowPassDepth', () => {
     patchShadowPassDepth(pass as Parameters<typeof patchShadowPassDepth>[0]);
 
     expect(pass.getLayerParameters({} as any, 0, null)).toMatchObject({
-      blend: false,
       depthTest: true,
       depthMask: true,
-      depthWriteEnabled: true,
-      depthCompare: 'less-equal',
       polygonOffsetFill: false,
       polygonOffset: [0, 0]
     });

--- a/src/effects/src/custom-deck-lighting-effect.spec.ts
+++ b/src/effects/src/custom-deck-lighting-effect.spec.ts
@@ -6,16 +6,16 @@ import {patchShadowPassDepth} from './custom-deck-lighting-effect';
 describe('patchShadowPassDepth', () => {
   test('forces WebGL depth writes and disables polygon offset', () => {
     const pass = {
-      getLayerParameters: () => ({
+      getLayerParameters: (_layer: unknown, _layerIndex: number, _viewport: unknown) => ({
         depthTest: true,
         depthMask: false,
         blend: true
       })
     };
 
-    patchShadowPassDepth(pass as Parameters<typeof patchShadowPassDepth>[0]);
+    patchShadowPassDepth(pass);
 
-    expect(pass.getLayerParameters({} as any, 0, null)).toMatchObject({
+    expect(pass.getLayerParameters({}, 0, null)).toMatchObject({
       depthTest: true,
       depthMask: true,
       polygonOffsetFill: false,

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -42,7 +42,11 @@ const SHADOW_PASS_DEPTH_PARAMETERS = {
 };
 
 export function patchShadowPassDepth(pass: {
-  getLayerParameters: (...args: unknown[]) => Record<string, unknown>;
+  getLayerParameters: (
+    layer: unknown,
+    layerIndex: number,
+    viewport: unknown
+  ) => Record<string, unknown>;
 }) {
   const originalGetLayerParameters = pass.getLayerParameters.bind(pass);
   pass.getLayerParameters = (layer, layerIndex, viewport) => ({

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -16,43 +16,34 @@ const DEFAULT_LIGHTING_EFFECT = new LightingEffect();
  * Exposes private members of LightingEffect that we need to access.
  * These are runtime-accessible but TypeScript marks them as private.
  */
-type ShadowPassLike = {
-  delete(): void;
-  render(params: Record<string, unknown>): void;
-  getLayerParameters: (
-    layer: {props?: {parameters?: Record<string, unknown>}},
-    layerIndex: number,
-    viewport: unknown
-  ) => Record<string, unknown>;
-};
-
 interface LightingEffectPrivate {
   shadow: boolean;
-  shadowPasses: ShadowPassLike[];
+  shadowPasses: {
+    delete(): void;
+    render(params: Record<string, unknown>): void;
+    getLayerParameters: (
+      layer: unknown,
+      layerIndex: number,
+      viewport: unknown
+    ) => Record<string, unknown>;
+  }[];
   dummyShadowMap: Texture | null;
   _createShadowPasses(device: unknown): void;
 }
 
-// deck.gl's ShadowPass sets depthWriteEnabled/depthCompare, but Kepler's WebGL
-// path applies parameters via withParametersWebGL, which only honors GL-style
-// depthTest/depthMask. Layers that set depthMask: false for 2D stacking then
-// fail to write the shadow map, so shadows appear or vanish depending on order.
-//
-// polygonOffset is applied per layerIndex (later layers pulled toward the camera).
-// In the shadow pass the camera is the sun, so a ground plane drawn after buildings
-// is biased closer than building walls and overwrites them. Roofs stay closer, so
-// shadows on the plane look correct while buildings stop receiving shadows.
+// WebGL applies GL-style depthTest/depthMask; deck.gl's ShadowPass only sets
+// depthWriteEnabled. Disable polygonOffset so a later ground plane is not
+// pulled toward the sun and cannot overwrite building walls in the shadow map.
 const SHADOW_PASS_DEPTH_PARAMETERS = {
-  blend: false,
   depthTest: true,
   depthMask: true,
-  depthWriteEnabled: true,
-  depthCompare: 'less-equal',
   polygonOffsetFill: false,
   polygonOffset: [0, 0]
 };
 
-export function patchShadowPassDepth(pass: ShadowPassLike) {
+export function patchShadowPassDepth(pass: {
+  getLayerParameters: (...args: unknown[]) => Record<string, unknown>;
+}) {
   const originalGetLayerParameters = pass.getLayerParameters.bind(pass);
   pass.getLayerParameters = (layer, layerIndex, viewport) => ({
     ...originalGetLayerParameters(layer, layerIndex, viewport),

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -16,11 +16,48 @@ const DEFAULT_LIGHTING_EFFECT = new LightingEffect();
  * Exposes private members of LightingEffect that we need to access.
  * These are runtime-accessible but TypeScript marks them as private.
  */
+type ShadowPassLike = {
+  delete(): void;
+  render(params: Record<string, unknown>): void;
+  getLayerParameters: (
+    layer: {props?: {parameters?: Record<string, unknown>}},
+    layerIndex: number,
+    viewport: unknown
+  ) => Record<string, unknown>;
+};
+
 interface LightingEffectPrivate {
   shadow: boolean;
-  shadowPasses: {delete(): void; render(params: Record<string, unknown>): void}[];
+  shadowPasses: ShadowPassLike[];
   dummyShadowMap: Texture | null;
   _createShadowPasses(device: unknown): void;
+}
+
+// deck.gl's ShadowPass sets depthWriteEnabled/depthCompare, but Kepler's WebGL
+// path applies parameters via withParametersWebGL, which only honors GL-style
+// depthTest/depthMask. Layers that set depthMask: false for 2D stacking then
+// fail to write the shadow map, so shadows appear or vanish depending on order.
+//
+// polygonOffset is applied per layerIndex (later layers pulled toward the camera).
+// In the shadow pass the camera is the sun, so a ground plane drawn after buildings
+// is biased closer than building walls and overwrites them. Roofs stay closer, so
+// shadows on the plane look correct while buildings stop receiving shadows.
+const SHADOW_PASS_DEPTH_PARAMETERS = {
+  blend: false,
+  depthTest: true,
+  depthMask: true,
+  depthWriteEnabled: true,
+  depthCompare: 'less-equal',
+  polygonOffsetFill: false,
+  polygonOffset: [0, 0]
+};
+
+export function patchShadowPassDepth(pass: ShadowPassLike) {
+  const originalGetLayerParameters = pass.getLayerParameters.bind(pass);
+  pass.getLayerParameters = (layer, layerIndex, viewport) => ({
+    ...originalGetLayerParameters(layer, layerIndex, viewport),
+    ...SHADOW_PASS_DEPTH_PARAMETERS
+  });
 }
 
 /** Extended shadow module props with our custom field. */
@@ -165,6 +202,9 @@ class CustomDeckLightingEffect extends LightingEffect {
     const {device, deck} = context;
     if (this._private.shadow && !this._private.dummyShadowMap) {
       this._private._createShadowPasses(device);
+      for (const shadowPass of this._private.shadowPasses) {
+        patchShadowPassDepth(shadowPass);
+      }
       deck._addDefaultShaderModule(CustomShadowModule || shadow);
       this._private.dummyShadowMap = device.createTexture({width: 1, height: 1});
     }

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -1554,6 +1554,11 @@ class Layer implements KeplerLayer {
     visible: boolean;
   }) {
     const blendingParameters = mapState.layerParameters ?? {};
+    const enable3d = Boolean(this.config.visConfig.enable3d);
+    const is3dView = Boolean(mapState.dragRotate);
+    // Always depth-test so a flat layer cannot paint over closer extruded
+    // geometry (e.g. a ground plane covering buildings in top view). Only 3D
+    // layers / 3D view write depth, so coplanar 2D layers still stack by order.
     return {
       id: this.id,
       idx,
@@ -1561,7 +1566,8 @@ class Layer implements KeplerLayer {
       pickable: true,
       wrapLongitude: true,
       parameters: {
-        depthTest: Boolean(mapState.dragRotate || this.config.visConfig.enable3d),
+        depthTest: true,
+        depthMask: is3dView || enable3d,
         ...blendingParameters
       },
       hidden: this.config.hidden,

--- a/src/layers/src/geojson-layer/geojson-layer.spec.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.spec.ts
@@ -3,6 +3,45 @@
 
 import GeoJsonLayer from './geojson-layer';
 
+describe('GeoJsonLayer default deck parameters', () => {
+  const gpuFilter = null as any;
+  const layerCallbacks = {};
+
+  const propsFor = (layer: GeoJsonLayer, mapState: Record<string, unknown>) =>
+    layer.getDefaultDeckLayerProps({
+      idx: 0,
+      gpuFilter,
+      mapState: mapState as any,
+      layerCallbacks,
+      visible: true
+    }).parameters;
+
+  test('flat layer in top view depth-tests but does not write depth', () => {
+    const layer = new GeoJsonLayer({id: 'geojson_depth'});
+    expect(propsFor(layer, {dragRotate: false})).toMatchObject({
+      depthTest: true,
+      depthMask: false
+    });
+  });
+
+  test('extruded layer writes depth even in top view so it can occlude a flat plane', () => {
+    const layer = new GeoJsonLayer({id: 'geojson_depth'});
+    layer.config.visConfig.enable3d = true;
+    expect(propsFor(layer, {dragRotate: false})).toMatchObject({
+      depthTest: true,
+      depthMask: true
+    });
+  });
+
+  test('3D view writes depth for flat layers so they participate in occlusion', () => {
+    const layer = new GeoJsonLayer({id: 'geojson_depth'});
+    expect(propsFor(layer, {dragRotate: true})).toMatchObject({
+      depthTest: true,
+      depthMask: true
+    });
+  });
+});
+
 describe('GeoJsonLayer hover overlay cache', () => {
   const polygonFeature = {
     type: 'Feature' as const,

--- a/test/browser/layer-tests/geojson-layer-specs.js
+++ b/test/browser/layer-tests/geojson-layer-specs.js
@@ -563,7 +563,7 @@ test('#GeojsonLayer -> renderLayer', t => {
           filled: false,
           wireframe: false,
           opacity: 0.8,
-          parameters: {depthTest: false},
+          parameters: {depthTest: true, depthMask: false},
           visible: true,
           autoHighlight: false,
           wrapLongitude: false,


### PR DESCRIPTION
## Summary
- Always depth-test layers so a flat GeoJSON plane cannot cover closer extruded features in top view.
- In the shadow pass, force depth writes and disable polygon offset so a later ground plane cannot overwrite building walls in the shadow map.

## Test plan
- Add a non-extruded GeoJSON plane and an extruded GeoJSON layer, then enable Light & Shadow.
- Swap layer order: building shadows and plane shadows should stay the same.
- Switch to top view: extruded features should remain visible over the plane.