### PR TITLE
fix: geojson stroke color via config

### DIFF
--- a/src/reducers/src/vis-state-merger.ts
+++ b/src/reducers/src/vis-state-merger.ts
@@ -992,6 +992,29 @@ export function validateSavedTextLabel(
 }
 
 /**
+ * Saved visual channel field/scale may live in any of:
+ * - `config[key]` after schema parse (VisualChannelSchemaV1 folds channels into config)
+ * - `visualChannels[key]` as a sibling of `config` (unparsed addDataToMap payload)
+ * - `config.visualChannels[key]` (common mistake of nesting visualChannels inside config)
+ *
+ * Without this lookup, programmatic GeoJSON strokeColorField never binds and
+ * strokeColorDomain stays at the default `[0, 1]` (kepler.gl #3061).
+ */
+function getSavedVisualChannelValue(savedLayer: ParsedLayer, key: string): any {
+  const config = savedLayer.config as Record<string, any> | undefined;
+  if (config && config[key] !== undefined) {
+    return config[key];
+  }
+  const channels =
+    (savedLayer as {visualChannels?: Record<string, any>}).visualChannels ||
+    (config && config.visualChannels);
+  if (channels && typeof channels === 'object' && channels[key] !== undefined) {
+    return channels[key];
+  }
+  return undefined;
+}
+
+/**
  * Validate saved visual channels config with new data,
  * refer to vis-state-schema.js VisualChannelSchemaV1
  */
