### PR TITLE
feat: warn before slow grid/hexagon aggregation

### DIFF
--- a/src/components/src/side-panel/layer-panel/aggregation-size-warning.tsx
+++ b/src/components/src/side-panel/layer-panel/aggregation-size-warning.tsx
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import React from 'react';
+import styled from 'styled-components';
+import {FormattedMessage} from '@kepler.gl/localization';
+import {Button} from '../../common/styled-components';
+
+const WarningBox = styled.div`
+  margin-top: 8px;
+  padding: 8px 10px;
+  border-radius: 2px;
+  background-color: ${props => props.theme.panelBackgroundHover};
+  color: ${props => props.theme.textColor};
+  font-size: 11px;
+  line-height: 16px;
+`;
+
+const WarningText = styled.div`
+  color: ${props => props.theme.warningColor || props.theme.errorColor || props.theme.textColorHl};
+`;
+
+const Actions = styled.div`
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+  justify-content: flex-end;
+`;
+
+export type AggregationSizeWarningProps = {
+  cellCount: number;
+  onCancel?: () => void;
+  onConfirm?: () => void;
+  requireConfirm?: boolean;
+};
+
+function formatCells(n: number): string {
+  return Math.round(n).toLocaleString();
+}
+
+export const AggregationSizeWarning: React.FC<AggregationSizeWarningProps> = ({
+  cellCount,
+  onCancel,
+  onConfirm,
+  requireConfirm = false
+}) => (
+  <WarningBox className="aggregation-size-warning">
+    <WarningText>
+      <FormattedMessage
+        id="layer.aggregationSize.slow"
+        defaultMessage="The layer aggregation may be slow with up to {cells} cells"
+        values={{cells: formatCells(cellCount)}}
+      />
+    </WarningText>
+    {requireConfirm && onConfirm ? (
+      <Actions>
+        {onCancel ? (
+          <Button secondary small type="button" onClick={onCancel}>
+            <FormattedMessage id="layer.aggregationSize.cancel" defaultMessage="Cancel" />
+          </Button>
+        ) : null}
+        <Button small type="button" onClick={onConfirm}>
+          <FormattedMessage id="layer.aggregationSize.continue" defaultMessage="Continue" />
+        </Button>
+      </Actions>
+    ) : null}
+  </WarningBox>
+);
+
+export default AggregationSizeWarning;

