### PR TITLE
feat: support webMCP

### DIFF
--- a/examples/demo-app/README.md
+++ b/examples/demo-app/README.md
@@ -13,6 +13,22 @@ This is the src code of kepler.gl demo app. You can copy this folder out and run
 > in-browser map. See [`docs/NEXT_PLAN.md`](docs/NEXT_PLAN.md) for the permanent
 > separation back into a kepler.gl `src/mcp/` module.
 
+#### Agent surfaces
+
+The demo exposes the same DuckDB-free `map.*` command catalog through two
+transports (`kepler-mcp-shared.ts` holds the common glue):
+
+- **`kepler-mcp-bridge.tsx`** — WebSocket reverse-connect to a local
+  kepler-mcp-demo process (opt-in via `?mcp=<token>` or the bottom-left chip).
+- **`kepler-webmcp.tsx`** — native [WebMCP](https://webmachinelearning.github.io/webmcp/)
+  registration on `document.modelContext` (fallback `navigator.modelContext`),
+  for harnesses with a built-in browser (Chrome's agent, Claude Desktop's
+  browser, ...). Needs Chrome 149+ with the WebMCP origin trial or
+  `chrome://flags/#enable-webmcp-testing`; the chip is hidden when the API is
+  not available. Tool names fold `map.load-data` → `map_load_data` (dots are
+  common MCP-tool-name poison); the original command id is kept in the
+  description and every result string.
+
 #### Pre requirement
 - [Node.js ^20.x](http://nodejs.org): We use Node to generate the documentation, run a
   development web server, run tests, and generate distributable files. Depending on your system,

--- a/examples/demo-app/esbuild.config.mjs
+++ b/examples/demo-app/esbuild.config.mjs
@@ -174,6 +174,7 @@ const config = {
   loader: {
     '.js': 'jsx',
     '.css': 'css',
+    '.md': 'text',
     '.ttf': 'file',
     '.woff': 'file',
     '.woff2': 'file'

--- a/examples/demo-app/src/app.tsx
+++ b/examples/demo-app/src/app.tsx
@@ -12,8 +12,7 @@ import {useParams, useSearchParams, useLocation} from 'react-router-dom';
 import {WebMercatorViewport} from '@deck.gl/core';
 import {setMapBoundary} from '@openassistant/kepler-assistant';
 import {AiAssistantPanel} from '@openassistant/kepler-assistant';
-import {KeplerMcpBridge} from './kepler-mcp-bridge';
-import {KeplerWebMcp} from './kepler-webmcp';
+import {KeplerTransportStatus} from './kepler-transport-status';
 import {panelBorderColor, theme} from '@kepler.gl/styles';
 import {ParsedConfig} from '@kepler.gl/types';
 import {getApplicationConfig} from '@kepler.gl/utils';
@@ -947,8 +946,7 @@ const App = props => {
                 </>
               )}
             </PanelGroup>
-            <KeplerMcpBridge reduxStore={reduxStore} />
-            <KeplerWebMcp reduxStore={reduxStore} />
+            <KeplerTransportStatus reduxStore={reduxStore} />
           </div>
         </GlobalStyle>
       </ThemeProvider>

--- a/examples/demo-app/src/app.tsx
+++ b/examples/demo-app/src/app.tsx
@@ -13,6 +13,7 @@ import {WebMercatorViewport} from '@deck.gl/core';
 import {setMapBoundary} from '@openassistant/kepler-assistant';
 import {AiAssistantPanel} from '@openassistant/kepler-assistant';
 import {KeplerMcpBridge} from './kepler-mcp-bridge';
+import {KeplerWebMcp} from './kepler-webmcp';
 import {panelBorderColor, theme} from '@kepler.gl/styles';
 import {ParsedConfig} from '@kepler.gl/types';
 import {getApplicationConfig} from '@kepler.gl/utils';
@@ -947,6 +948,7 @@ const App = props => {
               )}
             </PanelGroup>
             <KeplerMcpBridge reduxStore={reduxStore} />
+            <KeplerWebMcp reduxStore={reduxStore} />
           </div>
         </GlobalStyle>
       </ThemeProvider>

--- a/examples/demo-app/src/kepler-mcp-bridge.tsx
+++ b/examples/demo-app/src/kepler-mcp-bridge.tsx
@@ -14,17 +14,11 @@
  * the "Connect to map harness" button (pastes a token).
  */
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {getKeplerCommands, getValuesFromDataset} from '@kepler.gl/mcp';
-import type {KeplerContext, RoomCommandResult, ToolDescriptor} from '@kepler.gl/mcp';
-import {WebMercatorViewport} from '@deck.gl/core';
+import type {RoomCommandResult} from '@kepler.gl/mcp';
+import {buildCatalog, buildKeplerContext, formatResult, toDescriptor} from './kepler-mcp-shared';
 
 const DEFAULT_PORT = 8765;
 const WSHost = () => 'localhost';
-
-// map.* commands that need a DuckDB connector / the kepler-app glue
-// (`loadTableToKepler`, `loadTableIntoDuckDB`, `getConnector`). The mapping-only
-// bridge does not serve them.
-const DUCKDB_REQUIRED = new Set(['map.create-table', 'map.add-column', 'map.save-data']);
 
 type BridgeStatus = 'idle' | 'connecting' | 'connected' | 'error';
 
@@ -35,116 +29,6 @@ function getUrlConfig(): {token: string; port: number; host: string} {
   const port = Number(params.get('mcpPort')) || DEFAULT_PORT;
   const host = params.get('mcpHost') ?? WSHost();
   return {token, port, host};
-}
-
-/** Live accessors into the demo's own redux store — no kepler-assistant needed. */
-function buildKeplerContext(reduxStore: any): KeplerContext {
-  const readMap = () => reduxStore?.getState()?.demo?.keplerGl?.map;
-  return {
-    getVisState: () => readMap()?.visState,
-    getMapBoundary: () => {
-      // Recompute the current viewport corners from the live mapState (same
-      // WebMercatorViewport math the app's onViewStateChange uses). Fall back
-      // to the assistant slice's stored boundary if mapState lacks a size.
-      const mapState = readMap()?.mapState;
-      if (mapState?.width && mapState?.height) {
-        try {
-          const viewport = new WebMercatorViewport(mapState);
-          const nw = viewport.unproject([0, 0]);
-          const se = viewport.unproject([viewport.width, viewport.height]);
-          return {nw: [nw[0], nw[1]], se: [se[0], se[1]]};
-        } catch {
-          /* fall through to stored boundary */
-        }
-      }
-      return reduxStore?.getState()?.demo?.aiAssistant?.keplerGl?.mapBoundary;
-    },
-    getMapboxToken: () =>
-      typeof window !== 'undefined' ? (localStorage.getItem('mapbox-token') ?? undefined) : undefined,
-    dispatch: (action: any) => reduxStore?.dispatch(action),
-    getValuesFromDataset: (datasetName, variableName) => {
-      const visState = readMap()?.visState;
-      if (!visState) return [];
-      return getValuesFromDataset(visState.datasets, visState.layers, datasetName, variableName);
-    },
-    getDatasetContext: () => {
-      // Shape required by map.get-dataset-context: a human line, then a JSON
-      // array of {datasetName, datasetId, fields, layers} descriptors.
-      const visState = readMap()?.visState;
-      const datasets = visState?.datasets;
-      const layers = visState?.layers ?? [];
-      if (!datasets) return '';
-      const context =
-        'Please remember the following datasets and layers for answering the user question:';
-      const dataMeta = Object.values(datasets).map((ds: any) => ({
-        datasetName: ds?.label ?? ds?.id,
-        datasetId: ds?.id,
-        fields: (ds?.fields ?? []).map((f: any) => ({[f.name]: f.type})),
-        layers: layers
-          .filter((layer: any) => layer?.config?.dataId === ds?.id)
-          .map((layer: any) => ({
-            id: layer.id,
-            label: layer.config.label,
-            type: layer.type,
-            geometryMode: layer.config.columnMode,
-            geometryColumns: Object.fromEntries(
-              Object.entries(layer.config.columns)
-                .filter(([, value]) => value !== null)
-                .map(([key, value]) => [
-                  key,
-                  typeof value === 'object' && value !== null
-                    ? Object.fromEntries(Object.entries(value).filter(([, v]) => v !== null))
-                    : value
-                ])
-            )
-          }))
-      }));
-      return `${context}\n${JSON.stringify(dataMeta)}`;
-    },
-    loadTableToKepler: async () => ({
-      success: false,
-      error: 'map.save-data / loadTableToKepler is not available in the mapping-only bridge.'
-    }),
-    loadTableIntoDuckDB: async () => {
-      throw new Error('DuckDB operations are not available in the mapping-only bridge.');
-    },
-    getConnector: async () => {
-      throw new Error('DuckDB operations are not available in the mapping-only bridge.');
-    }
-  };
-}
-
-/** The DuckDB-free map.* commands this page serves over the bridge. */
-function buildCatalog(ctx: KeplerContext) {
-  return Object.values(getKeplerCommands(ctx)).filter(c => !DUCKDB_REQUIRED.has(c.id));
-}
-
-function toDescriptor(cmd: {id: string; name: string; description?: string; group?: string; keywords?: string[]; metadata?: {readOnly?: boolean; idempotent?: boolean; riskLevel?: string; requiresConfirmation?: boolean}; inputSchema?: any}): ToolDescriptor {
-  let inputSchema: Record<string, unknown> = {type: 'object'};
-  if (cmd.inputSchema) {
-    try {
-      // zod v4 -> JSON Schema
-      const zod: any = require('zod');
-      inputSchema = (zod.toJSONSchema?.(cmd.inputSchema) ?? {type: 'object'}) as Record<string, unknown>;
-    } catch {
-      inputSchema = {type: 'object'};
-    }
-  }
-  return {
-    id: cmd.id,
-    name: cmd.name,
-    description: cmd.description,
-    group: cmd.group,
-    keywords: cmd.keywords,
-    inputSchema,
-    metadata: cmd.metadata as ToolDescriptor['metadata']
-  };
-}
-
-function formatResult(result: RoomCommandResult): string {
-  if (result.error) return `✗ ${result.commandId}: ${result.error}`;
-  const data = result.data as {details?: string} | undefined;
-  return data?.details ? `✓ ${data.details}` : `✓ ${result.commandId} ok`;
 }
 
 type McpBridgeProps = {

--- a/examples/demo-app/src/kepler-mcp-bridge.tsx
+++ b/examples/demo-app/src/kepler-mcp-bridge.tsx
@@ -31,11 +31,18 @@ function getUrlConfig(): {token: string; port: number; host: string} {
   return {token, port, host};
 }
 
-type McpBridgeProps = {
-  reduxStore: any;
+export type BridgeStatusInfo = {
+  status: BridgeStatus;
+  error: string | null;
+  connected: boolean;
 };
 
-export function KeplerMcpBridge({reduxStore}: McpBridgeProps) {
+type McpBridgeProps = {
+  reduxStore: any;
+  onStatus?: (info: BridgeStatusInfo) => void;
+};
+
+export function KeplerMcpBridge({reduxStore, onStatus}: McpBridgeProps) {
   const [token, setToken] = useState(getUrlConfig().token);
   const [port, setPort] = useState(getUrlConfig().port);
   const [status, setStatus] = useState<BridgeStatus>('idle');
@@ -127,27 +134,19 @@ export function KeplerMcpBridge({reduxStore}: McpBridgeProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Report status up so a parent can render a unified summary chip.
+  useEffect(() => {
+    onStatus?.({status, error, connected: status === 'connected'});
+  }, [status, error, onStatus]);
+
   const connected = status === 'connected';
-  const chip = (connected ? '#2e7cf6' : status === 'error' ? '#d64545' : '#555') as const;
+  const dot = connected ? '#8ff29a' : status === 'connecting' ? '#ffe27a' : '#fff';
 
   return (
-    <div style={{position: 'fixed', left: 12, bottom: 12, zIndex: 9999, fontFamily: 'monospace', fontSize: 11}}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          background: chip,
-          color: '#fff',
-          borderRadius: 999,
-          padding: '4px 10px',
-          boxShadow: '0 2px 8px rgba(0,0,0,.35)'
-        }}
-      >
-        <span style={{width: 8, height: 8, borderRadius: 8, background: status === 'connected' ? '#8ff29a' : status === 'connecting' ? '#ffe27a' : '#fff', flex: 'none'}} />
-        <span>
-          map harness · {status}
-        </span>
+    <div style={{display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start'}}>
+      <div style={{display: 'flex', alignItems: 'center', gap: 8, color: '#fff'}}>
+        <span style={{width: 8, height: 8, borderRadius: 8, background: dot, flex: 'none'}} />
+        <span>map harness · {status}</span>
         {connected ? (
           <button onClick={disconnect} style={btnStyle}>disconnect</button>
         ) : (
@@ -169,16 +168,7 @@ export function KeplerMcpBridge({reduxStore}: McpBridgeProps) {
         )}
       </div>
       {(error || log.length > 0) && (
-        <div
-          style={{
-            marginTop: 4,
-            background: 'rgba(0,0,0,.85)',
-            color: '#ddd',
-            borderRadius: 6,
-            padding: '4px 8px',
-            maxWidth: 420
-          }}
-        >
+        <div style={{color: '#ddd', maxWidth: 420}}>
           {error && <div style={{color: '#ff9e9e'}}>{error}</div>}
           {log.slice(-4).map((line, i) => (
             <div key={i} style={{whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'}}>

--- a/examples/demo-app/src/kepler-mcp-shared.ts
+++ b/examples/demo-app/src/kepler-mcp-shared.ts
@@ -14,11 +14,27 @@
 import {getKeplerCommands, getValuesFromDataset} from '@kepler.gl/mcp';
 import type {KeplerContext, RoomCommandResult, ToolDescriptor} from '@kepler.gl/mcp';
 import {WebMercatorViewport} from '@deck.gl/core';
+import mapSkillMarkdown from '../../../src/mcp/skill/kepler/SKILL.md';
 
 // map.* commands that need a DuckDB connector / the kepler-app glue
 // (`loadTableToKepler`, `loadTableIntoDuckDB`, `getConnector`). The demo
 // surfaces (mapping-only bridge / webMCP) do not serve them.
 export const DUCKDB_REQUIRED = new Set(['map.create-table', 'map.add-column', 'map.save-data']);
+
+// Mutating map.* commands every agent will reach for without reading the
+// skill. Each gets a pointer to kepler.get-map-skill prepended to its
+// description so the reader tool is impossible to miss.
+const SKILL_REQUIRED = new Set([
+  'map.add-layer',
+  'map.update-layer-color',
+  'map.add-time-filter',
+  'map.toggle-time-filter',
+  'map.split-view',
+  'map.load-data',
+  'map.set-basemap'
+]);
+
+const SKILL_HINT = `\nREAD THE MAP SKILL FIRST: call kepler.get-map-skill before using this command — it explains layer-type selection, color rules, and the workflow.`;
 
 /** Live accessors into the demo's own redux store — no kepler-assistant needed. */
 export function buildKeplerContext(reduxStore: any): KeplerContext {
@@ -97,9 +113,42 @@ export function buildKeplerContext(reduxStore: any): KeplerContext {
   };
 }
 
-/** The DuckDB-free map.* commands this page serves to agents. */
+/** The DuckDB-free map.* commands this page serves to agents, plus the map skill reader. */
 export function buildCatalog(ctx: KeplerContext) {
-  return Object.values(getKeplerCommands(ctx)).filter(c => !DUCKDB_REQUIRED.has(c.id));
+  const commands = Object.values(getKeplerCommands(ctx)).filter(c => !DUCKDB_REQUIRED.has(c.id));
+  return [getMapSkillCommand(), ...commands.map(c => withSkillHint(c))];
+}
+
+/**
+ * Read-only tool that serves the kepler.gl map-management skill verbatim. First
+ * in the catalog so it is the first tool any surface advertises; every mutating
+ * command's description also points at it (see `withSkillHint`).
+ */
+function getMapSkillCommand() {
+  return {
+    id: 'kepler.get-map-skill',
+    name: 'Read map skill',
+    group: 'Map',
+    description: `READ THE MAP SKILL FIRST — the kepler.gl map-management skill, served verbatim from src/mcp/skill/kepler/SKILL.md.
+
+Call this command BEFORE any other map command. It explains how to choose a layer type (point, arc, line, grid, hexagon, cluster, heatmap, geojson, h3, trip, s2, flow), how to color layers (case-sensitive colorBy, breaks vs unique colorMaps), time animation, split view, and the complete add-layer workflow with JSON examples.
+
+When the user asks for a flow map, "OD flows", "a map of movements" → this skill maps that to layerType "flow" (use "arc" only for straight great-circle lines between un-clustered points).`,
+    keywords: ['skill', 'map', 'workflow', 'guide', 'read-me-first'],
+    metadata: {readOnly: true, idempotent: true, riskLevel: 'low'},
+    execute: async () => ({
+      success: true,
+      commandId: 'kepler.get-map-skill',
+      data: {details: mapSkillMarkdown}
+    })
+  };
+}
+
+function withSkillHint(cmd: ReturnType<typeof getKeplerCommands>[string]) {
+  if (SKILL_REQUIRED.has(cmd.id) && cmd.description) {
+    return {...cmd, description: `${cmd.description}${SKILL_HINT}`};
+  }
+  return cmd;
 }
 
 export function toDescriptor(cmd: {id: string; name: string; description?: string; group?: string; keywords?: string[]; metadata?: {readOnly?: boolean; idempotent?: boolean; riskLevel?: string; requiresConfirmation?: boolean}; inputSchema?: any}): ToolDescriptor {

--- a/examples/demo-app/src/kepler-mcp-shared.ts
+++ b/examples/demo-app/src/kepler-mcp-shared.ts
@@ -1,0 +1,131 @@
+/**
+ * Shared plumbing for the demo-app's two agent surfaces over the
+ * `@kepler.gl/mcp` map.* commands:
+ *
+ *  - `kepler-mcp-bridge.tsx` — WebSocket reverse-connect to a local MCP server
+ *    (Claude Code / Codex driving the map without a browser extension)
+ *  - `kepler-webmcp.tsx` — native WebMCP registration (`document.modelContext`)
+ *    for harnesses with a built-in browser (Chrome's agent, Claude Desktop's
+ *    browser, ...)
+ *
+ * Both surfaces execute commands against the demo's own redux store through
+ * the same `buildKeplerContext` and serve the same DuckDB-free catalog.
+ */
+import {getKeplerCommands, getValuesFromDataset} from '@kepler.gl/mcp';
+import type {KeplerContext, RoomCommandResult, ToolDescriptor} from '@kepler.gl/mcp';
+import {WebMercatorViewport} from '@deck.gl/core';
+
+// map.* commands that need a DuckDB connector / the kepler-app glue
+// (`loadTableToKepler`, `loadTableIntoDuckDB`, `getConnector`). The demo
+// surfaces (mapping-only bridge / webMCP) do not serve them.
+export const DUCKDB_REQUIRED = new Set(['map.create-table', 'map.add-column', 'map.save-data']);
+
+/** Live accessors into the demo's own redux store — no kepler-assistant needed. */
+export function buildKeplerContext(reduxStore: any): KeplerContext {
+  const readMap = () => reduxStore?.getState()?.demo?.keplerGl?.map;
+  return {
+    getVisState: () => readMap()?.visState,
+    getMapBoundary: () => {
+      // Recompute the current viewport corners from the live mapState (same
+      // WebMercatorViewport math the app's onViewStateChange uses). Fall back
+      // to the assistant slice's stored boundary if mapState lacks a size.
+      const mapState = readMap()?.mapState;
+      if (mapState?.width && mapState?.height) {
+        try {
+          const viewport = new WebMercatorViewport(mapState);
+          const nw = viewport.unproject([0, 0]);
+          const se = viewport.unproject([viewport.width, viewport.height]);
+          return {nw: [nw[0], nw[1]], se: [se[0], se[1]]};
+        } catch {
+          /* fall through to stored boundary */
+        }
+      }
+      return reduxStore?.getState()?.demo?.aiAssistant?.keplerGl?.mapBoundary;
+    },
+    getMapboxToken: () =>
+      typeof window !== 'undefined' ? (localStorage.getItem('mapbox-token') ?? undefined) : undefined,
+    dispatch: (action: any) => reduxStore?.dispatch(action),
+    getValuesFromDataset: (datasetName, variableName) => {
+      const visState = readMap()?.visState;
+      if (!visState) return [];
+      return getValuesFromDataset(visState.datasets, visState.layers, datasetName, variableName);
+    },
+    getDatasetContext: () => {
+      // Shape required by map.get-dataset-context: a human line, then a JSON
+      // array of {datasetName, datasetId, fields, layers} descriptors.
+      const visState = readMap()?.visState;
+      const datasets = visState?.datasets;
+      const layers = visState?.layers ?? [];
+      if (!datasets) return '';
+      const context =
+        'Please remember the following datasets and layers for answering the user question:';
+      const dataMeta = Object.values(datasets).map((ds: any) => ({
+        datasetName: ds?.label ?? ds?.id,
+        datasetId: ds?.id,
+        fields: (ds?.fields ?? []).map((f: any) => ({[f.name]: f.type})),
+        layers: layers
+          .filter((layer: any) => layer?.config?.dataId === ds?.id)
+          .map((layer: any) => ({
+            id: layer.id,
+            label: layer.config.label,
+            type: layer.type,
+            geometryMode: layer.config.columnMode,
+            geometryColumns: Object.fromEntries(
+              Object.entries(layer.config.columns)
+                .filter(([, value]) => value !== null)
+                .map(([key, value]) => [
+                  key,
+                  typeof value === 'object' && value !== null
+                    ? Object.fromEntries(Object.entries(value).filter(([, v]) => v !== null))
+                    : value
+                ])
+            )
+          }))
+      }));
+      return `${context}\n${JSON.stringify(dataMeta)}`;
+    },
+    loadTableToKepler: async () => ({
+      success: false,
+      error: 'map.save-data / loadTableToKepler is not available in the mapping-only bridge.'
+    }),
+    loadTableIntoDuckDB: async () => {
+      throw new Error('DuckDB operations are not available in the mapping-only bridge.');
+    },
+    getConnector: async () => {
+      throw new Error('DuckDB operations are not available in the mapping-only bridge.');
+    }
+  };
+}
+
+/** The DuckDB-free map.* commands this page serves to agents. */
+export function buildCatalog(ctx: KeplerContext) {
+  return Object.values(getKeplerCommands(ctx)).filter(c => !DUCKDB_REQUIRED.has(c.id));
+}
+
+export function toDescriptor(cmd: {id: string; name: string; description?: string; group?: string; keywords?: string[]; metadata?: {readOnly?: boolean; idempotent?: boolean; riskLevel?: string; requiresConfirmation?: boolean}; inputSchema?: any}): ToolDescriptor {
+  let inputSchema: Record<string, unknown> = {type: 'object'};
+  if (cmd.inputSchema) {
+    try {
+      // zod v4 -> JSON Schema
+      const zod: any = require('zod');
+      inputSchema = (zod.toJSONSchema?.(cmd.inputSchema) ?? {type: 'object'}) as Record<string, unknown>;
+    } catch {
+      inputSchema = {type: 'object'};
+    }
+  }
+  return {
+    id: cmd.id,
+    name: cmd.name,
+    description: cmd.description,
+    group: cmd.group,
+    keywords: cmd.keywords,
+    inputSchema,
+    metadata: cmd.metadata as ToolDescriptor['metadata']
+  };
+}
+
+export function formatResult(result: RoomCommandResult): string {
+  if (result.error) return `✗ ${result.commandId}: ${result.error}`;
+  const data = result.data as {details?: string} | undefined;
+  return data?.details ? `✓ ${data.details}` : `✓ ${result.commandId} ok`;
+}

--- a/examples/demo-app/src/kepler-transport-status.tsx
+++ b/examples/demo-app/src/kepler-transport-status.tsx
@@ -1,0 +1,119 @@
+/**
+ * kepler-transport-status — one status box for every way the map surface is
+ * exposed to an agent.
+ *
+ * Collapsed it is a single chip summarizing both transports (webMCP + the
+ * WebSocket harness bridge); hovering expands a panel with per-transport
+ * status and controls. The panel is part of the hover target, so moving from
+ * the chip into the panel keeps it open.
+ */
+import React, {useCallback, useRef, useState} from 'react';
+import {KeplerWebMcp, type WebMcpStatusInfo} from './kepler-webmcp';
+import {KeplerMcpBridge, type BridgeStatusInfo} from './kepler-mcp-bridge';
+
+type Props = {
+  reduxStore: any;
+};
+
+function webmcpLabel(info: WebMcpStatusInfo | null): string {
+  if (!info) return '…';
+  if (!info.available) return 'unavailable';
+  if (!info.enabled) return 'off';
+  if (info.status === 'registered') return String(info.toolCount);
+  return info.status;
+}
+
+function bridgeLabel(info: BridgeStatusInfo | null): string {
+  return info ? info.status : 'idle';
+}
+
+/** Worst state across both transports drives the chip color. */
+function overall(
+  webmcp: WebMcpStatusInfo | null,
+  bridge: BridgeStatusInfo | null
+): {color: string; dot: string} {
+  const states: string[] = [];
+  if (webmcp?.available && webmcp.enabled) states.push(webmcp.status);
+  if (bridge) states.push(bridge.status);
+  if (states.includes('error')) return {color: '#d64545', dot: '#fff'};
+  if (states.includes('registering') || states.includes('connecting'))
+    return {color: '#b58900', dot: '#ffe27a'};
+  if (states.includes('registered') || states.includes('connected'))
+    return {color: '#2e7cf6', dot: '#8ff29a'};
+  return {color: '#555', dot: '#fff'};
+}
+
+export function KeplerTransportStatus({reduxStore}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const [webmcp, setWebmcp] = useState<WebMcpStatusInfo | null>(null);
+  const [bridge, setBridge] = useState<BridgeStatusInfo | null>(null);
+  const closeTimer = useRef<number | null>(null);
+
+  const open = useCallback(() => {
+    if (closeTimer.current !== null) {
+      window.clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setExpanded(true);
+  }, []);
+
+  const scheduleClose = useCallback(() => {
+    if (closeTimer.current !== null) window.clearTimeout(closeTimer.current);
+    closeTimer.current = window.setTimeout(() => setExpanded(false), 150);
+  }, []);
+
+  const o = overall(webmcp, bridge);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        left: 12,
+        bottom: 12,
+        zIndex: 9999,
+        fontFamily: 'monospace',
+        fontSize: 11,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 4,
+        alignItems: 'flex-start'
+      }}
+      onMouseEnter={open}
+      onMouseLeave={scheduleClose}
+    >
+      <div
+        style={{
+          background: 'rgba(0,0,0,.92)',
+          borderRadius: 8,
+          padding: '8px 10px',
+          maxWidth: 440,
+          boxShadow: '0 4px 16px rgba(0,0,0,.4)',
+          display: expanded ? 'flex' : 'none',
+          flexDirection: 'column',
+          gap: 8
+        }}
+      >
+        <KeplerWebMcp reduxStore={reduxStore} onStatus={setWebmcp} />
+        <div style={{height: 1, background: 'rgba(255,255,255,.15)'}} />
+        <KeplerMcpBridge reduxStore={reduxStore} onStatus={setBridge} />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          background: o.color,
+          color: '#fff',
+          borderRadius: 999,
+          padding: '4px 10px',
+          boxShadow: '0 2px 8px rgba(0,0,0,.35)'
+        }}
+      >
+        <span style={{width: 8, height: 8, borderRadius: 8, background: o.dot, flex: 'none'}} />
+        <span>
+          map surface · webMCP {webmcpLabel(webmcp)} · harness {bridgeLabel(bridge)}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/examples/demo-app/src/kepler-webmcp.tsx
+++ b/examples/demo-app/src/kepler-webmcp.tsx
@@ -60,13 +60,22 @@ function webMcpName(commandId: string): string {
 
 type WebMcpStatus = 'idle' | 'registering' | 'registered' | 'error';
 
+export type WebMcpStatusInfo = {
+  available: boolean;
+  status: WebMcpStatus;
+  toolCount: number;
+  error: string | null;
+  enabled: boolean;
+};
+
 type McpWebMcpProps = {
   reduxStore: any;
+  onStatus?: (info: WebMcpStatusInfo) => void;
 };
 
 const ENABLED_KEY = 'kepler-webmcp-enabled';
 
-export function KeplerWebMcp({reduxStore}: McpWebMcpProps) {
+export function KeplerWebMcp({reduxStore, onStatus}: McpWebMcpProps) {
   const modelContext = useMemo(getModelContext, []);
   const [enabled, setEnabled] = useState(
     () => (typeof window === 'undefined' ? true : window.localStorage.getItem(ENABLED_KEY) !== 'false')
@@ -179,66 +188,43 @@ export function KeplerWebMcp({reduxStore}: McpWebMcpProps) {
     []
   );
 
-  if (!modelContext) {
-    // Feature detection failed — render nothing rather than a permanent dead chip.
-    return null;
-  }
+  // Report status up so a parent can render a unified summary chip.
+  useEffect(() => {
+    onStatus?.({available: !!modelContext, status, toolCount, error, enabled});
+  }, [modelContext, status, toolCount, error, enabled, onStatus]);
 
-  const chip =
-    status === 'registered' ? '#2e7cf6' : status === 'error' ? '#d64545' : status === 'registering' ? '#b58900' : '#555';
+  const available = !!modelContext;
+  const label = !available
+    ? 'API unavailable'
+    : !enabled
+      ? 'off'
+      : status === 'registered'
+        ? `${toolCount} map tools registered`
+        : status;
+  const dot =
+    !available || status === 'idle' || status === 'error'
+      ? '#fff'
+      : status === 'registered'
+        ? '#8ff29a'
+        : '#ffe27a';
 
   return (
-    <div style={{position: 'fixed', left: 12, bottom: 44, zIndex: 9999, fontFamily: 'monospace', fontSize: 11}}>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          background: chip,
-          color: '#fff',
-          borderRadius: 999,
-          padding: '4px 10px',
-          boxShadow: '0 2px 8px rgba(0,0,0,.35)'
-        }}
-      >
-        <span
-          style={{
-            width: 8,
-            height: 8,
-            borderRadius: 8,
-            background:
-              status === 'registered' ? '#8ff29a' : status === 'registering' ? '#ffe27a' : '#fff',
-            flex: 'none'
-          }}
-        />
-        <span>
-          webMCP ·{' '}
-          {status === 'registered' ? `${toolCount} map tools registered` : status}
-        </span>
-        {enabled ? (
-          <button onClick={() => setPersistedEnabled(false)} style={btnStyle}>
-            disable
-          </button>
-        ) : (
-          <button onClick={() => setPersistedEnabled(true)} style={btnStyle}>
-            enable
-          </button>
-        )}
+    <div style={{display: 'flex', flexDirection: 'column', gap: 4, alignItems: 'flex-start'}}>
+      <div style={{display: 'flex', alignItems: 'center', gap: 8, color: '#fff'}}>
+        <span style={{width: 8, height: 8, borderRadius: 8, background: dot, flex: 'none'}} />
+        <span>webMCP · {label}</span>
+        {available &&
+          (enabled ? (
+            <button onClick={() => setPersistedEnabled(false)} style={btnStyle}>
+              disable
+            </button>
+          ) : (
+            <button onClick={() => setPersistedEnabled(true)} style={btnStyle}>
+              enable
+            </button>
+          ))}
       </div>
-      {error && (
-        <div
-          style={{
-            marginTop: 4,
-            background: 'rgba(0,0,0,.85)',
-            color: '#ff9e9e',
-            borderRadius: 6,
-            padding: '4px 8px',
-            maxWidth: 420
-          }}
-        >
-          {error}
-        </div>
-      )}
+      {error && <div style={{color: '#ff9e9e', maxWidth: 420}}>{error}</div>}
     </div>
   );
 }

--- a/examples/demo-app/src/kepler-webmcp.tsx
+++ b/examples/demo-app/src/kepler-webmcp.tsx
@@ -1,0 +1,254 @@
+/**
+ * kepler-webmcp — exposes the same `@kepler.gl/mcp` map.* surface through the
+ * browser's native WebMCP API so harnesses with a built-in browser (Chrome's
+ * agent, Claude Desktop's browser, Codex, ...) can discover and call the tools
+ * directly — no WebSocket bridge or local helper process needed.
+ *
+ * WebMCP is a W3C Web Machine Learning CG draft: the page registers tools
+ * (`registerTool`) on an in-page model context and the embedded agent invokes
+ * them over the JS heap (webmachinelearning/webmcp). This surface registers
+ * the identical DuckDB-free command catalog as `kepler-mcp-bridge.tsx`, so any
+ * caller gets the same tools either way — the transport is the only
+ * difference.
+ *
+ * Feature detection: the interface has shifted between drafts — current spec
+ * puts `modelContext` on `document`, earlier Chromium builds on `navigator`
+ * (deprecated in Chromium 150). Native support: Chrome 149+ origin trial, or
+ * `chrome://flags/#enable-webmcp-testing`. When neither exists this component
+ * is inert (hidden chip).
+ */
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {buildCatalog, buildKeplerContext, formatResult, toDescriptor} from './kepler-mcp-shared';
+
+/**
+ * Minimal structural type for the WebMCP ModelContext (spec: ModelContext on
+ * Document, `registerTool(tool, options?) -> Promise<undefined>`). Kept
+ * structural because TypeScript DOM libs don't ship WebMCP yet — see the
+ * `webmcp-types` npm package for the full surface.
+ */
+type WebMcpTool = {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (input: any, options?: {signal?: AbortSignal}) => Promise<any>;
+  annotations?: {readOnlyHint?: boolean; untrustedContentHint?: boolean};
+};
+
+type ModelContextLike = {
+  registerTool: (tool: WebMcpTool, options?: {signal?: AbortSignal}) => Promise<void> | void;
+};
+
+/** `document.modelContext` (current spec) with the pre-150 `navigator.modelContext` fallback. */
+function getModelContext(): ModelContextLike | null {
+  const win = typeof window === 'undefined' ? null : window;
+  if (!win) return null;
+  const doc = win.document as any;
+  return (doc?.modelContext ?? (win.navigator as any)?.modelContext ?? null) as ModelContextLike;
+}
+
+/**
+ * WebMCP tool names allow `A-Za-z0-9._-`, but MCP-tool naming in agent
+ * harnesses is commonly restricted to `[A-Za-z0-9_-]`, so dots (as in
+ * `map.load-data`) are folded to underscores for the registered name. The
+ * original command id is kept in the description so callers can still map
+ * results back to `RoomCommandResult.commandId`.
+ */
+function webMcpName(commandId: string): string {
+  return commandId.replace(/\./g, '_');
+}
+
+type WebMcpStatus = 'idle' | 'registering' | 'registered' | 'error';
+
+type McpWebMcpProps = {
+  reduxStore: any;
+};
+
+const ENABLED_KEY = 'kepler-webmcp-enabled';
+
+export function KeplerWebMcp({reduxStore}: McpWebMcpProps) {
+  const modelContext = useMemo(getModelContext, []);
+  const [enabled, setEnabled] = useState(
+    () => (typeof window === 'undefined' ? true : window.localStorage.getItem(ENABLED_KEY) !== 'false')
+  );
+  const [status, setStatus] = useState<WebMcpStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [toolCount, setToolCount] = useState(0);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const ctx = useMemo(() => buildKeplerContext(reduxStore), [reduxStore]);
+  const catalog = useMemo(() => buildCatalog(ctx), [ctx]);
+
+  const setPersistedEnabled = useCallback((value: boolean) => {
+    setEnabled(value);
+    try {
+      window.localStorage.setItem(ENABLED_KEY, String(value));
+    } catch {
+      /* private mode etc. — keep the in-memory toggle */
+    }
+  }, []);
+
+  useEffect(() => {
+    controllerRef.current?.abort();
+    controllerRef.current = null;
+    setStatus('idle');
+    setError(null);
+    setToolCount(0);
+
+    if (!modelContext || !catalog.length) return;
+    if (!enabled) return;
+
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setStatus('registering');
+
+    let cancelled = false; // effect re-run / unmount while registrations are in flight
+
+    (async () => {
+      const results = await Promise.allSettled(
+        catalog.map(async cmd => {
+          const desc = toDescriptor(cmd);
+          const tool: WebMcpTool = {
+            // fold dots to underscores — see webMcpName above
+            name: webMcpName(cmd.id),
+            title: cmd.name,
+            description:
+              cmd.id === webMcpName(cmd.id)
+                ? cmd.description
+                : `${cmd.description ?? cmd.name} (command id: ${cmd.id})`,
+            inputSchema: desc.inputSchema,
+            annotations: {readOnlyHint: cmd.metadata?.readOnly === true},
+            // The agent's transport JSON-serializes the return value, and a
+            // rejected execute only surfaces as an opaque UnknownError — so
+            // errors are returned as text, never thrown.
+            execute: async input => {
+              try {
+                const result = await cmd.execute(
+                  {store: undefined, getState: () => undefined, invocation: {surface: 'webmcp'}} as any,
+                  input ?? {}
+                );
+                return formatResult(result as any);
+              } catch (err) {
+                return `✗ ${cmd.id}: ${err instanceof Error ? err.message : String(err)}`;
+              }
+            }
+          };
+          // Chrome 153+ accepts `{signal}` for unregistration; older drafts
+          // take only the tool. Fall back to the single-argument form.
+          try {
+            await modelContext.registerTool(tool, {signal: controller.signal});
+          } catch (err) {
+            if (controller.signal.aborted || cancelled) return;
+            await modelContext.registerTool(tool);
+          }
+        })
+      );
+
+      if (cancelled || controller.signal.aborted) return;
+      const rejected = results.filter(r => r.status === 'rejected');
+      if (rejected.length === results.length) {
+        setStatus('error');
+        setError(
+          `registerTool rejected every command (${rejected.length}). Is WebMCP enabled for this page?`
+        );
+        return;
+      }
+      setStatus('registered');
+      setToolCount(results.length - rejected.length);
+      if (rejected.length) {
+        setError(
+          `${rejected.length} of ${results.length} commands failed registration: ${rejected
+            .map(r => (r as PromiseRejectedResult).reason?.message ?? String((r as PromiseRejectedResult).reason))
+            .join('; ')}`
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [catalog, enabled, modelContext]);
+
+  // Cleanup: aborting the controller unregisters the tools (Chrome 153+;
+  // harmless where the signal option was ignored).
+  useEffect(
+    () => () => {
+      controllerRef.current?.abort();
+      controllerRef.current = null;
+    },
+    []
+  );
+
+  if (!modelContext) {
+    // Feature detection failed — render nothing rather than a permanent dead chip.
+    return null;
+  }
+
+  const chip =
+    status === 'registered' ? '#2e7cf6' : status === 'error' ? '#d64545' : status === 'registering' ? '#b58900' : '#555';
+
+  return (
+    <div style={{position: 'fixed', left: 12, bottom: 44, zIndex: 9999, fontFamily: 'monospace', fontSize: 11}}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          background: chip,
+          color: '#fff',
+          borderRadius: 999,
+          padding: '4px 10px',
+          boxShadow: '0 2px 8px rgba(0,0,0,.35)'
+        }}
+      >
+        <span
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 8,
+            background:
+              status === 'registered' ? '#8ff29a' : status === 'registering' ? '#ffe27a' : '#fff',
+            flex: 'none'
+          }}
+        />
+        <span>
+          webMCP ·{' '}
+          {status === 'registered' ? `${toolCount} map tools registered` : status}
+        </span>
+        {enabled ? (
+          <button onClick={() => setPersistedEnabled(false)} style={btnStyle}>
+            disable
+          </button>
+        ) : (
+          <button onClick={() => setPersistedEnabled(true)} style={btnStyle}>
+            enable
+          </button>
+        )}
+      </div>
+      {error && (
+        <div
+          style={{
+            marginTop: 4,
+            background: 'rgba(0,0,0,.85)',
+            color: '#ff9e9e',
+            borderRadius: 6,
+            padding: '4px 8px',
+            maxWidth: 420
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const btnStyle: React.CSSProperties = {
+  background: 'rgba(255,255,255,.2)',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 4,
+  padding: '2px 8px',
+  cursor: 'pointer',
+  fontSize: 11
+};

--- a/examples/demo-app/src/md.d.ts
+++ b/examples/demo-app/src/md.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Ambient declarations for non-code assets the demo-app esbuild bundles.
+ * `kepler-mcp-shared.ts` imports the map-management skill markdown as text
+ * (esbuild `loader: {'.md': 'text'}`); this keeps editors / tsc quiet.
+ */
+declare module '*.md' {
+  const content: string;
+  export default content;
+}

--- a/src/mcp/skill/kepler/SKILL.md
+++ b/src/mcp/skill/kepler/SKILL.md
@@ -32,7 +32,7 @@ not this one.
 
 | command                  | purpose                                                        |
 | ------------------------ | -------------------------------------------------------------- |
-| `map.add-layer`          | Add a layer (point, h3, arc, trip, hexagon, grid, cluster, heatmap, geojson, line, s2) to the map. |
+| `map.add-layer`          | Add a layer (point, flow, h3, arc, trip, hexagon, grid, cluster, heatmap, geojson, line, s2) to the map. |
 | `map.add-time-filter`    | Animate a NON-trip layer over a TIMESTAMP/DATE column.         |
 | `map.toggle-time-filter` | Show/hide the enlarged time controller at the bottom of the map. |
 | `map.split-view`         | Enable/disable dual-map comparison.                            |
@@ -57,7 +57,8 @@ assistant the dispatcher is the `executeApi` tool with
   for continuous intensity).
 - Density without precomputed cells → `grid` or `hexagon` (auto-binned).
 - Pre-aggregated H3 cells → `h3`.
-- Origin→destination flows → `arc`.
+- Origin→destination flows → `flow` (a dedicated flow layer with locations, clustering and weighted edges; requires two point lat/lng pairs — source + destination). Fall back to `arc` only when you want straight great-circle lines between points. For weighted flows optionally pass the magnitude column as `countColumn`.
+
 - Polylines / polygons → `line` / `geojson`. A decoded GEOMETRY `geom`
   column can be rendered directly with `geojson` — do NOT convert it to
   lat/lon columns or build an intermediate table. For geojson datasets use

--- a/src/mcp/src/commands/layer-creation-command.spec.ts
+++ b/src/mcp/src/commands/layer-creation-command.spec.ts
@@ -1,0 +1,106 @@
+import {getAddLayerCommand} from './layer-creation-command';
+import KeplerTable from '@kepler.gl/table';
+import {ALL_FIELD_TYPES} from '@kepler.gl/constants';
+
+/**
+ * Build a plain JS dataset with two point lat/lng pairs (origin + destination)
+ * plus a numeric flow-magnitude column — the shape the flow layer branch of
+ * guessDefaultLayer consumes. `findPointFieldPairs` keys off `_lat`/`_lng`
+ * suffixes, so origin_lat/origin_lng and dest_lat/dest_lng pair up.
+ */
+async function makeTwoPairTable() {
+  const table = new KeplerTable({color: [255, 0, 0]} as any);
+  await table.importData({
+    data: {
+      rows: [
+        // origin_lat, origin_lng, dest_lat, dest_lng, count
+        [37.77, -122.42, 37.79, -122.41, 5],
+        [37.78, -122.45, 37.76, -122.4, 12],
+        [37.74, -122.44, 37.8, -122.39, 3]
+      ],
+      fields: [
+        {name: 'origin_lat', type: ALL_FIELD_TYPES.real},
+        {name: 'origin_lng', type: ALL_FIELD_TYPES.real},
+        {name: 'dest_lat', type: ALL_FIELD_TYPES.real},
+        {name: 'dest_lng', type: ALL_FIELD_TYPES.real},
+        {name: 'count', type: ALL_FIELD_TYPES.integer}
+      ]
+    } as any
+  });
+  return table;
+}
+
+function makeCtx(table: KeplerTable) {
+  let dispatched: any = null;
+  const ctx = {
+    getVisState: () => ({datasets: {[table.id as string]: table}, layers: []}),
+    dispatch: (action: any) => {
+      dispatched = action;
+    },
+    getValuesFromDataset: () => [],
+    getMapBoundary: () => null,
+    getMapboxToken: () => undefined,
+    getDatasetContext: () => ''
+  };
+  return {ctx, getDispatched: () => dispatched};
+}
+
+type CommandResult = {success: boolean; error?: string; data?: Record<string, unknown>};
+
+describe('map.add-layer (flow)', () => {
+  it('builds a flow layer from the first two point field pairs, with weighted count', async () => {
+    const table = await makeTwoPairTable();
+    const {ctx, getDispatched} = makeCtx(table);
+
+    const cmd = getAddLayerCommand(ctx as any);
+    const result = (await cmd.execute({} as any, {
+      datasetName: table.label,
+      layerType: 'flow',
+      layerName: 'Trips flow',
+      countColumn: 'count'
+    })) as CommandResult;
+
+    expect(result.success).toBe(true);
+    const action = getDispatched();
+    expect(action).toBeTruthy();
+    expect(action.type).toMatch(/ADD_LAYER/);
+    expect(action.config.type).toBe('flow');
+    expect(action.config.config.label).toBe('Trips flow');
+    // buildLayerConfig flattens the column refs to column names. Optional
+    // columns the flow layer initializes empty (sourceName/targetName/targetH3)
+    // arrive as `null` — the reducer's validateLayersByDatasets runs with
+    // allowEmptyColumn, so subset-match on the meaningful ones.
+    expect(action.config.config.columns).toMatchObject({
+      lat0: 'origin_lat',
+      lng0: 'origin_lng',
+      lat1: 'dest_lat',
+      lng1: 'dest_lng',
+      count: 'count'
+    });
+    // count column must remain attached to the flow layer as the magnitude
+    expect(action.config.config.columns.count).toBe('count');
+  });
+
+  it('still builds a flow layer without a count column (all weights 1)', async () => {
+    const table = await makeTwoPairTable();
+    const {ctx, getDispatched} = makeCtx(table);
+
+    const cmd = getAddLayerCommand(ctx as any);
+    const result = (await cmd.execute({} as any, {
+      datasetName: table.label,
+      layerType: 'flow'
+    })) as CommandResult;
+
+    expect(result.success).toBe(true);
+    const action = getDispatched();
+    expect(action.config.type).toBe('flow');
+    expect(action.config.config.columns).toMatchObject({
+      lat0: 'origin_lat',
+      lng0: 'origin_lng',
+      lat1: 'dest_lat',
+      lng1: 'dest_lng'
+    });
+    // no count column → magnitude stays unset (null), so all flows weigh 1
+    expect(action.config.config.columns.count).toBeNull();
+  });
+});

--- a/src/mcp/src/commands/layer-creation-command.ts
+++ b/src/mcp/src/commands/layer-creation-command.ts
@@ -6,7 +6,11 @@ import {findDefaultLayer, findMapBounds} from '@kepler.gl/reducers';
 import {addLayer as addLayerAction, fitBounds} from '@kepler.gl/actions';
 import {KeplerContext} from './types';
 
-export function guessDefaultLayer(dataset: KeplerTable, layerType: string) {
+export function guessDefaultLayer(
+  dataset: KeplerTable,
+  layerType: string,
+  options?: {countColumn?: string}
+) {
   if (layerType === 'heatmap') {
     if (dataset.fieldPairs && dataset.fieldPairs.length > 0) {
       const props = dataset.fieldPairs.map(fieldPair => ({
@@ -44,6 +48,40 @@ export function guessDefaultLayer(dataset: KeplerTable, layerType: string) {
     throw new Error(
       `Failed to create a trip layer. Trip layer requires id, lat, lng, and timestamp columns.`
     );
+  } else if (layerType === 'flow') {
+    // Flow layers are never auto-detected (findDefaultLayerProps returns
+    // {props: []}), so build one explicitly from the first two point lat/lng
+    // field pairs — the same source/target pair logic the default arc layer
+    // uses: pair[0] = origin (lat0/lng0), pair[1] = destination (lat1/lng1).
+    // The count column (flow magnitude) is optional; without it every flow
+    // renders at weight 1.
+    const pairs = dataset.fieldPairs || [];
+    if (pairs.length < 2) {
+      throw new Error(
+        `Failed to create a flow layer. Flow layer requires two point lat/lng pairs ` +
+          `(origin + destination), e.g. origin_lat/origin_lng and dest_lat/dest_lng.`
+      );
+    }
+    const columns: any = {
+      lat0: pairs[0].pair.lat,
+      lng0: pairs[0].pair.lng,
+      lat1: pairs[1].pair.lat,
+      lng1: pairs[1].pair.lng
+    };
+    if (options?.countColumn && dataset.getColumnFieldIdx(options.countColumn) >= 0) {
+      columns.count = {
+        value: options.countColumn,
+        fieldIdx: dataset.getColumnFieldIdx(options.countColumn)
+      };
+    }
+    // LayerClasses' computed keys (keyMirror) aren't statically named, so
+    // access flow like the trip branch accesses trip: through an `as any` cast.
+    const layer = new (LayerClasses as any).flow({
+      isVisible: true,
+      label: `${pairs[0].defaultName} -> ${pairs[1].defaultName} flow`,
+      columns
+    });
+    return layer;
   }
   const defaultLayers = findDefaultLayer(dataset, LayerClasses as any);
   const layer = defaultLayers.find(l => l.type === layerType);
@@ -175,6 +213,7 @@ IMPORTANT: generated layer names must be unique.
 
 LAYER TYPES:
 - point: Point markers (requires lat/lng columns)
+- flow: Origin->destination flow map (requires two point lat/lng pairs, auto-detected)
 - h3: H3 hexagon cells (requires hexId column)
 - geojson: Polygon/geometry features (uses geometry column, usually auto-detected)
 - hexagon: Hexagonal binning of points
@@ -184,6 +223,14 @@ LAYER TYPES:
 - grid: Grid binning
 - trip: Animated trip (flights, deliveries, vessels)
 - s2: S2 geometry cells
+
+FLOW MAPS (layerType 'flow'):
+For origin->destination flows use layerType 'flow' — a dedicated flow layer that draws
+locations and weighted flows between them. It needs TWO point lat/lng pairs in the
+dataset (source pair + destination pair), which are auto-detected. Prefer 'flow' over
+'arc' for O-D flows; 'arc' draws straight great-circle lines without location clustering
+or flow aggregation. To weight the flows by a value column (flow magnitude), pass
+countColumn with the column name — omit it to render all flows at weight 1.
 
 BASIC MAP:
 - Use datasetName, latitudeColumn/longitudeColumn (for point maps), and layerType
@@ -217,6 +264,7 @@ For geojson datasets:
         .describe('Generate a unique name for the layer based on the context.'),
       layerType: z.enum([
         'point',
+        'flow',
         'arc',
         'line',
         'grid',
@@ -236,6 +284,12 @@ For geojson datasets:
         ),
       colorBy: z.string().optional(),
       colorType: z.enum(['breaks', 'unique']).optional(),
+      countColumn: z
+        .string()
+        .optional()
+        .describe(
+          'For layerType "flow" (and only flow): a numeric column whose value weights each flow (flow magnitude). Omit to render all flows at weight 1.'
+        ),
       colorMap: z
         .array(
           z.object({
@@ -256,6 +310,7 @@ For geojson datasets:
         colorBy?: string;
         colorType?: 'breaks' | 'unique';
         colorMap?: Array<{value: string | number | null; color: string}>;
+        countColumn?: string;
       };
       const {
         datasetName,
@@ -266,7 +321,8 @@ For geojson datasets:
         simpleColor,
         colorBy,
         colorType,
-        colorMap
+        colorMap,
+        countColumn
       } = args;
       try {
         const visState = ctx.getVisState();
@@ -280,7 +336,7 @@ For geojson datasets:
         }
 
         const dataset = datasets[datasetId];
-        let layer = guessDefaultLayer(dataset, layerType);
+        let layer = guessDefaultLayer(dataset, layerType, {countColumn});
 
         if (!layer) {
           if (layerType === 'point' && latitudeColumn && longitudeColumn) {


### PR DESCRIPTION
The main focus is to provide a consistent, DuckDB-free set of map commands to both the WebSocket harness via MCP and the new WebMCP browser API, while improving both developer ergonomics and user experience for agent integrations.

Note: this branch is based on `xli-kepler-mcp` branch