@@ -1002,28 +1025,26 @@ export function validateSavedVisualChannels(
   options: {throwOnError?: boolean} = {}
 ): null | Layer {
   Object.values(newLayer.visualChannels).forEach(({field, scale, key}) => {
+    const savedField = getSavedVisualChannelValue(savedLayer, field);
+    const savedScale = getSavedVisualChannelValue(savedLayer, scale);
     let foundField;
-    if (savedLayer.config) {
-      if (savedLayer.config[field]) {
-        foundField = fields.find(
-          fd => savedLayer.config && fd.name === savedLayer.config[field].name
-        );
-      }
+    if (savedField?.name) {
+      foundField = fields.find(fd => fd.name === savedField.name);
+    }
 
-      const foundChannel = {
-        ...(foundField ? {[field]: foundField} : {}),
-        ...(savedLayer.config[scale] ? {[scale]: savedLayer.config[scale]} : {})
-      };
-      if (Object.keys(foundChannel).length) {
-        newLayer.updateLayerConfig(foundChannel);
-      }
+    const foundChannel = {
+      ...(foundField ? {[field]: foundField} : {}),
+      ...(savedScale ? {[scale]: savedScale} : {})
+    };
+    if (Object.keys(foundChannel).length) {
+      newLayer.updateLayerConfig(foundChannel);
+    }
 
-      newLayer.validateVisualChannel(key);
-      if (options.throwOnError) {
-        const fieldName = savedLayer.config?.[field]?.name;
-        if (fieldName && fieldName !== newLayer.config[field]?.name) {
-          throw new Error(`Layer has invalid visual channel field: ${field}`);
-        }
+    newLayer.validateVisualChannel(key);
+    if (options.throwOnError) {
+      const fieldName = savedField?.name;
+      if (fieldName && fieldName !== newLayer.config[field]?.name) {
+        throw new Error(`Layer has invalid visual channel field: ${field}`);
       }
     }
   });

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -1060,6 +1060,34 @@ export function layerTypeChangeUpdater(
 }
 
 /**
+ * Bind visual channel fields to the dataset field of the same name.
+ * `addDataToMap` and `layerVisualChannelConfigChange` often pass `{name, type}`
+ * or processor fields whose valueAccessor is not bound to the KeplerTable, which
+ * leaves strokeColorDomain at `[0, 1]` (kepler.gl #3061).
+ */
+function resolveVisualChannelFieldFromDataset(
+  newConfig: VisStateActions.LayerVisualChannelConfigChangeUpdaterAction['newConfig'],
+  dataset: KeplerTable | undefined,
+  visualChannel: Layer['visualChannels'][string] | undefined
+) {
+  if (!dataset || !visualChannel) {
+    return newConfig;
+  }
+  const incoming = newConfig[visualChannel.field];
+  if (!incoming || typeof incoming !== 'object' || !incoming.name) {
+    return newConfig;
+  }
+  const found = dataset.fields.find(fd => fd.name === incoming.name);
+  if (!found) {
+    return newConfig;
+  }
+  return {
+    ...newConfig,
+    [visualChannel.field]: found
+  };
+}
+
+/**
  * Update layer visual channel
  * @memberof visStateUpdaters
  * @returns {Object} nextState
@@ -1069,12 +1097,17 @@ export function layerVisualChannelChangeUpdater(
   state: VisState,
   action: VisStateActions.LayerVisualChannelConfigChangeUpdaterAction
 ): VisState {
-  const {oldLayer, newConfig, newVisConfig, channel} = action;
+  const {oldLayer, newVisConfig, channel} = action;
   if (!oldLayer.config.dataId) {
     return state;
   }
 
   const dataset = state.datasets[oldLayer.config.dataId];
+  const newConfig = resolveVisualChannelFieldFromDataset(
+    action.newConfig,
+    dataset,
+    oldLayer.visualChannels[channel]
+  );
 
   const idx = state.layers.findIndex(l => l.id === oldLayer.id);
   let newLayer = oldLayer.updateLayerConfig(newConfig);

--- a/test/node/reducers/geojson-stroke-color-config.spec.js
+++ b/test/node/reducers/geojson-stroke-color-config.spec.js
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+// Programmatic GeoJSON stroke color (addDataToMap visualChannels +
+// layerVisualChannelConfigChange with {name, type}) must bind the dataset
+// field so strokeColorDomain is calculated from data, not left at [0, 1].
+
+import {drainTasksForTesting, succeedTaskWithValues} from '@kepler.gl/tasks';
+import {KeplerTable} from '@kepler.gl/table';
+import {VisStateActions} from '@kepler.gl/actions';
+import {visStateReducer, INITIAL_VIS_STATE, validateLayerWithData} from '@kepler.gl/reducers';
+import {processGeojson} from '@kepler.gl/processors';
+import cloneDeep from 'es-toolkit/compat/cloneDeep';
+
+import {geojsonData} from '../../fixtures/geojson';
+
+const reducer = visStateReducer;
+
+const mockCreateNewDataEntry = ({info, color, opts, data}) => {
+  const table = new KeplerTable({info, color, ...opts});
+  table.importData({data});
+  return table;
+};
+
+const applyCreateTableTasks = (tasks, state) =>
+  tasks.reduce((acc, task) => {
+    if (!task.label.includes('CREATE_TABLE_TASK')) return acc;
+    const tables = task.payload.map(payload => mockCreateNewDataEntry(payload));
+    return reducer(acc, succeedTaskWithValues(task, tables));
+  }, state);
+
+function applyAction(state, action) {
+  let newState = reducer(state, action);
+  const tasks = drainTasksForTesting();
+  newState = applyCreateTableTasks(tasks, newState);
+  return newState;
+}
+
+describe('geojson strokeColor programmatic config', () => {
+  let fields;
+  let rows;
+  let dataset;
+
+  beforeAll(async () => {
+    ({fields, rows} = processGeojson(cloneDeep(geojsonData)));
+    dataset = new KeplerTable({info: {id: 'traffic-data'}});
+    await dataset.importData({data: {fields, rows}});
+  });
+
+  test('validateLayerWithData binds strokeColorField nested inside config', () => {
+    const nestedConfig = {
+      id: 'traffic-layer-nested',
+      type: 'geojson',
+      config: {
+        dataId: 'traffic-data',
+        label: 'Traffic Layer',
+        columns: {geojson: '_geojson'},
+        isVisible: true,
+        visConfig: {stroked: true, filled: false},
+        visualChannels: {
+          strokeColorField: {name: 'TRIPS', type: 'integer'},
+          strokeColorScale: 'quantize'
+        }
+      }
+    };
+
+    const layer = validateLayerWithData(dataset, nestedConfig, INITIAL_VIS_STATE.layerClasses);
+    expect(layer).toBeTruthy();
+    expect(layer.config.strokeColorField?.name).toBe('TRIPS');
+    expect(layer.config.strokeColorScale).toBe('quantize');
+    layer.updateLayerDomain({'traffic-data': dataset});
+    expect(layer.config.strokeColorDomain).toEqual([4, 20]);
+  });
+
+  test('validateLayerWithData binds sibling visualChannels without schema parse', () => {
+    const siblingConfig = {
+      id: 'traffic-layer-sibling',
+      type: 'geojson',
+      config: {
+        dataId: 'traffic-data',
+        label: 'Traffic Layer',
+        columns: {geojson: '_geojson'},
+        isVisible: true,
+        visConfig: {stroked: true, filled: false}
+      },
+      visualChannels: {
+        strokeColorField: {name: 'TRIPS', type: 'integer'},
+        strokeColorScale: 'quantize'
+      }
+    };
+
+    const layer = validateLayerWithData(dataset, siblingConfig, INITIAL_VIS_STATE.layerClasses);
+    expect(layer.config.strokeColorField?.name).toBe('TRIPS');
+    layer.updateLayerDomain({'traffic-data': dataset});
+    expect(layer.config.strokeColorDomain).toEqual([4, 20]);
+  });
+
+  test('layerVisualChannelConfigChange resolves {name, type} to dataset field', () => {
+    const initialState = applyAction(
+      {...INITIAL_VIS_STATE},
+      VisStateActions.updateVisData([
+        {
+          info: {id: 'traffic-data', label: 'Traffic Data'},
+          data: {fields, rows}
+        }
+      ])
+    );
+
+    const geojsonLayer = initialState.layers.find(l => l.type === 'geojson');
+    expect(geojsonLayer).toBeTruthy();
+
+    const nextState = reducer(
+      initialState,
+      VisStateActions.layerVisualChannelConfigChange(
+        geojsonLayer,
+        {
+          strokeColorField: {name: 'TRIPS', type: 'integer'},
+          strokeColorScale: 'quantize'
+        },
+        'strokeColor'
+      )
+    );
+
+    const updated = nextState.layers.find(l => l.id === geojsonLayer.id);
+    expect(updated.config.strokeColorField?.name).toBe('TRIPS');
+    expect(typeof updated.config.strokeColorField?.valueAccessor).toBe('function');
+    expect(updated.config.strokeColorScale).toBe('quantize');
+    expect(updated.config.strokeColorDomain).toEqual([4, 20]);
+  });
+
+  test('layerVisualChannelConfigChange resolves processGeojson fields', () => {
+    const processorField = fields.find(f => f.name === 'TRIPS');
+    expect(processorField).toBeTruthy();
+
+    const initialState = applyAction(
+      {...INITIAL_VIS_STATE},
+      VisStateActions.updateVisData([
+        {
+          info: {id: 'traffic-data', label: 'Traffic Data'},
+          data: {fields, rows}
+        }
+      ])
+    );
+    const geojsonLayer = initialState.layers.find(l => l.type === 'geojson');
+
+    const nextState = reducer(
+      initialState,
+      VisStateActions.layerVisualChannelConfigChange(
+        geojsonLayer,
+        {strokeColorField: {...processorField}, strokeColorScale: 'quantize'},
+        'strokeColor'
+      )
+    );
+
+    expect(nextState.layers.find(l => l.id === geojsonLayer.id).config.strokeColorDomain).toEqual([
+      4, 20
+    ]);
+  });
+});

--- a/test/node/reducers/vis-state-test.js
+++ b/test/node/reducers/vis-state-test.js
@@ -488,7 +488,7 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.2', async t => {
     })
   );
   const newLayer = nextState.layers[0];
-  t.equal(newLayer.config.colorField, stringField, 'should update colorField');
+  t.equal(newLayer.config.colorField.name, stringField.name, 'should update colorField');
   t.equal(newLayer.config.colorScale, 'ordinal', 'should scale to ordinal');
   t.deepEqual(
     newLayer.config.colorDomain,
@@ -511,7 +511,7 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.2', async t => {
     })
   );
   const newLayer2 = nextState2.layers[0];
-  t.equal(newLayer2.config.sizeField, intField, 'should update sizeField');
+  t.equal(newLayer2.config.sizeField.name, intField.name, 'should update sizeField');
   t.equal(newLayer2.config.sizeScale, 'sqrt', 'should scale to sqrt');
   t.deepEqual(newLayer2.config.sizeDomain, [1, 12124], 'should calculate size domain');
   t.deepEqual(newLayer2.config.visConfig.radiusRange, [5, 10], 'should update size range');
@@ -521,7 +521,7 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.2', async t => {
 
   const newLayer3 = nextState3.layers[0];
   t.equal(newLayer3.type, 'hexagon', 'should change type to hexagon');
-  t.equal(newLayer3.config.colorField, stringField, 'should keep colorField');
+  t.equal(newLayer3.config.colorField.name, stringField.name, 'should keep colorField');
   t.deepEqual(
     newLayer3.config.colorDomain,
     [0, 1],
@@ -530,7 +530,7 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.2', async t => {
   t.equal(newLayer3.config.colorScale, 'ordinal', 'should set colorScale to ordinal');
   t.equal(newLayer3.config.sizeScale, 'sqrt', 'should set sizeScale to default');
   t.deepEqual(newLayer3.config.sizeDomain, [0, 1], 'should set sizeDomain to default');
-  t.equal(newLayer3.config.sizeField, intField, 'should keep sizeField');
+  t.equal(newLayer3.config.sizeField.name, intField.name, 'should keep sizeField');
   t.notEqual(newLayer3.id, newLayer2.id, 'should change id');
   t.equal(newLayer3.config.visConfig.colorRange, mockColorRange, 'should not deep copy colorRange');
   t.equal(
@@ -544,14 +544,14 @@ test('#visStateReducer -> LAYER_TYPE_CHANGE.2', async t => {
   const newLayer4 = nextState4.layers[0];
   t.equal(newLayer4.type, 'icon', 'should change type to icon');
   t.notEqual(newLayer4.id, newLayer2.id, 'should change id');
-  t.equal(newLayer4.config.colorField, stringField, 'should keep colorField');
+  t.equal(newLayer4.config.colorField.name, stringField.name, 'should keep colorField');
   t.deepEqual(
     newLayer4.config.colorDomain,
     ['driver_analytics', 'driver_analytics_0', 'driver_gps'],
     'should calculate color domain'
   );
   t.equal(newLayer4.config.colorScale, 'ordinal', 'should keep color scale');
-  t.equal(newLayer4.config.sizeField, intField, 'should keep sizeField');
+  t.equal(newLayer4.config.sizeField.name, intField.name, 'should keep sizeField');
   t.equal(newLayer4.config.sizeScale, 'sqrt', 'should scale to linear');
   t.deepEqual(newLayer4.config.sizeDomain, [1, 12124], 'should keep size domain');
   t.deepEqual(newLayer4.config.visConfig.radiusRange, [5, 10], 'should keep size range');


### PR DESCRIPTION
## Summary
Bind GeoJSON `strokeColorField` when loading a layer from config or dispatching `layerVisualChannelConfigChange`, so programmatic line colors work instead of leaving `strokeColorDomain` at `[0, 1]`.

Closes [#3061](https://github.com/keplergl/kepler.gl/issues/3061).

This PR shoudn't cause any issues with existing configs.

## Test plan
- [x] `addDataToMap` a GeoJSON line layer with `visualChannels.strokeColorField` (sibling of `config`, or nested inside it)
- [x] Dispatch `layerVisualChannelConfigChange` with `{name, type}` only and confirm colors apply
- [x] Confirm stroke color domain is computed from the data, not `[0, 1]`
- [x] Side-panel “Stroke Color Based On” still works as before