### PR TITLE
fix(layers): trip layer color-by-field reads correct row in TABLE mode

### DIFF
--- a/src/layers/src/trip-layer/trip-layer-color.spec.ts
+++ b/src/layers/src/trip-layer/trip-layer-color.spec.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import TripLayer from './trip-layer';
+import KeplerTable from '@kepler.gl/table';
+import {ALL_FIELD_TYPES, SCALE_TYPES} from '@kepler.gl/constants';
+
+/**
+ * Build a small taxi-trip table: 3 trips (2 points each) across 3 companies.
+ * Rows are grouped by trip id so that feature index != row index — the first
+ * trip occupies rows 0-1, so reading the color field by feature index would
+ * return the first trip's company for the first two features.
+ */
+async function makeTripTable() {
+  const table = new KeplerTable({color: [255, 0, 0]} as any);
+  await table.importData({
+    data: {
+      rows: [
+        // trip 1 (Uber): 2 points
+        ['t1', 37.77, -122.42, '2024-01-01 00:00:00', 'Uber'],
+        ['t1', 37.78, -122.41, '2024-01-01 00:00:10', 'Uber'],
+        // trip 2 (Lyft): 2 points
+        ['t2', 37.79, -122.4, '2024-01-01 00:00:20', 'Lyft'],
+        ['t2', 37.8, -122.39, '2024-01-01 00:00:30', 'Lyft'],
+        // trip 3 (Waymo): 2 points
+        ['t3', 37.81, -122.38, '2024-01-01 00:00:40', 'Waymo'],
+        ['t3', 37.82, -122.37, '2024-01-01 00:00:50', 'Waymo']
+      ],
+      fields: [
+        {name: 'id', type: ALL_FIELD_TYPES.string},
+        {name: 'latitude', type: ALL_FIELD_TYPES.real},
+        {name: 'longitude', type: ALL_FIELD_TYPES.real},
+        {name: 'timestamp', type: ALL_FIELD_TYPES.timestamp},
+        {name: 'company', type: ALL_FIELD_TYPES.string}
+      ]
+    } as any
+  });
+  return table;
+}
+
+function makeTripLayer(table: KeplerTable) {
+  const layer = new TripLayer({
+    id: 'trip1',
+    dataId: table.id,
+    columnMode: 'table',
+    columns: {
+      id: {value: 'id', fieldIdx: table.fields.findIndex(f => f.name === 'id')},
+      lat: {value: 'latitude', fieldIdx: table.fields.findIndex(f => f.name === 'latitude')},
+      lng: {value: 'longitude', fieldIdx: table.fields.findIndex(f => f.name === 'longitude')},
+      timestamp: {
+        value: 'timestamp',
+        fieldIdx: table.fields.findIndex(f => f.name === 'timestamp')
+      },
+      geojson: {value: null, fieldIdx: -1}
+    }
+  } as any);
+
+  const companyField = table.fields.find(f => f.name === 'company')!;
+  layer.updateLayerConfig({
+    colorField: companyField,
+    colorScale: SCALE_TYPES.customOrdinal,
+    colorDomain: ['Uber', 'Lyft', 'Waymo'],
+    visConfig: {
+      ...layer.config.visConfig,
+      colorRange: {
+        name: 'custom',
+        type: 'customOrdinal',
+        category: 'Custom',
+        colors: ['#000000', '#FF00BF', '#00A86B', '#E82127'],
+        colorMap: [
+          ['Lyft', '#000000'],
+          ['Tesla', '#FF00BF'],
+          ['Uber', '#00A86B'],
+          ['Waymo', '#E82127']
+        ]
+      }
+    }
+  });
+  return layer;
+}
+
+describe('TripLayer TABLE mode color by field', () => {
+  it('getColor accessor maps each trip to its own company color', async () => {
+    const table = await makeTripTable();
+    const layer = makeTripLayer(table);
+
+    layer.updateLayerMeta(table);
+    const layerData = layer.formatLayerData({[table.id]: table}, null);
+
+    // Each feature is a trip; getColor should return the trip's company color,
+    // not the company of the row at the feature index.
+    const colors = layerData.data.map(f => layerData.getColor(f));
+    // Uber -> green [0,168,107], Lyft -> black [0,0,0], Waymo -> red [232,33,39]
+    expect(colors[0]).toEqual([0, 168, 107]);
+    expect(colors[1]).toEqual([0, 0, 0]);
+    expect(colors[2]).toEqual([232, 33, 39]);
+  });
+});

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -653,7 +653,13 @@ export default class TripLayer extends Layer {
         throw new Error(`Unsupported column mode: ${this.config.columnMode}`);
     }
     const indexAccessor = f => f.properties.index;
