### PR TITLE
fix: hovered extruded features stop casting Light & Shadow

### DIFF
--- a/src/effects/src/custom-deck-lighting-effect.spec.ts
+++ b/src/effects/src/custom-deck-lighting-effect.spec.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {shadowMapHoverFixModule} from './custom-deck-lighting-effect';
+
+describe('shadowMapHoverFixModule', () => {
+  test('re-encodes shadow map depth after picking highlight', () => {
+    const inject = (
+      shadowMapHoverFixModule as {
+        inject: Record<string, {order: number; injection: string}>;
+      }
+    ).inject['fs:DECKGL_FILTER_COLOR'];
+
+    // deck.gl picking blends highlightColor at order 99, which would overwrite
+    // encoded shadow depth for the hovered object.
+    expect(inject.order).toBeGreaterThan(99);
+    expect(inject.injection).toContain('shadow.drawShadowMap');
+    expect(inject.injection).toContain('shadow_filterShadowColor');
+  });
+});

--- a/src/effects/src/custom-deck-lighting-effect.ts
+++ b/src/effects/src/custom-deck-lighting-effect.ts
@@ -128,6 +128,26 @@ function createCustomShadowModule(): ShaderModule | null {
 
 const CustomShadowModule = createCustomShadowModule();
 
+// deck.gl picking injects at order 99 and blends highlightColor over the
+// fragment. In the shadow pass that overwrites encoded depth, so a hovered
+// extruded feature stops casting a shadow. Re-encode after picking.
+// Color-pass highlight compositing is unchanged (shadow still runs first).
+const PICKING_FILTER_COLOR_ORDER = 99;
+
+export const shadowMapHoverFixModule = {
+  name: 'shadow-map-hover-fix',
+  inject: {
+    'fs:DECKGL_FILTER_COLOR': {
+      order: PICKING_FILTER_COLOR_ORDER + 1,
+      injection: `
+  if (shadow.drawShadowMap) {
+    color = shadow_filterShadowColor(color);
+  }
+      `
+    }
+  }
+} as unknown as ShaderModule;
+
 /**
  * Detect layers that use the PBR shader module (3D tile sublayers:
  * ScenegraphLayer sets `_lighting: 'pbr'`, SimpleMeshLayer sets `pbrMaterial`).
@@ -143,6 +163,8 @@ function isPbrLayer(layer: any): boolean {
  * - A patched shadow module with `outputUniformShadow` for uniform shadow
  *   during nighttime (avoids partial shadows from below).
  * - Simple phong replacement for PBR layers (avoids microfacet specular).
+ * - Shadow-map depth re-encoded after picking highlight so hovered extruded
+ *   features still cast shadows.
  * - getShaderModuleProps override that always provides dummyShadowMap
  *   to prevent "Bad texture binding" errors when shadows are disabled.
  */
@@ -166,6 +188,7 @@ class CustomDeckLightingEffect extends LightingEffect {
     if (this._private.shadow && !this._private.dummyShadowMap) {
       this._private._createShadowPasses(device);
       deck._addDefaultShaderModule(CustomShadowModule || shadow);
+      deck._addDefaultShaderModule(shadowMapHoverFixModule);
       this._private.dummyShadowMap = device.createTexture({width: 1, height: 1});
     }
   }
@@ -198,6 +221,7 @@ class CustomDeckLightingEffect extends LightingEffect {
       this._private.dummyShadowMap.destroy();
       this._private.dummyShadowMap = null;
       context.deck._removeDefaultShaderModule(CustomShadowModule || shadow);
+      context.deck._removeDefaultShaderModule(shadowMapHoverFixModule);
     }
   }
 

--- a/src/effects/tsconfig.production.json
+++ b/src/effects/tsconfig.production.json
@@ -24,5 +24,6 @@
     "isolatedModules": true,
     "baseUrl": "./src"
   },
-  "include": ["src", "../deckgl-types.d.ts"]
+  "include": ["src", "../deckgl-types.d.ts"],
+  "exclude": ["**/*.spec.*"]
 }


### PR DESCRIPTION
## Summary
- Hover highlight was blending over the shadow map, so the hovered extruded feature (GeoJSON buildings, etc.) stopped casting a shadow.
- Re-encode shadow-map depth after picking, only in the shadow pass. Color-pass highlight is unchanged.

## Test plan
- [x] Add Light & Shadow, enable 3D on a GeoJSON layer with many extruded features
- [x] Hover a building: it stays highlighted and still casts a shadow
- [x] Confirm neighboring features, 2D hover outlines, and picking/tooltips still work