--- a/src/components/src/side-panel/layer-panel/aggregation-world-unit-size-control.tsx
+++ b/src/components/src/side-panel/layer-panel/aggregation-world-unit-size-control.tsx
@@ -37,7 +37,6 @@ export default function AggregationWorldUnitSizeControl({
     () => estimateAggregationCellCount(bounds, draft, kind, pointCount || undefined),
     [bounds, draft, kind, pointCount]
   );
-  const dangerous = isAggregationCellCountSlow(cellCount, pointCount);
 
   const sliderLayer = useMemo(
     () => ({
@@ -90,9 +89,9 @@ export default function AggregationWorldUnitSizeControl({
         layer={sliderLayer as Layer}
         onChange={onSliderChange}
       />
-      {pendingConfirm && dangerous && cellCount != null ? (
+      {pendingConfirm ? (
         <AggregationSizeWarning
-          cellCount={cellCount}
+          cellCount={cellCount ?? 0}
           requireConfirm
           onCancel={onCancel}
           onConfirm={onConfirm}

--- a/src/components/src/side-panel/layer-panel/aggregation-world-unit-size-control.tsx
+++ b/src/components/src/side-panel/layer-panel/aggregation-world-unit-size-control.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import {Layer, estimateAggregationCellCount, isAggregationCellCountSlow} from '@kepler.gl/layers';
+import AggregationSizeWarning from './aggregation-size-warning';
+import VisConfigSliderFactory from './vis-config-slider';
+
+type VisConfigSlider = ReturnType<typeof VisConfigSliderFactory>;
+
+type AggregationWorldUnitSizeControlProps = {
+  layer: Layer;
+  VisConfigSlider: VisConfigSlider;
+  visConfiguratorProps: any;
+  pointCount?: number;
+};
+
+export default function AggregationWorldUnitSizeControl({
+  layer,
+  VisConfigSlider,
+  visConfiguratorProps,
+  pointCount = 0
+}: AggregationWorldUnitSizeControlProps) {
+  const committed = layer.config.visConfig.worldUnitSize as number;
+  const kind = (layer.type === 'hexagon' ? 'hexagon' : 'grid') as 'grid' | 'hexagon';
+  const bounds = layer.meta?.bounds as number[] | undefined;
+
+  const [draft, setDraft] = useState(committed);
+  const [pendingConfirm, setPendingConfirm] = useState(false);
+
+  useEffect(() => {
+    setDraft(committed);
+    setPendingConfirm(false);
+  }, [committed]);
+
+  const cellCount = useMemo(
+    () => estimateAggregationCellCount(bounds, draft, kind, pointCount || undefined),
+    [bounds, draft, kind, pointCount]
+  );
+  const dangerous = isAggregationCellCountSlow(cellCount, pointCount);
+
+  const sliderLayer = useMemo(
+    () => ({
+      config: {
+        ...layer.config,
+        visConfig: {
+          ...layer.config.visConfig,
+          worldUnitSize: draft
+        }
+      }
+    }),
+    [layer.config, draft]
+  );
+
+  const onSliderChange = useCallback(
+    (v: Record<string, number | string | number[] | string[]>) => {
+      const next = v.worldUnitSize as number;
+      setDraft(next);
+      const nextCount = estimateAggregationCellCount(bounds, next, kind, pointCount || undefined);
+      const committedCount =
+        estimateAggregationCellCount(bounds, committed, kind, pointCount || undefined) || 0;
+      if (
+        isAggregationCellCountSlow(nextCount, pointCount) &&
+        (nextCount as number) > committedCount
+      ) {
+        setPendingConfirm(true);
+        return;
+      }
+      setPendingConfirm(false);
+      visConfiguratorProps.onChange({worldUnitSize: next});
+    },
+    [bounds, kind, committed, pointCount, visConfiguratorProps]
+  );
+
+  const onCancel = useCallback(() => {
+    setDraft(committed);
+    setPendingConfirm(false);
+  }, [committed]);
+
+  const onConfirm = useCallback(() => {
+    setPendingConfirm(false);
+    visConfiguratorProps.onChange({worldUnitSize: draft});
+  }, [draft, visConfiguratorProps]);
+
+  return (
+    <>
+      <VisConfigSlider
+        {...layer.visConfigSettings.worldUnitSize}
+        {...visConfiguratorProps}
+        layer={sliderLayer as Layer}
+        onChange={onSliderChange}
+      />
+      {pendingConfirm && dangerous && cellCount != null ? (
+        <AggregationSizeWarning
+          cellCount={cellCount}
+          requireConfirm
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/components/src/side-panel/layer-panel/layer-configurator.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-configurator.tsx
@@ -30,6 +30,7 @@ import LayerErrorMessage from './layer-error-message';
 import LayerTypeSelectorFactory from './layer-type-selector';
 import TextLabelPanelFactory from './text-label-panel';
 import VisConfigSliderFactory from './vis-config-slider';
+import AggregationWorldUnitSizeControl from './aggregation-world-unit-size-control';
 import VisConfigSwitchFactory from './vis-config-switch';
 import ScenegraphModelSelectorFactory, {
   ScenegraphCustomModelUrlInput
@@ -674,7 +675,7 @@ export default function LayerConfiguratorFactory(
       return this._renderAggregationLayerConfig(props);
     }
 
-    _renderAggregationLayerConfig({layer, visConfiguratorProps, layerChannelConfigProps}) {
+    _renderAggregationLayerConfig({layer, dataset, visConfiguratorProps, layerChannelConfigProps}) {
       const {config} = layer;
       const {
         visConfig: {enable3d, fixedHeight}
@@ -715,7 +716,12 @@ export default function LayerConfiguratorFactory(
 
           {/* Cell size */}
           <LayerConfigGroup label={'layer.radius'} collapsible>
-            <VisConfigSlider {...layer.visConfigSettings.worldUnitSize} {...visConfiguratorProps} />
+            <AggregationWorldUnitSizeControl
+              layer={layer}
+              VisConfigSlider={VisConfigSlider}
+              visConfiguratorProps={visConfiguratorProps}
+              pointCount={dataset?.filteredIndex?.length ?? dataset?.length ?? 0}
+            />
             <ConfigGroupCollapsibleContent>
               <VisConfigSlider {...layer.visConfigSettings.coverage} {...visConfiguratorProps} />
             </ConfigGroupCollapsibleContent>

--- a/src/components/src/side-panel/layer-panel/layer-panel.tsx
+++ b/src/components/src/side-panel/layer-panel/layer-panel.tsx
@@ -12,12 +12,19 @@ import {FormattedMessage} from '@kepler.gl/localization';
 import styled from 'styled-components';
 
 import {ActionHandler, MapStateActions, VisStateActions, toggleModal} from '@kepler.gl/actions';
-import {dataTestIds, GLOBE_SUPPORTED_LAYERS} from '@kepler.gl/constants';
-import {Layer, LayerBaseConfig} from '@kepler.gl/layers';
+import {dataTestIds, GLOBE_SUPPORTED_LAYERS, LAYER_TYPES} from '@kepler.gl/constants';
+import {
+  Layer,
+  LayerBaseConfig,
+  estimateAggregationCellCount,
+  getLayerPointCount,
+  isAggregationCellCountSlow
+} from '@kepler.gl/layers';
 import {Datasets} from '@kepler.gl/table';
 import {ColorUI, LayerVisConfig, MapState, NestedPartial, SplitMap} from '@kepler.gl/types';
 import LayerConfiguratorFactory from './layer-configurator';
 import LayerPanelHeaderFactory from './layer-panel-header';
+import AggregationSizeWarning from './aggregation-size-warning';
 
 type LayerPanelProps = {
   className?: string;
@@ -64,16 +71,46 @@ const PanelWrapper = styled.div`
 
 LayerPanelFactory.deps = [LayerConfiguratorFactory, LayerPanelHeaderFactory];
 
+type LayerPanelState = {
+  typeWarning: {
+    cellCount: number;
+    nextType: string;
+  } | null;
+};
+
 function LayerPanelFactory(
   LayerConfigurator: ReturnType<typeof LayerConfiguratorFactory>,
   LayerPanelHeader: ReturnType<typeof LayerPanelHeaderFactory>
 ): React.ComponentType<LayerPanelProps> {
-  class LayerPanel extends Component<LayerPanelProps> {
+  class LayerPanel extends Component<LayerPanelProps, LayerPanelState> {
+    state: LayerPanelState = {typeWarning: null};
+
     updateLayerConfig = (newProp: Partial<LayerBaseConfig>) => {
       this.props.layerConfigChange(this.props.layer, newProp);
     };
 
     updateLayerType = (newType: string) => {
+      if (newType === LAYER_TYPES.grid || newType === LAYER_TYPES.hexagon) {
+        const sizeKm = Number(this.props.layer.config.visConfig?.worldUnitSize) || 1;
+        const dataset = this.props.datasets[this.props.layer.config.dataId || ''];
+        const pointCount = getLayerPointCount(dataset);
+        const cellCount = estimateAggregationCellCount(
+          this.props.layer.meta?.bounds,
+          sizeKm,
+          newType,
+          pointCount
+        );
+        if (isAggregationCellCountSlow(cellCount, pointCount)) {
+          this.setState({
+            typeWarning: {
+              cellCount: cellCount as number,
+              nextType: newType
+            }
+          });
+          return;
+        }
+      }
+      this.setState({typeWarning: null});
       this.props.layerTypeChange(this.props.layer, newType);
     };
 
@@ -184,6 +221,22 @@ function LayerPanelFactory(
             isDragNDropEnabled={isDraggable}
             listeners={listeners}
           />
+          {this.state.typeWarning ? (
+            <div style={{padding: '0 12px 8px'}}>
+              <AggregationSizeWarning
+                cellCount={this.state.typeWarning.cellCount}
+                requireConfirm
+                onCancel={() => this.setState({typeWarning: null})}
+                onConfirm={() => {
+                  const nextType = this.state.typeWarning?.nextType;
+                  this.setState({typeWarning: null});
+                  if (nextType) {
+                    this.props.layerTypeChange(this.props.layer, nextType);
+                  }
+                }}
+              />
+            </div>
+          ) : null}
           {isConfigActive && (
             <LayerConfigurator
               layer={layer}

--- a/src/layers/src/aggregation-cell-count.spec.ts
+++ b/src/layers/src/aggregation-cell-count.spec.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {
+  AGGREGATION_CELL_COUNT_WARNING_THRESHOLD,
+  estimateAggregationCellCount,
+  estimateBboxAggregationCellCount,
+  isAggregationCellCountSlow
+} from './aggregation-cell-count';
+
+describe('aggregation-cell-count', () => {
+  const sfBounds = [-122.52, 37.7, -122.35, 37.84];
+
+  test('returns null for missing bounds or invalid size', () => {
+    expect(estimateBboxAggregationCellCount(null, 1)).toBeNull();
+    expect(estimateAggregationCellCount(null, 1)).toBeNull();
+    expect(estimateAggregationCellCount(sfBounds, 0)).toBeNull();
+    expect(estimateAggregationCellCount(sfBounds, -1)).toBeNull();
+  });
+
+  test('grid cell count grows as cell size shrinks', () => {
+    const at1km = estimateBboxAggregationCellCount(sfBounds, 1, 'grid') as number;
+    const at01km = estimateBboxAggregationCellCount(sfBounds, 0.1, 'grid') as number;
+    expect(at1km).toBeGreaterThan(0);
+    expect(at01km / at1km).toBeGreaterThan(50);
+    expect(isAggregationCellCountSlow(at1km)).toBe(false);
+  });
+
+  test('occupied count is capped by the number of points', () => {
+    const bayArea = [-123.1, 36.9, -121.5, 38.5];
+    const bbox = estimateBboxAggregationCellCount(bayArea, 0.01, 'grid') as number;
+    expect(bbox).toBeGreaterThan(1_000_000);
+    expect(estimateAggregationCellCount(bayArea, 0.01, 'grid', 50_000)).toBe(50_000);
+    expect(estimateAggregationCellCount(bayArea, 0.01, 'grid', 1000)).toBe(1000);
+  });
+
+  test('does not warn for tens of thousands of points', () => {
+    const bayArea = [-123.1, 36.9, -121.5, 38.5];
+    expect(isAggregationCellCountSlow(22_652, 22_652)).toBe(false);
+    expect(isAggregationCellCountSlow(50_000, 50_000)).toBe(false);
+    expect(
+      isAggregationCellCountSlow(
+        estimateAggregationCellCount(bayArea, 0.01, 'grid', 50_000),
+        50_000
+      )
+    ).toBe(false);
+  });
+
+  test('warns only when both points and occupied cells are large', () => {
+    expect(isAggregationCellCountSlow(100_000, 100_000)).toBe(true);
+    expect(isAggregationCellCountSlow(500, 200_000)).toBe(false);
+    expect(isAggregationCellCountSlow(200_000, 200_000)).toBe(true);
+    expect(100_000).toBe(AGGREGATION_CELL_COUNT_WARNING_THRESHOLD);
+  });
+
+  test('occupied count is the bbox count when cells are coarser than the point set', () => {
+    const count = estimateAggregationCellCount(sfBounds, 50, 'grid', 1_000_000) as number;
+    expect(count).toBeLessThan(100);
+  });
+
+  test('hexagon count is on the same order as the grid for the same radius', () => {
+    const grid = estimateBboxAggregationCellCount(sfBounds, 0.5, 'grid') as number;
+    const hex = estimateBboxAggregationCellCount(sfBounds, 0.5, 'hexagon') as number;
+    expect(hex).toBeGreaterThan(0);
+    expect(hex / grid).toBeGreaterThan(0.3);
+    expect(hex / grid).toBeLessThan(3);
+  });
+});

--- a/src/layers/src/aggregation-cell-count.ts
+++ b/src/layers/src/aggregation-cell-count.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+export const AGGREGATION_CELL_COUNT_WARNING_THRESHOLD = 20_000;
+
+export type AggregationBinType = 'grid' | 'hexagon';
+
+const KM_PER_DEG_LAT = 110.574;
+
+/**
+ * Approximate number of grid / hexagon cells that would cover a lng/lat bounding
+ * box at the given cell size (km). This counts empty cells too and can be huge
+ * when the data extent is large; deck.gl only creates occupied bins.
+ *
+ * bounds: [minLng, minLat, maxLng, maxLat]
+ */
+export function estimateBboxAggregationCellCount(
+  bounds: number[] | null | undefined,
+  cellSizeKm: number,
+  binType: AggregationBinType = 'grid'
+): number | null {
+  if (!bounds || bounds.length < 4) return null;
+  if (!Number.isFinite(cellSizeKm) || cellSizeKm <= 0) return null;
+
+  const [minLng, minLat, maxLng, maxLat] = bounds;
+  if (![minLng, minLat, maxLng, maxLat].every(Number.isFinite)) return null;
+  if (maxLng <= minLng || maxLat <= minLat) return null;
+
+  const midLat = (minLat + maxLat) / 2;
+  const kmPerDegLng = 111.32 * Math.cos((midLat * Math.PI) / 180);
+  const widthKm = (maxLng - minLng) * Math.abs(kmPerDegLng);
+  const heightKm = (maxLat - minLat) * KM_PER_DEG_LAT;
+
+  if (binType === 'hexagon') {
+    // Pointy-top hexagon area for radius r: (3 * sqrt(3) / 2) * r^2
+    const hexAreaKm2 = 1.5 * Math.sqrt(3) * cellSizeKm * cellSizeKm;
+    if (hexAreaKm2 <= 0) return null;
+    return Math.max(1, Math.ceil((widthKm * heightKm) / hexAreaKm2));
+  }
+
+  const cols = Math.max(1, Math.ceil(widthKm / cellSizeKm));
+  const rows = Math.max(1, Math.ceil(heightKm / cellSizeKm));
+  return cols * rows;
+}
+
+/**
+ * Upper bound on cells the aggregation will actually create: occupied bins only,
+ * so never more than the point count.
+ */
+export function estimateAggregationCellCount(
+  bounds: number[] | null | undefined,
+  cellSizeKm: number,
+  binType: AggregationBinType = 'grid',
+  pointCount?: number
+): number | null {
+  const bboxCount = estimateBboxAggregationCellCount(bounds, cellSizeKm, binType);
+  const points =
+    typeof pointCount === 'number' && Number.isFinite(pointCount) && pointCount >= 0
+      ? Math.floor(pointCount)
+      : null;
+
+  if (bboxCount == null) {
+    return points && points > 0 ? points : null;
+  }
+  if (points == null || points <= 0) {
+    return bboxCount;
+  }
+  return Math.min(bboxCount, points);
+}
+
+/**
+ * Warn only for large point sets that would also produce many occupied bins.
+ * ~20k points is still fast at any radius; cost shows up around 100k+ occupied cells.
+ */
+export function isAggregationCellCountSlow(
+  cellCount: number | null | undefined,
+  pointCount?: number
+): boolean {
+  if (typeof cellCount !== 'number') return false;
+  const points = typeof pointCount === 'number' && pointCount > 0 ? pointCount : cellCount;
+  return (
+    points >= AGGREGATION_CELL_COUNT_WARNING_THRESHOLD &&
+    cellCount >= AGGREGATION_CELL_COUNT_WARNING_THRESHOLD
+  );
+}
+
+export function getLayerPointCount(
+  dataset:
+    | {
+        filteredIndex?: ArrayLike<unknown>;
+        length?: number;
+      }
+    | null
+    | undefined
+): number {
+  if (!dataset) return 0;
+  if (dataset.filteredIndex && typeof dataset.filteredIndex.length === 'number') {
+    return dataset.filteredIndex.length;
+  }
+  return typeof dataset.length === 'number' ? dataset.length : 0;
+}

--- a/src/layers/src/aggregation-cell-count.ts
+++ b/src/layers/src/aggregation-cell-count.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-export const AGGREGATION_CELL_COUNT_WARNING_THRESHOLD = 20_000;
+export const AGGREGATION_CELL_COUNT_WARNING_THRESHOLD = 100_000;
 
 export type AggregationBinType = 'grid' | 'hexagon';
 

--- a/src/layers/src/index.ts
+++ b/src/layers/src/index.ts
@@ -175,6 +175,14 @@ export const EditorLayerUtils = {
 };
 
 export {getFilterDataFunc} from './aggregation-layer';
+export {
+  AGGREGATION_CELL_COUNT_WARNING_THRESHOLD,
+  estimateAggregationCellCount,
+  estimateBboxAggregationCellCount,
+  getLayerPointCount,
+  isAggregationCellCountSlow
+} from './aggregation-cell-count';
+export type {AggregationBinType} from './aggregation-cell-count';
 
 export * from './layer-update';
 export * from './layer-utils';

--- a/src/localization/src/translations/en.ts
+++ b/src/localization/src/translations/en.ts
@@ -152,7 +152,12 @@ export default {
       'An error occurred during layer update: {errorMessage}. Make sure the format of the input data is valid.',
     interaction: 'Interaction',
     heatmap: 'Heatmap',
-    aggregation: 'Aggregation'
+    aggregation: 'Aggregation',
+    aggregationSize: {
+      slow: 'The layer aggregation may be slow with up to {cells} cells',
+      continue: 'Continue',
+      cancel: 'Cancel'
+    }
   },
   layerVisConfigs: {
     angle: 'Angle',


### PR DESCRIPTION
## Summary
- Show a confirm when changing grid size, hexagon radius, or switching to a grid/hexagon layer would produce about 100k+ occupied cells.
- Aggregation is unchanged: the warning is opt-in UX so a tiny radius on a large dataset is less likely to freeze the UI by surprise.

## Related issues
- Related to https://github.com/keplergl/kepler.gl/issues/2935 (`[Bug] Keple.gl freezes when layer is changed to grid layer`).

<img width="861" height="520" alt="Screenshot 2026-09-07 at 1 20 20 AM" src="https://github.com/user-attachments/assets/af9111af-f978-4bf1-be0e-129b4ee56973" />

**This PR does not close #2935.** The freeze is still there if the user continues, or if a saved map already uses a small cell size.

## Not in this PR
- No worker / async aggregation (an earlier attempt was dropped).
- No hard cap on cell size or occupied-cell count.
- No spinner or cancel while aggregation is running.
- Loading a config that already has a small radius can still freeze on startup.

## Test plan
- [x] On a small dataset (<100k points), changing grid/hex radius never shows the warning.
- [x] On a large dataset, shrinking radius toward native resolution shows “The layer aggregation may be slow with up to N cells” with Cancel / Continue.
- [x] Cancel keeps the previous radius; Continue applies the new size (may be slow).
- [x] Switching layer type to grid/hexagon uses the same confirm when the estimate is over the threshold.
- [x] After Cancel or Continue, the layer is not stuck: slider and map stay in sync.