-    const dataAccessor = dc => d => ({index: d.properties.index});
+    // For GEOJSON mode, properties.index is the row index in the data container.
+    // For TABLE mode, properties.index is the feature index (not a row index), so
+    // read field values from the first row of the trip (properties.values) instead.
+    const dataAccessor =
+      this.config.columnMode === COLUMN_MODE_GEOJSON
+        ? (dc => d => ({index: d.properties.index}))
+        : (() => d => d.properties.values[0]);
     const accessors = this.getAttributeAccessors({dataAccessor, dataContainer});
     const getFilterValue = gpuFilter.filterValueAccessor(dataContainer)(
       indexAccessor,

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -656,10 +656,12 @@ export default class TripLayer extends Layer {
     // For GEOJSON mode, properties.index is the row index in the data container.
     // For TABLE mode, properties.index is the feature index (not a row index), so
     // read field values from the first row of the trip (properties.values) instead.
-    const dataAccessor =
-      this.config.columnMode === COLUMN_MODE_GEOJSON
-        ? (dc => d => ({index: d.properties.index}))
-        : (() => d => d.properties.values[0]);
+    let dataAccessor;
+    if (this.config.columnMode === COLUMN_MODE_GEOJSON) {
+      dataAccessor = dc => d => ({index: d.properties.index});
+    } else {
+      dataAccessor = () => d => d.properties.values[0];
+    }
     const accessors = this.getAttributeAccessors({dataAccessor, dataContainer});
     const getFilterValue = gpuFilter.filterValueAccessor(dataContainer)(
       indexAccessor,
@@ -1039,7 +1041,7 @@ export default class TripLayer extends Layer {
   private _findDatumForFeatureByTime(
     featureIndex: number,
     animationConfig: AnimationConfig,
-    interpolateCoords: boolean = true
+    interpolateCoords = true
   ): DatumForFeatureByTime {
     const {currentTime} = animationConfig ?? {};
     if (notNullorUndefined(currentTime)) {
@@ -1052,10 +1054,7 @@ export default class TripLayer extends Layer {
         return {idx: -1, coords: null, datum: null, prevDatum: null, advancement: 0};
       }
       if (idx >= coordinates.length) idx = coordinates.length - 1;
-      if (
-        timestamps[0] <= currentTime &&
-        currentTime <= timestamps[timestamps.length - 1]
-      ) {
+      if (timestamps[0] <= currentTime && currentTime <= timestamps[timestamps.length - 1]) {
         const datum = coordinates[idx]?.datum;
         let coords = coordinates[idx].slice(0, 3);
         const prevCoords = idx > 0 ? coordinates[idx - 1].slice(0, 3) : null;


### PR DESCRIPTION
It looks like a regression:

## Summary

Fixes the trip layer's color-by-field accessor in TABLE column mode.

In TABLE column mode, each feature's `properties.index` is the **feature index** (trip ordinal), not a row index into the data container. The color accessor was resolving field values via `dc.valueAt(featureIndex, fieldIdx)`, which reads the value at the feature-index row — the wrong trip's value whenever the first trip spans more rows than the feature count. When the first trip has many points, every trip resolves to the first trip's category (e.g. all green for an Uber-leading dataset).

## Change

Read field values from the trip's first row (`d.properties.values[0]`) in TABLE mode, matching the behavior of `efb072eb` that `9194faaf` reverted. GEOJSON mode keeps resolving by row index.

## Tests

Adds `trip-layer-color.spec.ts` covering the TABLE-mode color accessor. Verified passing on `master`:

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```

> Note: this is a cherry-pick of `d794b817` from the `xli-kepler-mcp` branch, which is not being merged for now.