### PR TITLE
feat: in-place row edits for Arrow tables and GeoJSON layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 ## Unreleased
 
 - feat: `addToDataset` / `removeFromDataset` to append, upsert, and delete rows in place without breaking layers (#176). Row tables and Arrow tables with primitive columns (concat); DuckDB still warns and no-ops until INSERT exists.
+- fix: GeoJSON layer rebuilds features when the table revision or row count changes, not on filter-only updates.
 
 ## [3.3.0-alpha.8] - Aug 26 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Ref: http://keepachangelog.com/en/0.3.0/
 
 ## Unreleased
 
-- feat: `addToDataset` / `removeFromDataset` to append, upsert, and delete rows in place without breaking layers (#176). Row tables only; Arrow/DuckDB warn and no-op until INSERT/concat exist.
+- feat: `addToDataset` / `removeFromDataset` to append, upsert, and delete rows in place without breaking layers (#176). Row tables and Arrow tables with primitive columns (concat); DuckDB still warns and no-ops until INSERT exists.
 
 ## [3.3.0-alpha.8] - Aug 26 2026
 

--- a/docs/api-reference/actions/actions.md
+++ b/docs/api-reference/actions/actions.md
@@ -528,9 +528,9 @@ Returns **{type: ActionTypes.ADD_LAYER, props: props}**
 
 ### addToDataset
 
-Append or upsert rows on an existing in-memory row dataset without `addDataToMap`. Keeps layer identity and style. Pass `options.upsertBy` to replace rows that share that key and append the rest.
+Append or upsert rows on an existing in-memory row or Arrow dataset without `addDataToMap`. Keeps layer identity and style. Pass `options.upsertBy` to replace rows that share that key and append the rest.
 
-Not implemented for Arrow or DuckDB tables (no INSERT / concat yet); those calls warn and leave the table unchanged. Use `addDataToMap` with `keepExistingConfig` for a full replace.
+DuckDB tables (no INSERT yet) warn and leave the table unchanged. Arrow tables concat primitive columns in place; nested, binary, and geoarrow columns are rejected. Use `addDataToMap` with `keepExistingConfig` for a full replace.
 
 - **ActionTypes**: `ActionTypes.ADD_TO_DATASET`
 - **Updaters**: `visStateUpdaters.addToDatasetUpdater`
@@ -744,9 +744,9 @@ Returns **{type: ActionTypes.REMOVE_DATASET, key: key}**
 
 ### removeFromDataset
 
-Delete rows from an existing in-memory row dataset without restyling layers. The second argument is either row indexes or `{field, values}` to match a column (for example an id).
+Delete rows from an existing in-memory row or Arrow dataset without restyling layers. The second argument is either row indexes or `{field, values}` to match a column (for example an id).
 
-Not implemented for Arrow or DuckDB tables; those calls warn and leave the table unchanged.
+DuckDB tables warn and leave the table unchanged. Arrow tables concat the kept slices in place.
 
 - **ActionTypes**: `ActionTypes.REMOVE_FROM_DATASET`
 - **Updaters**: `visStateUpdaters.removeFromDatasetUpdater`

--- a/docs/api-reference/reducers/vis-state.md
+++ b/docs/api-reference/reducers/vis-state.md
@@ -107,7 +107,7 @@ Returns **[Object][69]** nextState
 
 ### addToDatasetUpdater
 
-Append or upsert rows on an existing in-memory row dataset. Keeps layers and re-runs filters. Arrow/DuckDB tables warn and are left unchanged (INSERT / concat not implemented).
+Append or upsert rows on an existing in-memory row or Arrow dataset. Keeps layers and re-runs filters. DuckDB tables warn and are left unchanged (INSERT not implemented). Nested / geoarrow Arrow columns are rejected.
 
 -   **Action**: [`addToDataset`](../actions/actions.md#addtodataset)
 
@@ -338,7 +338,7 @@ Returns **[Object][69]** nextState
 
 ### removeFromDatasetUpdater
 
-Delete rows by index or by field values from an existing in-memory row dataset. Keeps layers. Arrow/DuckDB tables warn and are left unchanged.
+Delete rows by index or by field values from an existing in-memory row or Arrow dataset. Keeps layers. DuckDB tables warn and are left unchanged.
 
 -   **Action**: [`removeFromDataset`](../actions/actions.md#removefromdataset)
 

--- a/examples/live-data/README.md
+++ b/examples/live-data/README.md
@@ -13,9 +13,10 @@ update styles:
   (injected rows disappear).
 
 This bundles local monorepo `src/` (not a published npm package). Host-row
-edits only work for in-memory CSV (`RowDataContainer`), which this example
-uses. Arrow and DuckDB tables log a warning and leave the data unchanged
-(INSERT / concat are not implemented yet). The **Keyed by id** controls
+edits work for in-memory CSV (`RowDataContainer`) and Arrow tables with
+primitive columns. DuckDB tables log a warning and leave the data unchanged
+(INSERT is not implemented yet). Nested, binary, and geoarrow Arrow columns
+are also left unchanged. The **Keyed by id** controls
 exercise `addToDataset(id, rows, {upsertBy: 'id'})` and
 `removeFromDataset(id, {field: 'id', values})`.
 

--- a/examples/live-data/README.md
+++ b/examples/live-data/README.md
@@ -1,16 +1,21 @@
 # Live remotely hosted data
 
 Loads a CORS CSV of points orbiting San Francisco as a remotely hosted dataset
-and **polls it every 300 ms**. The right sidebar switches between two host-app
-update styles:
+and **polls it every 300 ms**. The right sidebar switches between host-app
+update styles. **CSV / Arrow / GeoJSON** each get their own Kepler instance
+(the map is remounted). Formats are not converted in place on the same dataset.
 
 - **Poll URL** — HTTP snapshot replace (`refreshDataset` /
   `metadata.refreshIntervalMs`) on `DatasetType.EXTERNALLY_HOSTED`. Positions
-  come from wall-clock time; one full loop takes **2 minutes**.
-- **Host rows** — pauses the poll, then the example dispatches `addToDataset` /
-  `removeFromDataset` so rows change in place without tearing down the point
-  layer. Switching back to Poll URL resumes fetching and **replaces** the table
-  (injected rows disappear).
+  come from wall-clock time; one full loop takes **2 minutes**. CSV only.
+- **Host rows** — pauses the poll (CSV) or starts a fresh in-memory table
+  (Arrow / GeoJSON), then dispatches `addToDataset` / `removeFromDataset` so
+  rows change in place without tearing down that instance's layer.
+- **CSV / Arrow / GeoJSON** — remounts Kepler with a matching table and layer.
+  Arrow is a primitive `ArrowDataContainer` (point layer). GeoJSON fetches
+  [buildings-australia.geojson](https://raw.githubusercontent.com/keplergl/kepler.gl-data/refs/heads/master/datasets/buildings-australia.geojson)
+  from GitHub at runtime (not bundled) onto a GeoJSON layer. Switching back to
+  CSV starts a new poll instance.
 
 This bundles local monorepo `src/` (not a published npm package). Host-row
 edits work for in-memory CSV (`RowDataContainer`) and Arrow tables with
@@ -50,16 +55,39 @@ run next to `yarn start` on 8080). The CSV server listens at
 
 ### Host rows
 
-- Orbit **freezes** (interval set to 0).
+- On the CSV poll instance, orbit **freezes** (interval set to 0). Arrow and
+  GeoJSON always start in Host rows with a new Kepler instance.
 - **Add 1 / Add 5** drop points on outer rings (4–6), same layer id.
 - **Remove last / Remove random** delete by row index.
 - **Keyed by id** — **Insert/Move tracker** upserts `track-01` (`upsertBy: 'id'`).
-  First click adds a ring-7 point; later clicks move that same row (ids list
-  and row count stay put). **Remove tracker** / **Remove veh-01** /
+  First click adds a ring-7 point; later clicks **replace** that same row (ids list
+  and row count stay put). On an Arrow table that concat-replaces one row. On
+  GeoJSON **Move tracker** swaps in another building footprint from the file.
+  **Remove tracker** / **Remove veh-01** /
   **Remove last host** delete with `{field: 'id', values}`.
 - **Auto trail** appends a point every 800ms and drops the oldest host row
   after 20 so the cloud stays bounded.
-- Switch back to Poll URL: next CSV fetch restores the 3 orbiting vehicles.
+- **Poll URL** remounts (or resumes) the CSV poll instance.
+
+### Arrow table
+
+- Click **Arrow**. Kepler remounts with a seed Arrow table and a point layer
+  (Host rows). Sidebar **table** should read `ArrowDataContainer`.
+- **Insert tracker**, then **Move tracker** — row count stays the same, `track-01`
+  jumps. That is Arrow `replace` (concat left + new row + right), not a full
+  `addDataToMap` replace.
+- **Add 1** / **Remove last** exercise append and slice-remove on the same table.
+
+### GeoJSON features
+
+- Click **GeoJSON**. Kepler remounts over Monash, Victoria and **fetches**
+  building MultiPolygons from
+  [buildings-australia.geojson](https://raw.githubusercontent.com/keplergl/kepler.gl-data/refs/heads/master/datasets/buildings-australia.geojson)
+  (~597 footprints). Seed shows 8 buildings; color is `land_use`.
+- **Add 1 / Add 5** append the next footprints from that file (`host-*` ids).
+  **Remove last** drops one. **Insert tracker** adds `track-01`; **Move tracker**
+  replaces that row with another building (`upsertBy: 'id'`) — row count stays
+  the same, a different footprint appears.
 
 ## CSV server only (Add Data URL)
 

--- a/examples/live-data/src/app.tsx
+++ b/examples/live-data/src/app.tsx
@@ -18,19 +18,27 @@ import {
   wrapTo
 } from '@kepler.gl/actions';
 import {DatasetType} from '@kepler.gl/constants';
+import {processArrowBatches, processGeojson} from '@kepler.gl/processors';
 import {initApplicationConfig} from '@kepler.gl/utils';
+import * as arrow from 'apache-arrow';
 
 initApplicationConfig({enableAnnotations: false});
 
 const MAP_ID = 'map';
 const SIDEBAR_WIDTH = 300;
 const DATASET_ID = 'live-vehicles';
+const POINT_LAYER_ID = 'live-orbit-point';
+const GEOJSON_LAYER_ID = 'live-orbit-geojson';
 const LIVE_DATA_URL = process.env.LIVE_DATA_URL || 'http://localhost:4010/vehicles.csv';
 const REFRESH_INTERVAL_MS = 300;
 const AUTO_INTERVAL_MS = 800;
 const MAX_HOST_ROWS = 20;
 const TRACKER_ID = 'track-01';
 const POLL_VEHICLE_ID = 'veh-01';
+const GEOJSON_SEED_COUNT = 8;
+const BUILDINGS_URL =
+  'https://raw.githubusercontent.com/keplergl/kepler.gl-data/refs/heads/master/datasets/buildings-australia.geojson';
+const MONASH = {lat: -37.8949, lng: 145.1443};
 
 const SF = {lat: 37.7749, lng: -122.4194};
 const COS_LAT = Math.cos((SF.lat * Math.PI) / 180);
@@ -38,6 +46,7 @@ const KM_PER_DEG_LAT = 111.32;
 const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5));
 
 type LiveMode = 'poll' | 'host';
+type TableFormat = 'csv' | 'arrow' | 'geojson';
 
 type KeplerRootState = {
   keplerGl: {
@@ -50,6 +59,7 @@ type KeplerRootState = {
             dataContainer?: {
               numRows: () => number;
               valueAt: (row: number, col: number) => unknown;
+              getTable?: () => unknown;
             };
             metadata?: {
               refreshStatus?: string;
@@ -118,6 +128,14 @@ function hostRowIndexes(dataset: LiveDataset | undefined): number[] {
   }, []);
 }
 
+function isArrowTable(dataset: LiveDataset | undefined): boolean {
+  return typeof dataset?.dataContainer?.getTable === 'function';
+}
+
+function isGeojsonTable(dataset: LiveDataset | undefined): boolean {
+  return (dataset?.fields || []).some(field => field.name === '_geojson');
+}
+
 function makeHostVehicle(seq: number, options?: {id?: string; ring?: number}) {
   const angle = seq * GOLDEN_ANGLE;
   const radiusKm = 5.2 + (seq % 8) * 0.35;
@@ -133,6 +151,232 @@ function makeHostVehicle(seq: number, options?: {id?: string; ring?: number}) {
     progress: 0,
     orbit_s: 0,
     updated_at: new Date().toISOString()
+  };
+}
+
+function seedVehicles() {
+  return [0, 1, 2].map(index =>
+    makeHostVehicle(index + 1, {
+      id: `veh-${String(index + 1).padStart(2, '0')}`,
+      ring: index + 1
+    })
+  );
+}
+
+function vehiclesToRowData(vehicles: Record<string, unknown>[]) {
+  const names = Object.keys(vehicles[0]);
+  return {
+    fields: names.map(name => ({name})),
+    rows: vehicles.map(row => names.map(name => row[name]))
+  };
+}
+
+type BuildingFeature = {
+  type?: string;
+  properties?: Record<string, unknown> | null;
+  geometry?: {type: string; coordinates: unknown} | null;
+};
+
+let buildingsCache: BuildingFeature[] | null = null;
+let buildingsLoad: Promise<BuildingFeature[]> | null = null;
+
+function loadBuildings(): Promise<BuildingFeature[]> {
+  if (buildingsCache) {
+    return Promise.resolve(buildingsCache);
+  }
+  if (!buildingsLoad) {
+    buildingsLoad = fetch(BUILDINGS_URL)
+      .then(response => {
+        if (!response.ok) {
+          throw new Error(`Buildings GeoJSON HTTP ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((json: {features?: BuildingFeature[]}) => {
+        const features = (json.features || []).filter(feature => feature?.geometry);
+        if (!features.length) {
+          throw new Error('Buildings GeoJSON had no features');
+        }
+        buildingsCache = features;
+        return features;
+      })
+      .catch(error => {
+        buildingsLoad = null;
+        throw error;
+      });
+  }
+  return buildingsLoad;
+}
+
+function buildingAt(seq: number): BuildingFeature {
+  const features = buildingsCache;
+  if (!features?.length) {
+    throw new Error('Buildings GeoJSON is not loaded');
+  }
+  return features[seq % features.length];
+}
+
+function buildingRow(feature: BuildingFeature, id: string) {
+  const properties = {
+    id,
+    land_use: String(feature.properties?.LAND_USE_T ?? ''),
+    height: Number(feature.properties?.HEIGHT_AVE ?? 0),
+    lga: String(feature.properties?.LGA_NAME ?? '')
+  };
+  const wrapped = {
+    type: 'Feature' as const,
+    properties,
+    geometry: feature.geometry
+  };
+  return {_geojson: wrapped, ...properties};
+}
+
+function seedBuildingRows(features: BuildingFeature[]) {
+  return features
+    .slice(0, GEOJSON_SEED_COUNT)
+    .map(feature =>
+      buildingRow(feature, `bldg-${feature.properties?.TARGET_FID ?? feature.properties?.BF_FID}`)
+    );
+}
+
+function nextHostBuildingRow(seq: number) {
+  return buildingRow(
+    buildingAt(GEOJSON_SEED_COUNT + seq - 1),
+    `host-${String(seq).padStart(3, '0')}`
+  );
+}
+
+function nextTrackerBuildingRow(seq: number) {
+  return buildingRow(buildingAt(seq), TRACKER_ID);
+}
+
+const MAP_VIEW = {
+  latitude: 37.7749,
+  longitude: -122.4194,
+  zoom: 12.2,
+  pitch: 0,
+  bearing: 0
+};
+
+const GEOJSON_MAP_VIEW = {
+  latitude: MONASH.lat,
+  longitude: MONASH.lng,
+  zoom: 16,
+  pitch: 0,
+  bearing: 0
+};
+
+const POINT_LAYER_CONFIG = {
+  id: POINT_LAYER_ID,
+  type: 'point',
+  config: {
+    dataId: DATASET_ID,
+    label: 'Live orbit',
+    columns: {lat: 'lat', lng: 'lng', altitude: null},
+    isVisible: true,
+    visConfig: {radius: 24, filled: true, opacity: 0.85}
+  },
+  visualChannels: {
+    colorField: {name: 'ring', type: 'integer'},
+    colorScale: 'quantize'
+  }
+};
+
+const GEOJSON_LAYER_CONFIG = {
+  id: GEOJSON_LAYER_ID,
+  type: 'geojson',
+  config: {
+    dataId: DATASET_ID,
+    label: 'Monash buildings',
+    columns: {geojson: '_geojson'},
+    isVisible: true,
+    visConfig: {filled: true, stroked: true, thickness: 0.6, radius: 16, opacity: 0.8}
+  },
+  visualChannels: {
+    colorField: {name: 'land_use', type: 'string'},
+    colorScale: 'ordinal'
+  }
+};
+
+function mapConfig(layers: object[], mapState = MAP_VIEW) {
+  return {
+    version: 'v1' as const,
+    config: {
+      visState: {layers},
+      mapState,
+      mapStyle: {styleType: 'dark-matter'}
+    }
+  };
+}
+
+function buildAddDataToMap(format: TableFormat, mode: LiveMode, buildings?: BuildingFeature[]) {
+  const options = {
+    centerMap: false,
+    autoCreateLayers: false,
+    keepExistingConfig: false,
+    layerVisConfig: {radius: 24, filled: true, opacity: 0.85}
+  };
+
+  if (format === 'geojson') {
+    const rows = seedBuildingRows(buildings || buildingsCache || []);
+    return {
+      datasets: {
+        info: {id: DATASET_ID, label: 'Monash buildings'},
+        data: processGeojson({
+          type: 'FeatureCollection',
+          features: rows.map(row => row._geojson)
+        })
+      },
+      options: {
+        ...options,
+        centerMap: true
+      },
+      config: mapConfig([GEOJSON_LAYER_CONFIG], GEOJSON_MAP_VIEW)
+    };
+  }
+
+  if (format === 'arrow') {
+    const table = arrow.tableFromJSON(seedVehicles());
+    return {
+      datasets: {
+        info: {id: DATASET_ID, label: 'Live orbit'},
+        data: processArrowBatches(table.batches)
+      },
+      options,
+      config: mapConfig([POINT_LAYER_CONFIG])
+    };
+  }
+
+  if (mode === 'host') {
+    return {
+      datasets: {
+        info: {id: DATASET_ID, label: 'Live orbit'},
+        data: vehiclesToRowData(seedVehicles())
+      },
+      options,
+      config: mapConfig([POINT_LAYER_CONFIG])
+    };
+  }
+
+  return {
+    datasets: {
+      info: {
+        id: DATASET_ID,
+        label: 'Live orbit',
+        type: DatasetType.EXTERNALLY_HOSTED
+      },
+      data: {fields: [], rows: []},
+      metadata: {
+        source: LIVE_DATA_URL,
+        sourceFormat: 'csv',
+        refreshIntervalMs: REFRESH_INTERVAL_MS
+      }
+    },
+    options: {
+      ...options,
+      centerMap: true
+    },
+    config: mapConfig([POINT_LAYER_CONFIG])
   };
 }
 
@@ -182,7 +426,7 @@ function ModeToggle({
     <div
       style={{
         display: 'flex',
-        marginBottom: 14,
+        marginBottom: 8,
         border: '1px solid #4a5160',
         borderRadius: 6,
         overflow: 'hidden'
@@ -208,6 +452,52 @@ function ModeToggle({
             color: enabled ? '#f7f7f7' : '#6a7485',
             fontWeight: mode === value ? 600 : 400,
             fontSize: 13
+          }}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function FormatToggle({
+  format,
+  onChange
+}: {
+  format: TableFormat;
+  onChange: (next: TableFormat) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        marginBottom: 14,
+        border: '1px solid #4a5160',
+        borderRadius: 6,
+        overflow: 'hidden'
+      }}
+    >
+      {(
+        [
+          ['csv', 'CSV'],
+          ['arrow', 'Arrow'],
+          ['geojson', 'GeoJSON']
+        ] as const
+      ).map(([value, label]) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => onChange(value)}
+          style={{
+            flex: 1,
+            padding: '7px 10px',
+            border: 0,
+            cursor: 'pointer',
+            background: format === value ? '#4a6a4e' : 'transparent',
+            color: '#f7f7f7',
+            fontWeight: format === value ? 600 : 400,
+            fontSize: 12
           }}
         >
           {label}
@@ -269,7 +559,8 @@ function PollSidebar({dataset}: {dataset: LiveDataset | undefined}) {
       <p style={{margin: '16px 0 0', color: '#c3c9d5'}}>
         Layers panel: dataset refresh is 300ms. Click reload to sample the orbit immediately.
         Switching to <strong>Host rows</strong> pauses the poll so you can append or delete without
-        the next snapshot wiping your edits.
+        the next snapshot wiping your edits. <strong>Arrow</strong> / <strong>GeoJSON</strong> drop
+        this Kepler instance and load a fresh table of that type — they do not convert this CSV.
       </p>
     </>
   );
@@ -279,6 +570,8 @@ function HostSidebar({
   dataset,
   autoTrail,
   keyedNote,
+  geojsonLoading,
+  geojsonError,
   onAutoTrail,
   onAdd,
   onRemoveLast,
@@ -291,6 +584,8 @@ function HostSidebar({
   dataset: LiveDataset | undefined;
   autoTrail: boolean;
   keyedNote: string;
+  geojsonLoading?: boolean;
+  geojsonError?: string;
   onAutoTrail: (next: boolean) => void;
   onAdd: (count: number) => void;
   onRemoveLast: () => void;
@@ -307,15 +602,34 @@ function HostSidebar({
   const hasPollVehicle = ids.includes(POLL_VEHICLE_ID);
   const hostIds = ids.filter(id => id.startsWith('host-'));
   const lastHostId = hostIds[hostIds.length - 1];
+  const arrow = isArrowTable(dataset);
+  const geojson = isGeojsonTable(dataset);
+
+  const geojsonBusy = Boolean(geojsonLoading || geojsonError);
 
   return (
     <>
+      {geojsonLoading ? (
+        <p style={{margin: '0 0 12px', color: '#9ad0a8'}}>Fetching buildings GeoJSON…</p>
+      ) : null}
+      {geojsonError ? <p style={{margin: '0 0 12px', color: '#f19c99'}}>{geojsonError}</p> : null}
       <p style={{margin: '0 0 12px', color: '#c3c9d5'}}>
         Polling is off. The host app dispatches <code>addToDataset</code> /{' '}
         <code>removeFromDataset</code> so rows change in place — same layer id and style. Host
         points land on outer rings (4–6) and color by <code>ring</code>.
+        {geojson || geojsonLoading || geojsonError
+          ? ' This instance fetches Monash building footprints at runtime. Add pulls the next building from that file; Move tracker replaces one footprint in place.'
+          : arrow
+          ? ' This instance is an Arrow table: append/upsert concat batches; Move tracker replaces the matching id.'
+          : ' Arrow and GeoJSON each remount Kepler with their own table — they do not convert these CSV rows.'}
       </p>
       <div style={{display: 'grid', gap: 8, marginBottom: 12}}>
+        <div style={{display: 'flex', justifyContent: 'space-between', gap: 12}}>
+          <span style={{color: '#c3c9d5'}}>table</span>
+          <span>
+            {geojson ? 'GeoJSON features' : arrow ? 'ArrowDataContainer' : 'RowDataContainer'}
+          </span>
+        </div>
         <div style={{display: 'flex', justifyContent: 'space-between', gap: 12}}>
           <span style={{color: '#c3c9d5'}}>rows</span>
           <span>
@@ -331,16 +645,34 @@ function HostSidebar({
           }}
         >
           <span style={{color: '#c3c9d5', flexShrink: 0}}>ids</span>
-          <span style={{textAlign: 'right', wordBreak: 'break-word'}}>
+          <span
+            style={{
+              minWidth: 0,
+              maxHeight: 52,
+              overflowY: 'auto',
+              textAlign: 'right',
+              wordBreak: 'break-word'
+            }}
+          >
             {ids.length ? ids.join(', ') : '—'}
           </span>
         </div>
       </div>
       <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8}}>
-        <button type="button" style={buttonStyle} onClick={() => onAdd(1)} disabled={!dataset}>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() => onAdd(1)}
+          disabled={!dataset || geojsonBusy}
+        >
           Add 1
         </button>
-        <button type="button" style={buttonStyle} onClick={() => onAdd(5)} disabled={!dataset}>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={() => onAdd(5)}
+          disabled={!dataset || geojsonBusy}
+        >
           Add 5
         </button>
         <button type="button" style={buttonStyle} onClick={onRemoveLast} disabled={rows < 1}>
@@ -353,11 +685,17 @@ function HostSidebar({
       <p style={{margin: '16px 0 8px', fontWeight: 600}}>Keyed by id</p>
       <p style={{margin: '0 0 8px', color: '#c3c9d5'}}>
         <code>upsertBy: &apos;id&apos;</code> keeps the same row. First click inserts{' '}
-        <code>{TRACKER_ID}</code> (ring 7); later clicks move it and the row count stays put.
-        Removes use <code>{'{field, values}'}</code>, not a row index.
+        <code>{TRACKER_ID}</code> (ring 7); later clicks <strong>replace</strong> it
+        {geojson ? ' with another building from the file' : arrow ? ' via Arrow concat' : ''} and
+        the row count stays put. Removes use <code>{'{field, values}'}</code>, not a row index.
       </p>
       <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8}}>
-        <button type="button" style={buttonStyle} onClick={onUpsertTracker} disabled={!dataset}>
+        <button
+          type="button"
+          style={buttonStyle}
+          onClick={onUpsertTracker}
+          disabled={!dataset || geojsonBusy}
+        >
           {hasTracker ? 'Move tracker' : 'Insert tracker'}
         </button>
         <button type="button" style={buttonStyle} onClick={onRemoveTracker} disabled={!hasTracker}>
@@ -399,24 +737,36 @@ function HostSidebar({
           type="checkbox"
           checked={autoTrail}
           onChange={event => onAutoTrail(event.target.checked)}
-          disabled={!dataset}
+          disabled={!dataset || geojsonBusy}
         />
         Auto trail (add every 800ms, keep {MAX_HOST_ROWS} host rows)
       </label>
       <p style={{margin: '16px 0 0', color: '#c3c9d5'}}>
-        Switch back to <strong>Poll URL</strong> to resume HTTP snapshot replace — injected rows
-        disappear on the next fetch.
+        <strong>Poll URL</strong> remounts the CSV poll instance — injected rows disappear.
       </p>
     </>
   );
 }
 
-function LiveDataSidebar() {
+function LiveDataSidebar({
+  mode,
+  tableFormat,
+  geojsonLoading,
+  geojsonError,
+  onMode,
+  onFormat
+}: {
+  mode: LiveMode;
+  tableFormat: TableFormat;
+  geojsonLoading: boolean;
+  geojsonError: string;
+  onMode: (next: LiveMode) => void;
+  onFormat: (next: TableFormat) => void;
+}) {
   const dispatch = useDispatch();
   const dataset = useSelector(
     (state: KeplerRootState) => state.keplerGl[MAP_ID]?.visState?.datasets?.[DATASET_ID]
   );
-  const [mode, setMode] = useState<LiveMode>('poll');
   const [autoTrail, setAutoTrail] = useState(false);
   const [keyedNote, setKeyedNote] = useState('');
   const hostSeq = useRef(1);
@@ -425,29 +775,27 @@ function LiveDataSidebar() {
   datasetRef.current = dataset;
 
   const toKepler = useCallback(
-    (action: Parameters<typeof wrapTo>[1]) => dispatch(wrapTo(MAP_ID, action)),
+    (action: unknown) => dispatch(wrapTo(MAP_ID, action as never)),
     [dispatch]
   );
 
-  const setLiveMode = useCallback(
-    (next: LiveMode) => {
-      setMode(next);
-      if (next === 'poll') {
-        setAutoTrail(false);
-        setKeyedNote('');
-        toKepler(
-          updateDatasetProps(DATASET_ID, {metadata: {refreshIntervalMs: REFRESH_INTERVAL_MS}})
-        );
-        toKepler(refreshDataset(DATASET_ID));
-        return;
-      }
-      toKepler(updateDatasetProps(DATASET_ID, {metadata: {refreshIntervalMs: 0}}));
-    },
-    [toKepler]
-  );
+  useEffect(() => {
+    setAutoTrail(false);
+    setKeyedNote('');
+    hostSeq.current = 1;
+    trackSeq.current = 1;
+  }, [tableFormat, mode]);
 
   const addHostRows = useCallback(
     (count: number) => {
+      if (isGeojsonTable(datasetRef.current)) {
+        if (!buildingsCache?.length) {
+          return;
+        }
+        const rows = Array.from({length: count}, () => nextHostBuildingRow(hostSeq.current++));
+        toKepler(addToDataset(DATASET_ID, rows));
+        return;
+      }
       const rows = Array.from({length: count}, () => makeHostVehicle(hostSeq.current++));
       toKepler(addToDataset(DATASET_ID, rows));
     },
@@ -473,7 +821,14 @@ function LiveDataSidebar() {
   const upsertTracker = useCallback(() => {
     const ids = rowIds(datasetRef.current);
     const existed = ids.includes(TRACKER_ID);
-    const row = makeHostVehicle(trackSeq.current++, {id: TRACKER_ID, ring: 7});
+    const row = isGeojsonTable(datasetRef.current)
+      ? buildingsCache?.length
+        ? nextTrackerBuildingRow(trackSeq.current++)
+        : null
+      : makeHostVehicle(trackSeq.current++, {id: TRACKER_ID, ring: 7});
+    if (!row) {
+      return;
+    }
     toKepler(addToDataset(DATASET_ID, row, {upsertBy: 'id'}));
     setKeyedNote(
       existed
@@ -511,7 +866,14 @@ function LiveDataSidebar() {
       if (extras.length >= MAX_HOST_ROWS) {
         toKepler(removeFromDataset(DATASET_ID, extras[0]));
       }
-      toKepler(addToDataset(DATASET_ID, makeHostVehicle(hostSeq.current++)));
+      if (isGeojsonTable(datasetRef.current)) {
+        if (!buildingsCache?.length) {
+          return;
+        }
+        toKepler(addToDataset(DATASET_ID, nextHostBuildingRow(hostSeq.current++)));
+      } else {
+        toKepler(addToDataset(DATASET_ID, makeHostVehicle(hostSeq.current++)));
+      }
     }, AUTO_INTERVAL_MS);
     return () => window.clearInterval(timer);
   }, [autoTrail, mode, toKepler]);
@@ -521,9 +883,10 @@ function LiveDataSidebar() {
       <h2 style={{margin: '0 0 8px', fontSize: 16}}>Live data</h2>
       <ModeToggle
         mode={mode}
-        hostEnabled={(dataset?.dataContainer?.numRows?.() ?? 0) > 0}
-        onChange={setLiveMode}
+        hostEnabled={tableFormat !== 'csv' || (dataset?.dataContainer?.numRows?.() ?? 0) > 0}
+        onChange={onMode}
       />
+      <FormatToggle format={tableFormat} onChange={onFormat} />
       {mode === 'poll' ? (
         <PollSidebar dataset={dataset} />
       ) : (
@@ -531,6 +894,8 @@ function LiveDataSidebar() {
           dataset={dataset}
           autoTrail={autoTrail}
           keyedNote={keyedNote}
+          geojsonLoading={tableFormat === 'geojson' ? geojsonLoading : false}
+          geojsonError={tableFormat === 'geojson' ? geojsonError : ''}
           onAutoTrail={setAutoTrail}
           onAdd={addHostRows}
           onRemoveLast={removeLast}
@@ -548,80 +913,118 @@ function LiveDataSidebar() {
 const App = () => {
   const dispatch = useDispatch();
   const {width, height} = useWindowSize();
+  const [mode, setMode] = useState<LiveMode>('poll');
+  const [tableFormat, setTableFormat] = useState<TableFormat>('csv');
+  const [session, setSession] = useState(0);
+  const [geojsonLoading, setGeojsonLoading] = useState(false);
+  const [geojsonError, setGeojsonError] = useState('');
+  const pollInstanceRef = useRef(true);
+
+  const toKepler = useCallback(
+    (action: unknown) => dispatch(wrapTo(MAP_ID, action as never)),
+    [dispatch]
+  );
 
   useEffect(() => {
-    dispatch(
-      wrapTo(
-        MAP_ID,
-        addDataToMap({
-          datasets: {
-            info: {
-              id: DATASET_ID,
-              label: 'Live orbit',
-              type: DatasetType.EXTERNALLY_HOSTED
-            },
-            data: {fields: [], rows: []},
-            metadata: {
-              source: LIVE_DATA_URL,
-              sourceFormat: 'csv',
-              refreshIntervalMs: REFRESH_INTERVAL_MS
-            }
-          },
-          options: {
-            centerMap: true,
-            autoCreateLayers: false,
-            layerVisConfig: {radius: 24, filled: true, opacity: 0.85}
-          },
-          config: {
-            version: 'v1',
-            config: {
-              visState: {
-                layers: [
-                  {
-                    id: 'live-orbit-point',
-                    type: 'point',
-                    config: {
-                      dataId: DATASET_ID,
-                      label: 'Live orbit',
-                      columns: {lat: 'lat', lng: 'lng', altitude: null},
-                      isVisible: true,
-                      visConfig: {radius: 24, filled: true, opacity: 0.85}
-                    },
-                    visualChannels: {
-                      colorField: {name: 'ring', type: 'integer'},
-                      colorScale: 'quantize'
-                    }
-                  }
-                ]
-              },
-              mapState: {
-                latitude: 37.7749,
-                longitude: -122.4194,
-                zoom: 12.2,
-                pitch: 0,
-                bearing: 0
-              },
-              mapStyle: {
-                styleType: 'dark-matter'
-              }
-            }
+    let cancelled = false;
+    pollInstanceRef.current = tableFormat === 'csv' && mode === 'poll';
+
+    async function loadMap() {
+      if (tableFormat === 'geojson') {
+        setGeojsonLoading(true);
+        setGeojsonError('');
+        try {
+          const buildings = await loadBuildings();
+          if (cancelled) {
+            return;
           }
-        })
-      )
-    );
-  }, [dispatch]);
+          toKepler(addDataToMap(buildAddDataToMap('geojson', mode, buildings) as never));
+        } catch (error) {
+          if (!cancelled) {
+            setGeojsonError(error instanceof Error ? error.message : String(error));
+          }
+        } finally {
+          if (!cancelled) {
+            setGeojsonLoading(false);
+          }
+        }
+        return;
+      }
+      setGeojsonLoading(false);
+      setGeojsonError('');
+      toKepler(addDataToMap(buildAddDataToMap(tableFormat, mode) as never));
+    }
+
+    loadMap();
+    return () => {
+      cancelled = true;
+    };
+    // session is the remount signal; format/mode are applied in the same React batch as session++
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [session, toKepler]);
+
+  const remount = useCallback((nextFormat: TableFormat, nextMode: LiveMode) => {
+    setTableFormat(nextFormat);
+    setMode(nextMode);
+    setSession(value => value + 1);
+  }, []);
+
+  const setLiveMode = useCallback(
+    (next: LiveMode) => {
+      if (next === 'poll') {
+        if (tableFormat === 'csv' && pollInstanceRef.current) {
+          setMode('poll');
+          toKepler(
+            updateDatasetProps(DATASET_ID, {metadata: {refreshIntervalMs: REFRESH_INTERVAL_MS}})
+          );
+          toKepler(refreshDataset(DATASET_ID));
+          return;
+        }
+        remount('csv', 'poll');
+        return;
+      }
+      if (tableFormat === 'csv' && pollInstanceRef.current) {
+        setMode('host');
+        toKepler(updateDatasetProps(DATASET_ID, {metadata: {refreshIntervalMs: 0}}));
+        return;
+      }
+      if (tableFormat !== 'csv') {
+        return;
+      }
+      remount('csv', 'host');
+    },
+    [remount, tableFormat, toKepler]
+  );
+
+  const setLiveTableFormat = useCallback(
+    (next: TableFormat) => {
+      if (next === tableFormat) {
+        return;
+      }
+      remount(next, next === 'csv' ? 'poll' : 'host');
+    },
+    [remount, tableFormat]
+  );
 
   return (
     <div style={{display: 'flex', width: '100%', height: '100%'}}>
       <div style={{position: 'relative', flex: 1, minWidth: 0}}>
         <KeplerGl
+          key={session}
           mapboxApiAccessToken="pk.xxx.yyy"
           id={MAP_ID}
           width={Math.max(width - SIDEBAR_WIDTH, 0)}
           height={height}
         />
       </div>
-      <LiveDataSidebar />
+      <LiveDataSidebar
+        mode={mode}
+        tableFormat={tableFormat}
+        geojsonLoading={geojsonLoading}
+        geojsonError={geojsonError}
+        onMode={setLiveMode}
+        onFormat={setLiveTableFormat}
+      />
     </div>
   );
 };

--- a/src/actions/src/actions.ts
+++ b/src/actions/src/actions.ts
@@ -51,7 +51,7 @@ export type ActionHandlers<T extends {[k: string]: Handler}> = {
  * @param {boolean} data.options.readOnly `default: false` if `readOnly` is set to `true`
  * the left setting panel will be hidden
  * @param {boolean} data.options.keepExistingConfig whether to keep exiting map data and associated layer filter  interaction config `default: false`.
- * To append, upsert, or delete rows on an existing in-memory row dataset without replacing it or creating layers, use `addToDataset` / `removeFromDataset`. Arrow and DuckDB tables do not support those actions yet.
+ * To append, upsert, or delete rows on an existing in-memory row or Arrow dataset without replacing it or creating layers, use `addToDataset` / `removeFromDataset`. DuckDB tables do not support those actions yet.
  * @param {Object} data.config this object will contain the full kepler.gl instance configuration {mapState, mapStyle, visState}
  * @public
  * @example

--- a/src/actions/src/vis-state-actions.ts
+++ b/src/actions/src/vis-state-actions.ts
@@ -1041,7 +1041,8 @@ export type AddToDatasetOptions = {
   /**
    * Field name used as a unique key. Matching rows are replaced in place;
    * keys that are not in the table are appended. Last incoming row wins when
-   * the same key appears twice. Row tables only — Arrow/DuckDB no-op with a warning.
+   * the same key appears twice. DuckDB tables no-op with a warning. Nested /
+   * geoarrow Arrow columns also no-op (primitive Arrow columns concat in place).
    */
   upsertBy?: string;
 };
@@ -1052,13 +1053,14 @@ export type AddToDatasetUpdaterAction = {
   options?: AddToDatasetOptions;
 };
 /**
- * Append rows to an existing in-memory row dataset without `addDataToMap`.
+ * Append rows to an existing in-memory row or Arrow dataset without `addDataToMap`.
  * Keeps layer identity and style. Pass `options.upsertBy` to replace rows that
  * share that key and append the rest.
  *
- * Not implemented for Arrow or DuckDB tables (no INSERT / concat yet); those
- * calls warn and leave the table unchanged. Use `addDataToMap` with
- * `keepExistingConfig` for a full replace.
+ * DuckDB tables (no INSERT yet) warn and leave the table unchanged. Arrow
+ * tables concat primitive columns in place; nested, binary, and geoarrow
+ * columns are rejected. Use `addDataToMap` with `keepExistingConfig` for a
+ * full replace.
  * @memberof visStateActions
  * @param dataId dataset id
  * @param rows one row or an array of rows (arrays in field order, or objects keyed by field name)
@@ -1090,12 +1092,12 @@ export type RemoveFromDatasetUpdaterAction = {
   byField?: RemoveFromDatasetByField;
 };
 /**
- * Delete rows from an existing in-memory row dataset without restyling layers.
+ * Delete rows from an existing in-memory row or Arrow dataset without restyling layers.
  * The second argument is either row indexes or `{field, values}` to match a
  * column (e.g. an id). Out-of-range indexes are a no-op for the whole action.
  *
- * Not implemented for Arrow or DuckDB tables; those calls warn and leave the
- * table unchanged. For a full table replace use `addDataToMap` with
+ * DuckDB tables warn and leave the table unchanged. Arrow tables concat the
+ * kept slices in place. For a full table replace use `addDataToMap` with
  * `keepExistingConfig`.
  * @memberof visStateActions
  * @param dataId dataset id

--- a/src/duckdb/src/table/duckdb-table.ts
+++ b/src/duckdb/src/table/duckdb-table.ts
@@ -2,6 +2,7 @@
 // Copyright contributors to the kepler.gl project
 
 import * as arrow from 'apache-arrow';
+import Console from 'global/console';
 
 import {
   DatasetType,
@@ -70,6 +71,13 @@ const DUCKDB_WKB_COLUMN = 'wkb_geometry';
  in order to support Kepler maps saved before introduction of DuckDb plugin.
  */
 const KEPLER_GEOM_FROM_GEOJSON_COLUMN = '_geojson';
+
+const DUCKDB_ROW_EDIT_NOT_IMPLEMENTED =
+  'In-place row edits (append, upsert, delete) are not implemented for DuckDB tables. DuckDB INSERT is not supported yet. Use addDataToMap with keepExistingConfig to replace the table.';
+
+function warnDuckDbRowEdits(method: string): void {
+  Console.warn(`KeplerGlDuckDbTable.${method}: ${DUCKDB_ROW_EDIT_NOT_IMPLEMENTED}`);
+}
 
 /**
  * Names of columns that most likely contain binary wkb geometry
@@ -298,6 +306,25 @@ export class KeplerGlDuckDbTable extends KeplerTable {
     const {cols} = await this.createTableAndGetArrow(data);
 
     return super.update({cols, rows: [], fields: []});
+  }
+
+  /**
+   * DuckDB's Arrow view is a query snapshot. Mutating it without SQL INSERT
+   * would desync the WASM table, so row edits stay a warned no-op.
+   */
+  appendRows(_rows: any[][]): boolean {
+    warnDuckDbRowEdits('appendRows');
+    return false;
+  }
+
+  upsertRows(_rows: any[][], _keyField: string): boolean {
+    warnDuckDbRowEdits('upsertRows');
+    return false;
+  }
+
+  removeRows(_indexes: number[]): boolean {
+    warnDuckDbRowEdits('removeRows');
+    return false;
   }
 
   static getFileProcessor = function (data: any, inputFormat?: string) {

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -1349,7 +1349,7 @@ class Layer implements KeplerLayer {
     const triggerChanged = this.getChangedTriggers(dataUpdateTriggers);
 
     if (triggerChanged && (triggerChanged.getMeta || triggerChanged.getData)) {
-      this.updateLayerMeta(effectiveDataset, getPosition);
+      this.updateLayerMeta(effectiveDataset, getPosition, triggerChanged);
 
       // reset filteredItemCount
       this.filteredItemCount = {};
@@ -1706,7 +1706,7 @@ class Layer implements KeplerLayer {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  updateLayerMeta(dataset: KeplerTable, getPosition) {
+  updateLayerMeta(dataset: KeplerTable, getPosition, triggerChanged?) {
     // implemented in subclasses
   }
 

--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -608,7 +608,11 @@ export default class GeoJsonLayer extends Layer {
     return booleanWithin(turfPoint(point), polygon);
   }
 
-  updateLayerMeta(dataset: KeplerTable) {
+  updateLayerMeta(
+    dataset: KeplerTable,
+    _getPosition?: unknown,
+    triggerChanged?: {getMeta?: boolean; getData?: boolean} | false
+  ) {
     const {dataContainer} = dataset;
 
     this.dataContainer = dataContainer;
@@ -666,7 +670,14 @@ export default class GeoJsonLayer extends Layer {
         }
         this.updateMeta({bounds, fixedRadius, featureTypes});
       }
-    } else if (this.dataToFeature.length === 0 || this.config.columnMode === COLUMN_MODE_TABLE) {
+    } else if (
+      // Keep the first-parse skip for filter-only updates (getData.filteredIndex).
+      // Rebuild when row count changes (add/remove) or getMeta changes (dataRevision).
+      this.dataToFeature.length === 0 ||
+      this.config.columnMode === COLUMN_MODE_TABLE ||
+      this.dataToFeature.length !== dataContainer.numRows() ||
+      Boolean(triggerChanged && triggerChanged.getMeta)
+    ) {
       const getFeature = this.getPositionAccessor(dataContainer);
 
       const {dataToFeature, bounds, fixedRadius, featureTypes, centroids} = getGeojsonLayerMeta({

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -3278,8 +3278,8 @@ function normalizeDatasetRows(
 }
 
 /**
- * Append or upsert rows on an existing in-memory row dataset. Keeps layers and re-runs filters.
- * Arrow/DuckDB tables warn and are left unchanged (INSERT / concat not implemented).
+ * Append or upsert rows on an existing in-memory row or Arrow dataset. Keeps layers and re-runs filters.
+ * DuckDB tables warn and are left unchanged (INSERT not implemented). Nested / geoarrow Arrow columns are rejected.
  * @memberof visStateUpdaters
  * @public
  */
@@ -3312,8 +3312,8 @@ export function addToDatasetUpdater(
 }
 
 /**
- * Delete rows by index or by field values from an existing in-memory row dataset.
- * Keeps layers. Arrow/DuckDB tables warn and are left unchanged.
+ * Delete rows by index or by field values from an existing in-memory row or Arrow dataset.
+ * Keeps layers. DuckDB tables warn and are left unchanged.
  * @memberof visStateUpdaters
  * @public
  */

--- a/src/table/src/kepler-table.ts
+++ b/src/table/src/kepler-table.ts
@@ -108,7 +108,7 @@ export type TimeFieldFilterProps = TimeRangeFieldDomain & {
 const FID_KEY = 'name';
 
 const ROW_EDIT_NOT_IMPLEMENTED =
-  'In-place row edits (append, upsert, delete) are not implemented for Arrow/DuckDB tables. DuckDB INSERT and Arrow concat are not supported yet. Use addDataToMap with keepExistingConfig to replace the table.';
+  'In-place row edits (append, upsert, delete) are not implemented for this table. DuckDB tables omit row edits (no INSERT yet). Use addDataToMap with keepExistingConfig to replace the table.';
 
 function warnRowEditsUnavailable(method: string): void {
   Console.warn(`KeplerTable.${method}: ${ROW_EDIT_NOT_IMPLEMENTED}`);
@@ -393,8 +393,8 @@ class KeplerTable<F extends Field = Field> {
   }
 
   /**
-   * Append column-ordered rows in place. No-op for Arrow/DuckDB (no `append`).
-   * Accessors stay bound: the container instance is not replaced.
+   * Append column-ordered rows in place. Accessors stay bound: the container
+   * instance is not replaced. No-op when the container has no `append` (DuckDB).
    * @returns false when the payload is rejected and the table is unchanged.
    */
   appendRows(rows: any[][]): boolean {
@@ -425,7 +425,8 @@ class KeplerTable<F extends Field = Field> {
 
   /**
    * Replace rows that share `keyField` and append the rest. Last incoming row
-   * wins for a repeated key. No-op for Arrow/DuckDB.
+   * wins for a repeated key. No-op when the container has no `append`/`replace`
+   * (DuckDB).
    * @returns false when the payload is rejected and the table is unchanged.
    */
   upsertRows(rows: any[][], keyField: string): boolean {
@@ -472,7 +473,9 @@ class KeplerTable<F extends Field = Field> {
       }
       const existing = keyToIndex.get(key);
       if (existing !== undefined) {
-        this.dataContainer.replace(existing, row);
+        if (!this.dataContainer.replace(existing, row)) {
+          return false;
+        }
       } else {
         toAppend.push(row);
       }
@@ -493,7 +496,8 @@ class KeplerTable<F extends Field = Field> {
   }
 
   /**
-   * Remove rows by index in place. No-op for Arrow/DuckDB (no `remove`).
+   * Remove rows by index in place. No-op when the container has no `remove`
+   * (DuckDB).
    * @returns false when any index is invalid and the table is unchanged.
    */
   removeRows(indexes: number[]): boolean {

--- a/src/utils/src/arrow-data-container.ts
+++ b/src/utils/src/arrow-data-container.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import {ALL_FIELD_TYPES} from '@kepler.gl/constants';
+import {ALL_FIELD_TYPES, GEOARROW_METADATA_KEY} from '@kepler.gl/constants';
 import {ProtoDatasetField} from '@kepler.gl/types';
 import * as arrow from 'apache-arrow';
 import {console as globalConsole} from 'global/window';
@@ -191,7 +191,12 @@ function copyArrowSchemaMetadata(from?: arrow.Schema | null, to?: arrow.Schema |
 
   const fromMeta = from.metadata as Map<string, string> | undefined;
   const toMeta = to.metadata as Map<string, string> | undefined;
-  if (fromMeta && toMeta && typeof fromMeta.forEach === 'function' && typeof toMeta.set === 'function') {
+  if (
+    fromMeta &&
+    toMeta &&
+    typeof fromMeta.forEach === 'function' &&
+    typeof toMeta.set === 'function'
+  ) {
     fromMeta.forEach((value, key) => {
       toMeta.set(key, value);
     });
@@ -262,7 +267,10 @@ function arrowCellToBuilderValue(value: unknown): unknown {
   return value;
 }
 
-function compactArrowVector(column: arrow.Vector, type: arrow.DataType = column.type): arrow.Vector {
+function compactArrowVector(
+  column: arrow.Vector,
+  type: arrow.DataType = column.type
+): arrow.Vector {
   if (!column || !column.data || column.data.length <= 1) {
     return column;
   }
@@ -282,9 +290,10 @@ function compactArrowVector(column: arrow.Vector, type: arrow.DataType = column.
   const builder = arrow.makeBuilder({type, nullValues: [null]});
   const length = column.length;
   for (let i = 0; i < length; i++) {
-    const isValid = typeof (column as {isValid?: (index: number) => boolean}).isValid === 'function'
-      ? (column as {isValid: (index: number) => boolean}).isValid(i)
-      : true;
+    const isValid =
+      typeof (column as {isValid?: (index: number) => boolean}).isValid === 'function'
+        ? (column as {isValid: (index: number) => boolean}).isValid(i)
+        : true;
     // FixedSizeList/List .get() returns nested Vectors. Appending those
     // silently writes NaN (points) or throws (lines/polygons). Plain JS
     // arrays are what makeBuilder expects.
@@ -298,6 +307,53 @@ function compactArrowVector(column: arrow.Vector, type: arrow.DataType = column.
     return (finished as {toVector: () => arrow.Vector}).toVector();
   }
   return column;
+}
+
+/**
+ * Primitive (and dictionary-of-primitive) columns can be rebuilt from JS row
+ * arrays via vectorFromArray. Nested, binary, and geoarrow columns cannot.
+ */
+function isSupportedArrowRowEditType(type: arrow.DataType): boolean {
+  if (
+    arrow.DataType.isUtf8(type) ||
+    arrow.DataType.isNull(type) ||
+    arrow.DataType.isInt(type) ||
+    arrow.DataType.isFloat(type) ||
+    arrow.DataType.isBool(type) ||
+    arrow.DataType.isDate(type) ||
+    arrow.DataType.isTimestamp(type) ||
+    arrow.DataType.isTime(type)
+  ) {
+    return true;
+  }
+  if (arrow.DataType.isDictionary(type)) {
+    const dictionary = (type as arrow.Dictionary).dictionary;
+    return Boolean(dictionary && isSupportedArrowRowEditType(dictionary));
+  }
+  return false;
+}
+
+function arrowFieldGeoArrowExtension(field?: arrow.Field | null): string | undefined {
+  const metadata = field?.metadata as Map<string, string> | Record<string, string> | undefined;
+  if (!metadata) {
+    return undefined;
+  }
+  if (typeof (metadata as Map<string, string>).get === 'function') {
+    return (metadata as Map<string, string>).get(GEOARROW_METADATA_KEY);
+  }
+  return (metadata as Record<string, string>)[GEOARROW_METADATA_KEY];
+}
+
+function concatArrowTables(tables: arrow.Table[]): arrow.Table | null {
+  const nonempty = tables.filter(table => table && table.numRows > 0);
+  if (!nonempty.length) {
+    return tables[0] ?? null;
+  }
+  let next = nonempty[0];
+  for (let i = 1; i < nonempty.length; i++) {
+    next = next.concat(nonempty[i]);
+  }
+  return next;
 }
 
 /**
@@ -385,6 +441,183 @@ export class ArrowDataContainer implements DataContainerInterface {
 
     // cache column data to make valueAt() faster
     // this._colData = this._cols.map(c => c.toArray());
+  }
+
+  /**
+   * Concat rows onto the Arrow table. Rejects the whole batch when any row is
+   * the wrong width or a column type cannot be rebuilt from JS values
+   * (nested, binary, geoarrow). Compacts after concat so batch count stays
+   * under the hover/picking cap.
+   */
+  append(rows: any[][]): boolean {
+    const extra = this._tableFromRows(rows, 'append');
+    if (!extra) {
+      return false;
+    }
+    try {
+      const next = this._numRows === 0 ? extra : this._arrowTable.concat(extra);
+      this._commitTable(next);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Replace one row by slicing around it and concatenating a one-row table.
+   * Same type restrictions as {@link append}.
+   */
+  replace(index: number, row: any[]): boolean {
+    if (!Number.isInteger(index) || index < 0 || index >= this._numRows) {
+      return false;
+    }
+    const extra = this._tableFromRows([row], 'replace');
+    if (!extra) {
+      return false;
+    }
+    try {
+      const parts: arrow.Table[] = [];
+      if (index > 0) {
+        parts.push(this._arrowTable.slice(0, index));
+      }
+      parts.push(extra);
+      if (index + 1 < this._numRows) {
+        parts.push(this._arrowTable.slice(index + 1));
+      }
+      const next = concatArrowTables(parts);
+      if (!next) {
+        return false;
+      }
+      this._commitTable(next);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Drop unique valid indexes by concatenating the kept slices. Works for any
+   * Arrow type (including nested/geoarrow) because no JS values are rebuilt.
+   * Any out-of-range or non-integer index rejects the whole call.
+   */
+  remove(indexes: number[]): boolean {
+    if (!Array.isArray(indexes) || !indexes.length) {
+      return false;
+    }
+
+    const numRows = this._numRows;
+    const toRemove = new Set<number>();
+    for (let i = 0; i < indexes.length; i++) {
+      const index = indexes[i];
+      if (!Number.isInteger(index) || index < 0 || index >= numRows) {
+        return false;
+      }
+      toRemove.add(index);
+    }
+
+    if (toRemove.size === numRows) {
+      this._assignTable(this._arrowTable.slice(0, 0));
+      return true;
+    }
+
+    try {
+      const kept: arrow.Table[] = [];
+      let start = 0;
+      const sorted = [...toRemove].sort((a, b) => a - b);
+      for (let i = 0; i < sorted.length; i++) {
+        const index = sorted[i];
+        if (index > start) {
+          kept.push(this._arrowTable.slice(start, index));
+        }
+        start = index + 1;
+      }
+      if (start < numRows) {
+        kept.push(this._arrowTable.slice(start));
+      }
+      const next = concatArrowTables(kept);
+      if (!next) {
+        return false;
+      }
+      this._commitTable(next);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private _commitTable(table: arrow.Table): void {
+    this._assignTable(compactArrowTable(table));
+  }
+
+  private _unsupportedRowEditReason(): string | null {
+    const fields = this._arrowTable?.schema?.fields || [];
+    if (!fields.length) {
+      return 'table has no columns';
+    }
+    for (let i = 0; i < fields.length; i++) {
+      const field = fields[i];
+      const extension = arrowFieldGeoArrowExtension(field);
+      if (typeof extension === 'string' && extension.startsWith('geoarrow')) {
+        return `column "${field.name}" is geoarrow (${extension})`;
+      }
+      if (!isSupportedArrowRowEditType(field.type)) {
+        return `column "${field.name}" has unsupported type ${field.type}`;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Build a same-schema table from JS rows, using each existing column's Arrow
+   * type so dictionary/utf8/float concat does not coerce to nulls.
+   */
+  private _tableFromRows(rows: any[][], method: string): arrow.Table | null {
+    if (!Array.isArray(rows) || !rows.length) {
+      return null;
+    }
+
+    const numCols = this._arrowTable?.numCols || this._numColumns;
+    if (!numCols) {
+      return null;
+    }
+    for (let i = 0; i < rows.length; i++) {
+      if (!Array.isArray(rows[i]) || rows[i].length !== numCols) {
+        return null;
+      }
+    }
+
+    const unsupported = this._unsupportedRowEditReason();
+    if (unsupported) {
+      globalConsole.warn(`ArrowDataContainer.${method}: ${unsupported}`);
+      return null;
+    }
+
+    const columns: Record<string, arrow.Vector> = {};
+    const seenNames = new Map<string, number>();
+    for (let i = 0; i < numCols; i++) {
+      const field = this._arrowTable.schema.fields[i];
+      const seen = seenNames.get(field.name) ?? 0;
+      seenNames.set(field.name, seen + 1);
+      const key = seen === 0 ? field.name : `${field.name}_${seen}`;
+      const values = rows.map(row => row[i]);
+      try {
+        columns[key] = arrow.vectorFromArray(values, field.type);
+      } catch {
+        globalConsole.warn(
+          `ArrowDataContainer.${method}: could not encode column "${field.name}" as ${field.type}`
+        );
+        return null;
+      }
+    }
+
+    let extra: arrow.Table;
+    try {
+      extra = new arrow.Table(this._arrowTable.schema, columns);
+    } catch {
+      extra = new arrow.Table(columns);
+    }
+    copyArrowSchemaMetadata(this._arrowTable.schema, extra.schema);
+    return extra;
   }
 
   numChunks(): number {

--- a/src/utils/src/data-container-interface.ts
+++ b/src/utils/src/data-container-interface.ts
@@ -20,19 +20,19 @@ export interface DataContainerInterface {
   update?(updateData: any[] | arrow.Table): void;
 
   /**
-   * Append rows in place. Implemented by row containers; Arrow/DuckDB omit this.
-   * @returns false when the rows are rejected (wrong shape) and the container is unchanged.
+   * Append rows in place. Implemented by row and Arrow containers. DuckDB omits this.
+   * @returns false when the rows are rejected (wrong shape or unsupported Arrow type) and the container is unchanged.
    */
   append?(rows: any[][]): boolean;
 
   /**
-   * Replace one row in place. Implemented by row containers; Arrow/DuckDB omit this.
+   * Replace one row in place. Implemented by row and Arrow containers. DuckDB omits this.
    * @returns false when the index or row is rejected and the container is unchanged.
    */
   replace?(index: number, row: any[]): boolean;
 
   /**
-   * Remove rows by index in place. Implemented by row containers; Arrow/DuckDB omit this.
+   * Remove rows by index in place. Implemented by row and Arrow containers. DuckDB omits this.
    * @returns false when any index is invalid and the container is unchanged.
    */
   remove?(indexes: number[]): boolean;

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -26,7 +26,8 @@ import {
   calculateLayerData
 } from '@kepler.gl/reducers';
 
-import {processCsvData, processGeojson} from '@kepler.gl/processors';
+import {processCsvData, processGeojson, processArrowBatches} from '@kepler.gl/processors';
+import * as arrow from 'apache-arrow';
 import {Layer, KeplerGlLayers, COLUMN_MODE_TABLE} from '@kepler.gl/layers';
 import {maybeToDate} from '@kepler.gl/table';
 import {
@@ -8351,9 +8352,9 @@ test('VisStateUpdater -> addToDataset no-ops', async t => {
   t.equal(
     reducer(state, VisStateActions.addToDataset('live', [3, 4])),
     state,
-    'tables without append (Arrow/DuckDB) are a no-op'
+    'tables without append are a no-op'
   );
-  t.ok(warn.called, 'should warn that in-place row edits are not implemented for Arrow/DuckDB');
+  t.ok(warn.called, 'should warn that in-place row edits are not implemented');
   warn.restore();
   t.equal(state.datasets.live.dataContainer.numRows(), 1, 'no-op must not mutate rows');
 
@@ -8458,9 +8459,9 @@ test('VisStateUpdater -> removeFromDataset deletes rows and keeps layers', async
   t.equal(
     reducer(oneIndex, VisStateActions.removeFromDataset('live', 0)),
     oneIndex,
-    'tables without remove (Arrow/DuckDB) are a no-op'
+    'tables without remove are a no-op'
   );
-  t.ok(warn.called, 'should warn that in-place deletes are not implemented for Arrow/DuckDB');
+  t.ok(warn.called, 'should warn that in-place deletes are not implemented');
   warn.restore();
 
   t.end();
@@ -8593,6 +8594,111 @@ test('VisStateUpdater -> addToDataset and removeFromDataset clear table sort', a
   const removed = reducer(sortedAgain, VisStateActions.removeFromDataset('live', 0));
   t.equal(removed.datasets.live.sortOrder, null, 'remove should drop sortOrder');
   t.equal(removed.datasets.live.sortColumn, undefined, 'remove should drop sortColumn');
+
+  t.end();
+});
+
+async function createArrowLiveDatasets(rows) {
+  const table = arrow.tableFromJSON(rows);
+  return createNewDataEntryMock({
+    info: {id: 'live', label: 'live.arrow'},
+    data: processArrowBatches(table.batches)
+  });
+}
+
+test('VisStateUpdater -> addToDataset and removeFromDataset on Arrow tables', async t => {
+  const datasets = await createArrowLiveDatasets([{lat: 37.77, lng: -122.42}]);
+  t.ok(
+    typeof datasets.live.dataContainer.append === 'function',
+    'Arrow dataset should expose append'
+  );
+
+  const {props} = PointLayer.findDefaultLayerProps(datasets.live);
+  const pointLayer = new PointLayer({
+    id: 'p1',
+    dataId: 'live',
+    isVisible: true,
+    ...props[0]
+  });
+  const {layerData, layer} = calculateLayerData(
+    pointLayer,
+    {...INITIAL_VIS_STATE, datasets, layers: [pointLayer], layerData: [{}]},
+    undefined
+  );
+  const state = {
+    ...INITIAL_VIS_STATE,
+    datasets,
+    layers: [layer],
+    layerData: [layerData],
+    layerOrder: [layer.id]
+  };
+
+  const appended = reducer(
+    state,
+    VisStateActions.addToDataset('live', [
+      [10, 20],
+      [30, 40]
+    ])
+  );
+  t.equal(appended.datasets.live.dataContainer.numRows(), 3, 'should append both Arrow rows');
+  t.equal(appended.layers[0].id, 'p1', 'should keep the same layer id');
+  t.equal(
+    appended.layerData[0].data.numRows,
+    3,
+    'should rebuild Arrow layer data with the new row count'
+  );
+  t.notEqual(
+    appended.layerData[0].data,
+    state.layerData[0].data,
+    'should replace the previous Arrow table snapshot'
+  );
+
+  const keyed = await createArrowLiveDatasets([
+    {id: 'a', lat: 1, lng: 2},
+    {id: 'b', lat: 3, lng: 4}
+  ]);
+  const upserted = reducer(
+    {...INITIAL_VIS_STATE, datasets: keyed},
+    VisStateActions.addToDataset(
+      'live',
+      [
+        {id: 'b', lat: 30, lng: 40},
+        {id: 'c', lat: 5, lng: 6}
+      ],
+      {upsertBy: 'id'}
+    )
+  );
+  t.equal(
+    upserted.datasets.live.dataContainer.numRows(),
+    3,
+    'should append only the new Arrow key'
+  );
+  t.equal(
+    upserted.datasets.live.dataContainer.valueAt(1, 1),
+    30,
+    'should replace the matching Arrow key'
+  );
+  t.equal(
+    upserted.datasets.live.dataContainer.valueAt(2, 0),
+    'c',
+    'should append the new Arrow key'
+  );
+
+  const removed = reducer(
+    upserted,
+    VisStateActions.removeFromDataset('live', {field: 'id', values: ['b']})
+  );
+  t.equal(removed.datasets.live.dataContainer.numRows(), 2, 'should drop the matching Arrow id');
+  t.equal(
+    removed.datasets.live.dataContainer.valueAt(0, 0),
+    'a',
+    'should keep unmatched Arrow ids'
+  );
+  t.equal(
+    removed.datasets.live.dataContainer.valueAt(1, 0),
+    'c',
+    'should keep later unmatched Arrow ids'
+  );
 
   t.end();
 });

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -8299,6 +8299,101 @@ test('VisStateUpdater -> addToDataset appends rows and keeps layers', async t =>
   t.end();
 });
 
+test('VisStateUpdater -> addToDataset rebuilds GeoJSON dataToFeature', async t => {
+  const initialData = processGeojson({
+    type: 'FeatureCollection',
+    features: [
+      {
+        type: 'Feature',
+        properties: {id: 'a', ring: 1},
+        geometry: {type: 'Point', coordinates: [-122.42, 37.77]}
+      }
+    ]
+  });
+  const datasets = await createNewDataEntryMock({
+    info: {id: 'live', label: 'live.geojson'},
+    data: initialData
+  });
+  const {props} = GeojsonLayer.findDefaultLayerProps(datasets.live);
+  t.ok(props.length, 'should find a geojson column');
+  const geoLayer = new GeojsonLayer({
+    id: 'g1',
+    dataId: 'live',
+    isVisible: true,
+    ...props[0]
+  });
+  const {layerData, layer} = calculateLayerData(
+    geoLayer,
+    {...INITIAL_VIS_STATE, datasets, layers: [geoLayer], layerData: [{}]},
+    undefined
+  );
+
+  t.equal(layer.dataToFeature.length, 1, 'should parse the initial feature');
+
+  const state = {
+    ...INITIAL_VIS_STATE,
+    datasets,
+    layers: [layer],
+    layerData: [layerData],
+    layerOrder: [layer.id]
+  };
+
+  const appended = reducer(
+    state,
+    VisStateActions.addToDataset('live', {
+      id: 'b',
+      ring: 2,
+      _geojson: {
+        type: 'Feature',
+        properties: {id: 'b', ring: 2},
+        geometry: {type: 'Point', coordinates: [-122.5, 37.8]}
+      }
+    })
+  );
+
+  t.equal(appended.datasets.live.dataContainer.numRows(), 2, 'should append the feature row');
+  t.equal(appended.layers[0].dataToFeature.length, 2, 'should rebuild dataToFeature after append');
+  t.equal(appended.layerData[0].data.length, 2, 'should rebuild layer data after append');
+  t.deepEqual(
+    appended.layers[0].dataToFeature[1].geometry.coordinates,
+    [-122.5, 37.8],
+    'should include the appended point'
+  );
+
+  const replaced = reducer(
+    appended,
+    VisStateActions.addToDataset(
+      'live',
+      {
+        id: 'a',
+        ring: 1,
+        _geojson: {
+          type: 'Feature',
+          properties: {id: 'a', ring: 1},
+          geometry: {type: 'Point', coordinates: [-122.1, 37.1]}
+        }
+      },
+      {upsertBy: 'id'}
+    )
+  );
+
+  t.equal(replaced.datasets.live.dataContainer.numRows(), 2, 'upsert should keep row count');
+  t.deepEqual(
+    replaced.layers[0].dataToFeature[0].geometry.coordinates,
+    [-122.1, 37.1],
+    'should rebuild dataToFeature after in-place replace'
+  );
+
+  const removed = reducer(
+    replaced,
+    VisStateActions.removeFromDataset('live', {field: 'id', values: 'b'})
+  );
+  t.equal(removed.layers[0].dataToFeature.length, 1, 'should drop the removed feature');
+  t.equal(removed.layerData[0].data.length, 1, 'should drop layer data for the removed feature');
+
+  t.end();
+});
+
 test('VisStateUpdater -> addToDataset object rows ignore prototype keys', async t => {
   const initialData = processCsvData('lat,lng\n1,2');
   const datasets = await createNewDataEntryMock({

--- a/test/node/utils/data-container-test.js
+++ b/test/node/utils/data-container-test.js
@@ -533,3 +533,102 @@ test('compactArrowTable -> Builder failure keeps the original table', t => {
 
   t.end();
 });
+
+function arrowContainerFromTable(table) {
+  const cols = Array.from({length: table.numCols}, (_, i) => table.getChildAt(i)).filter(Boolean);
+  return new ArrowDataContainer({
+    cols,
+    fields: table.schema.fields.map((field, fieldIdx) => ({
+      name: field.name,
+      fieldIdx
+    })),
+    arrowTable: table
+  });
+}
+
+test('ArrowDataContainer.append replace and remove', t => {
+  const dc = arrowContainerFromTable(
+    arrow.tableFromJSON([
+      {id: 'a', lat: 1},
+      {id: 'b', lat: 2}
+    ])
+  );
+
+  t.equal(
+    dc.append([
+      ['c', 3],
+      ['d', 4]
+    ]),
+    true,
+    'should append matching primitive/dictionary rows'
+  );
+  t.equal(dc.numRows(), 4, 'should grow without replacing existing rows');
+  t.equal(dc.valueAt(0, 0), 'a', 'should keep the original first id');
+  t.equal(dc.valueAt(3, 1), 4, 'should read the last appended lat');
+  t.equal(dc.numChunks(), 1, 'append should compact concat batches');
+
+  t.equal(dc.append([[1]]), false, 'should reject a wrong column count');
+  t.equal(dc.append([]), false, 'should reject an empty batch');
+  t.equal(dc.numRows(), 4, 'should leave rows unchanged after a rejected append');
+
+  t.equal(dc.replace(1, ['B', 22]), true, 'should overwrite a row by concat');
+  t.equal(dc.valueAt(1, 0), 'B', 'should read the replaced id');
+  t.equal(dc.valueAt(1, 1), 22, 'should read the replaced lat');
+  t.equal(dc.replace(99, ['z', 1]), false, 'should reject a replace with an out-of-range index');
+  t.equal(dc.replace(0, ['z']), false, 'should reject a replace with the wrong column count');
+  t.equal(dc.valueAt(0, 0), 'a', 'should leave the row unchanged after a rejected replace');
+
+  t.equal(dc.remove([1, 1, 3]), true, 'should drop unique valid indexes in one rebuild');
+  t.equal(dc.numRows(), 2, 'should keep the remaining rows');
+  t.equal(dc.valueAt(0, 0), 'a', 'should keep the former row 0');
+  t.equal(dc.valueAt(1, 0), 'c', 'should keep the former row 2');
+  t.deepEqual(dc.getPlainIndex(), [0, 1], 'should rebuild indexes after remove');
+
+  t.equal(dc.remove([99]), false, 'should reject an out-of-range index');
+  t.equal(dc.remove([-1]), false, 'should reject a negative index');
+  t.equal(dc.numRows(), 2, 'should leave rows unchanged after a rejected remove');
+
+  t.equal(dc.remove([0, 1]), true, 'should allow removing every remaining row');
+  t.equal(dc.numRows(), 0, 'should keep an empty table with the original schema');
+  t.equal(
+    dc.append([['e', 5]]),
+    true,
+    'empty table should accept an append that matches the schema'
+  );
+  t.equal(dc.numRows(), 1, 'empty table should grow from the append');
+  t.equal(dc.valueAt(0, 0), 'e', 'appended id should survive an empty-table concat');
+
+  t.end();
+});
+
+test('ArrowDataContainer.append rejects nested and geoarrow columns', t => {
+  const originalWarn = console.warn;
+  console.warn = () => {};
+
+  const listTable = new arrow.Table({
+    vals: arrow.vectorFromArray([
+      [1, 2],
+      [3, 4]
+    ])
+  });
+  const listDc = arrowContainerFromTable(listTable);
+  t.equal(listDc.append([[[5, 6]]]), false, 'should reject a List column');
+  t.equal(listDc.numRows(), 2, 'rejected append must not mutate a List table');
+  t.equal(listDc.remove([0]), true, 'remove should still concat slices of nested columns');
+  t.equal(listDc.numRows(), 1, 'should drop the nested row by slice');
+
+  const geoMeta = new Map();
+  geoMeta.set(GEOARROW_METADATA_KEY, GEOARROW_EXTENSIONS.WKB);
+  const wkbTable = tableFromColumnValues(
+    'geometry',
+    new arrow.Binary(),
+    [new Uint8Array([1, 2, 3])],
+    geoMeta
+  );
+  const geoDc = arrowContainerFromTable(wkbTable);
+  t.equal(geoDc.append([[new Uint8Array([4, 5, 6])]]), false, 'should reject a geoarrow column');
+  t.equal(geoDc.numRows(), 1, 'rejected append must not mutate a geoarrow table');
+
+  console.warn = originalWarn;
+  t.end();
+});

--- a/test/node/utils/duckdb-utils-test.js
+++ b/test/node/utils/duckdb-utils-test.js
@@ -3,6 +3,7 @@
 
 import test from 'tape';
 import * as arrow from 'apache-arrow';
+import Console from 'global/console';
 
 import {
   SUPPORTED_DUCKDB_DROP_EXTENSIONS,
@@ -22,6 +23,7 @@ import {
   sanitizeDuckDBTableName,
   quoteTableName
 } from '../../../src/duckdb/src/table/duckdb-table-utils';
+import {KeplerGlDuckDbTable} from '../../../src/duckdb/src/table/duckdb-table';
 
 import {GEOARROW_EXTENSIONS, GEOARROW_METADATA_KEY} from '@kepler.gl/constants';
 
@@ -588,5 +590,24 @@ test('duckdb-utils -> SUPPORTED_DUCKDB_DROP_EXTENSIONS', t => {
   t.ok(SUPPORTED_DUCKDB_DROP_EXTENSIONS.includes('arrow'), 'should include arrow');
   t.equal(SUPPORTED_DUCKDB_DROP_EXTENSIONS.length, 5, 'should have 5 supported extensions');
 
+  t.end();
+});
+
+test('KeplerGlDuckDbTable -> row edits stay a warned no-op', t => {
+  const table = new KeplerGlDuckDbTable({info: {id: 'duck', label: 'duck'}});
+  const originalWarn = Console.warn;
+  const warnings = [];
+  Console.warn = message => warnings.push(String(message));
+
+  t.equal(table.appendRows([[1, 2]]), false, 'appendRows should no-op');
+  t.equal(table.upsertRows([[1, 2]], 'id'), false, 'upsertRows should no-op');
+  t.equal(table.removeRows([0]), false, 'removeRows should no-op');
+  t.equal(table.dataContainer.numRows(), 0, 'should not mutate the empty seed table');
+  t.ok(
+    warnings.some(message => message.includes('DuckDB INSERT')),
+    'should warn that DuckDB INSERT is not implemented'
+  );
+
+  Console.warn = originalWarn;
   t.end();
 });


### PR DESCRIPTION
## Summary
- `addToDataset` / `removeFromDataset` now mutate Arrow tables with primitive columns in place (concat append, keyed upsert, slice remove). DuckDB still warns and no-ops until INSERT exists.
- GeoJSON layers rebuild `dataToFeature` when the table revision or row count changes, so appended features show on the map. Filter-only updates still skip a re-parse.
- Live-data example: **Arrow** and **GeoJSON** remount a matching table; GeoJSON fetches [buildings-australia.geojson](https://raw.githubusercontent.com/keplergl/kepler.gl-data/refs/heads/master/datasets/buildings-australia.geojson) at runtime.

## Test plan
- [x] `yarn test` vis-state + data-container + DuckDB no-op
- [x] `yarn start:live-data` → **Arrow**: Add / Remove last / Insert then Move tracker (row count stays put)
- [x] **GeoJSON**: seed buildings appear; Add 1 / Add 5 draw new footprints; Move tracker swaps `track-01` without growing the table