### PR TITLE
feat: WIP run grid/hexagon aggregation on a web worker

### DIFF
--- a/examples/demo-app/esbuild.config.mjs
+++ b/examples/demo-app/esbuild.config.mjs
@@ -47,6 +47,8 @@ const KEPLER_SRC_ALIASES = Object.fromEntries(
     'common-utils',
     'components',
     'constants',
+    'deckgl-arrow-layers',
+    'deckgl-layers',
     'duckdb',
     'layers',
     'localization',

--- a/src/components/src/loading-indicator.tsx
+++ b/src/components/src/loading-indicator.tsx
@@ -4,7 +4,11 @@
 import React, {PropsWithChildren, useRef, useEffect} from 'react';
 import styled, {withTheme, keyframes} from 'styled-components';
 
-import {getNumRasterTilesBeingLoaded, getNumVectorTilesBeingLoaded} from '@kepler.gl/layers';
+import {
+  getNumRasterTilesBeingLoaded,
+  getNumVectorTilesBeingLoaded,
+  getNumAggregationsBeingLoaded
+} from '@kepler.gl/layers';
 
 type StyledContainerProps = {
   $isVisible?: boolean;
@@ -77,9 +81,12 @@ const LoadingIndicator: React.FC<LoadingIndicatorProps & {theme: any}> = ({
   // Helper message to track number of tiles that are being loaded
   const numRasterTilesInProgress = getNumRasterTilesBeingLoaded();
   const numVectorTilesInProgress = getNumVectorTilesBeingLoaded();
+  const numAggregationsInProgress = getNumAggregationsBeingLoaded();
 
   let extraMessage = '';
-  if (numRasterTilesInProgress > 0 && numVectorTilesInProgress > 0) {
+  if (numAggregationsInProgress > 0) {
+    extraMessage = 'aggregating grid / hexagon cells';
+  } else if (numRasterTilesInProgress > 0 && numVectorTilesInProgress > 0) {
     // Both types loading: show combined count
     const totalTiles = numRasterTilesInProgress + numVectorTilesInProgress;
     extraMessage = `${totalTiles} tile${totalTiles === 1 ? ' is' : 's are'} being loaded`;

--- a/src/components/src/map/layer-hover-info.tsx
+++ b/src/components/src/map/layer-hover-info.tsx
@@ -302,7 +302,7 @@ const CellInfo = ({
       <Row
         name={'total points'}
         key="count"
-        value={String(data.points && data.points.length)}
+        value={String(data.count ?? data.points?.length ?? 0)}
         isComparing={isComparing}
       />
       {colorField && layer.visualChannels.color && colorMeasure ? (

--- a/src/constants/src/layers.ts
+++ b/src/constants/src/layers.ts
@@ -358,7 +358,10 @@ export const LAYER_VIS_CONFIGS: LayerVisConfigSettings = {
     step: 0.0001,
     group: PROPERTY_GROUPS.cell,
     property: 'worldUnitSize',
-    allowCustomValue: true
+    allowCustomValue: true,
+    // First 20% of the slider covers 0–1 km so small radii are easier to pick.
+    focusRange: [MIN_WORLD_UNIT_SIZE, 1],
+    focusWeight: 0.2
   },
   elevationScale: {
     type: 'number',

--- a/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
+++ b/src/deckgl-layers/src/grid-layer/enhanced-cpu-grid-layer.ts
@@ -3,11 +3,16 @@
 
 import {GridLayer, GridLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, Layer, PickingInfo, Viewport} from '@deck.gl/core';
-import {enrichedAggregationUpdate, enrichedRenderLayers} from '../layer-utils/aggregation-utils';
+import {
+  enrichedAggregationUpdate,
+  enrichedRenderLayers,
+  getDisplayedAggregationLayout
+} from '../layer-utils/aggregation-utils';
 import {
   makeGlobeCellLayerClass,
   runBinOptionsWithMercatorViewport
 } from '../layer-utils/globe-cell-utils';
+import WorkerBackedCPUAggregator from '../layer-utils/worker-cpu-aggregator';
 
 interface GridInternalState {
   cellOriginCommon?: [number, number];
@@ -39,6 +44,41 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
     ...GridLayer.defaultProps,
     gpuAggregation: false
   };
+
+  get isLoaded(): boolean {
+    const pending = Boolean(
+      (this.state as {aggregator?: {isPending?: boolean}})?.aggregator?.isPending
+    );
+    return super.isLoaded && !pending;
+  }
+
+  createAggregator(type: string) {
+    const aggregator = super.createAggregator(type);
+    if (type === 'cpu') {
+      return new WorkerBackedCPUAggregator({
+        syncAggregator: aggregator,
+        binType: 'grid',
+        requestRedraw: () => this.setNeedsRedraw(true)
+      });
+    }
+    return aggregator;
+  }
+
+  updateState(params: any) {
+    const aggregatorChanged = super.updateState(params);
+    const {changeFlags} = params;
+    if (changeFlags.updateTriggersChanged?.getColorWeight) {
+      (
+        this.state as {aggregator?: {setNeedsUpdate(channel: number): void}}
+      ).aggregator?.setNeedsUpdate(0);
+    }
+    if (changeFlags.updateTriggersChanged?.getElevationWeight) {
+      (
+        this.state as {aggregator?: {setNeedsUpdate(channel: number): void}}
+      ).aggregator?.setNeedsUpdate(1);
+    }
+    return aggregatorChanged;
+  }
 
   // HACK: deck.gl 9's _onAggregationUpdate is private and its onSetColorDomain
   // callback only provides [min, max].  That is sufficient for quantize/linear
@@ -83,8 +123,8 @@ export default class ScaleEnhancedGridLayer extends GridLayer<any> {
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {
     const info = super.getPickingInfo(params) as GridLayerPickingInfo<Record<string, unknown>>;
     if (info.object) {
-      const {cellOriginCommon, cellSizeCommon, aggregatorViewport} = this
-        .state as unknown as GridInternalState;
+      const {aggregatorViewport} = this.state as unknown as GridInternalState;
+      const {cellOriginCommon, cellSizeCommon} = getDisplayedAggregationLayout(this);
       const coverage = this.props.coverage ?? 1;
       if (!cellOriginCommon || !cellSizeCommon || !aggregatorViewport) {
         console.error(

--- a/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
+++ b/src/deckgl-layers/src/hexagon-layer/enhanced-hexagon-layer.ts
@@ -3,11 +3,16 @@
 
 import {HexagonLayer, HexagonLayerPickingInfo} from '@deck.gl/aggregation-layers';
 import {GetPickingInfoParams, Layer, PickingInfo, Viewport} from '@deck.gl/core';
-import {enrichedAggregationUpdate, enrichedRenderLayers} from '../layer-utils/aggregation-utils';
+import {
+  enrichedAggregationUpdate,
+  enrichedRenderLayers,
+  getDisplayedAggregationLayout
+} from '../layer-utils/aggregation-utils';
 import {
   makeGlobeCellLayerClass,
   runBinOptionsWithMercatorViewport
 } from '../layer-utils/globe-cell-utils';
+import WorkerBackedCPUAggregator from '../layer-utils/worker-cpu-aggregator';
 
 const THIRD_PI = Math.PI / 3;
 const HexbinVertices = Array.from({length: 6}, (_, i) => {
@@ -50,6 +55,41 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
     ...HexagonLayer.defaultProps,
     gpuAggregation: false
   };
+
+  get isLoaded(): boolean {
+    const pending = Boolean(
+      (this.state as {aggregator?: {isPending?: boolean}})?.aggregator?.isPending
+    );
+    return super.isLoaded && !pending;
+  }
+
+  createAggregator(type: string) {
+    const aggregator = super.createAggregator(type);
+    if (type === 'cpu') {
+      return new WorkerBackedCPUAggregator({
+        syncAggregator: aggregator,
+        binType: 'hexagon',
+        requestRedraw: () => this.setNeedsRedraw(true)
+      });
+    }
+    return aggregator;
+  }
+
+  updateState(params: any) {
+    const aggregatorChanged = super.updateState(params);
+    const {changeFlags} = params;
+    if (changeFlags.updateTriggersChanged?.getColorWeight) {
+      (
+        this.state as {aggregator?: {setNeedsUpdate(channel: number): void}}
+      ).aggregator?.setNeedsUpdate(0);
+    }
+    if (changeFlags.updateTriggersChanged?.getElevationWeight) {
+      (
+        this.state as {aggregator?: {setNeedsUpdate(channel: number): void}}
+      ).aggregator?.setNeedsUpdate(1);
+    }
+    return aggregatorChanged;
+  }
 
   // HACK: deck.gl 9's _onAggregationUpdate is private and its onSetColorDomain
   // callback only provides [min, max].  That is sufficient for quantize/linear
@@ -94,8 +134,8 @@ export default class ScaleEnhancedHexagonLayer extends HexagonLayer<any> {
   getPickingInfo(params: GetPickingInfoParams): PickingInfo {
     const info = super.getPickingInfo(params) as HexagonLayerPickingInfo<Record<string, unknown>>;
     if (info.object) {
-      const {radiusCommon, hexOriginCommon, aggregatorViewport} = this
-        .state as unknown as HexInternalState;
+      const {aggregatorViewport} = this.state as unknown as HexInternalState;
+      const {radiusCommon, hexOriginCommon} = getDisplayedAggregationLayout(this);
       const coverage = this.props.coverage ?? 1;
       if (!radiusCommon || !aggregatorViewport) {
         console.error(

--- a/src/deckgl-layers/src/index.ts
+++ b/src/deckgl-layers/src/index.ts
@@ -22,6 +22,13 @@ export {default as WMSLayer} from './wms/wms-layer';
 
 export * from './layer-utils/shader-utils';
 export * from './layer-utils/aggregation-utils';
+export {
+  ASYNC_CPU_AGGREGATION_THRESHOLD,
+  isWorkerCompatibleAggregation,
+  shouldUseAsyncCpuAggregation,
+  toDeckAggregationOperation
+} from './layer-utils/cpu-aggregation-core';
+export {getNumAggregationsBeingLoaded} from './layer-utils/worker-cpu-aggregator';
 
 export * from './3d-building-layer/types';
 export * from './3d-building-layer/3d-building-utils';

--- a/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
+++ b/src/deckgl-layers/src/layer-utils/aggregation-utils.ts
@@ -9,16 +9,28 @@ import type {AggregatedBin, ColorMap} from '@kepler.gl/types';
  * The resulting map is compatible with the format kepler.gl expects for
  * histogram rendering and color-scale selector.
  */
+/**
+ * Histogram / custom-break UI does not need one object per cell. Building a
+ * Record of ~2M bins and writing it through Redux freezes the map (~600ms).
+ */
+const MAX_AGGREGATED_BINS_FOR_UI = 8192;
+
 export function buildAggregatedBinMap(
   binValues: ArrayLike<number>,
   binCount: number,
   aggregator?: any
 ): Record<number, AggregatedBin> {
   const bins: Record<number, AggregatedBin> = {};
-  for (let i = 0; i < binCount; i++) {
+  const counts: ArrayLike<number> | null | undefined =
+    aggregator?.getBinCounts?.() ?? aggregator?.result?.counts;
+  const stride =
+    binCount > MAX_AGGREGATED_BINS_FOR_UI ? Math.ceil(binCount / MAX_AGGREGATED_BINS_FOR_UI) : 1;
+  let j = 0;
+  for (let i = 0; i < binCount; i += stride) {
     const val = binValues[i];
-    const count = aggregator?.getBin?.(i)?.count ?? 0;
-    bins[i] = {i, value: val, counts: count};
+    const count = counts ? counts[i] : aggregator?.getBin?.(i)?.count ?? 0;
+    bins[j] = {i: j, value: val, counts: count};
+    j++;
   }
   return bins;
 }
@@ -121,30 +133,67 @@ export function enrichedAggregationUpdate(layer: any, ParentClass: any, channel:
   const binValues = result?.value as Float32Array | undefined;
   if (!binValues || aggregator.binCount <= 0) return;
 
+  const binCount = aggregator.binCount;
   layer.setState({
-    rawColorBinValues: Float32Array.from(binValues.subarray(0, aggregator.binCount))
+    rawColorBinValues: binValues.length === binCount ? binValues : binValues.subarray(0, binCount)
   });
 
-  const domain = aggregator.getResultDomain(0);
-  const aggregatedBins = buildAggregatedBinMap(binValues, aggregator.binCount, aggregator);
-
   if (props.colorMap) {
-    classifyBinsByCustomBreaks(layer.state.colors, aggregator.binCount, props.colorMap, binValues);
+    classifyBinsByCustomBreaks(layer.state.colors, binCount, props.colorMap, binValues);
   }
 
-  let enrichedDomain = domain;
-  if (props.colorScaleType === 'quantile') {
-    enrichedDomain = Array.from(binValues)
-      .slice(0, aggregator.binCount)
-      .filter(Number.isFinite)
-      .sort((a: number, b: number) => a - b);
-  }
-  props.onSetColorDomain?.({domain: enrichedDomain, aggregatedBins});
+  const domain = aggregator.getResultDomain(0);
+  const colorScaleType = props.colorScaleType;
+  const onSetColorDomain = props.onSetColorDomain;
+  // Legend/Redux must not run in this frame: allocating ~2M bin objects and
+  // dispatching them keeps the spinner up while the map ignores input.
+  requestAnimationFrame(() => {
+    const aggregatedBins = buildAggregatedBinMap(binValues, binCount, aggregator);
+    let enrichedDomain: number[] | [number, number] = domain;
+    if (colorScaleType === 'quantile') {
+      enrichedDomain = Object.values(aggregatedBins)
+        .map(b => b.value)
+        .filter(Number.isFinite)
+        .sort((a: number, b: number) => a - b);
+    }
+    onSetColorDomain?.({domain: enrichedDomain, aggregatedBins});
+  });
+}
+
+export type DisplayedAggregationLayout = {
+  cellSizeCommon?: [number, number];
+  cellOriginCommon?: [number, number];
+  radiusCommon?: number;
+  hexOriginCommon?: [number, number];
+};
+
+/**
+ * Layout used to draw the currently visible bins. While a worker job is in
+ * flight this is the origin/size the last result was computed with, not the
+ * layer's already-updated `cellSizeCommon` / `radiusCommon`.
+ */
+export function getDisplayedAggregationLayout(layer: any): DisplayedAggregationLayout {
+  const displayed = layer.state?.aggregator?.displayedBinOptions as
+    | DisplayedAggregationLayout
+    | null
+    | undefined;
+  if (displayed) return displayed;
+  return {
+    cellSizeCommon: layer.state?.cellSizeCommon,
+    cellOriginCommon: layer.state?.cellOriginCommon,
+    radiusCommon: layer.state?.radiusCommon,
+    hexOriginCommon: layer.state?.hexOriginCommon
+  };
 }
 
 /**
  * Shared renderLayers() wrapper that re-classifies bins when custom colorMap
  * changes between renders without triggering a full re-aggregation.
+ *
+ * While async aggregation is pending, Grid/Hex cell layers must keep using the
+ * binOptions that match the last bins. Cells are placed as `origin + col * size`;
+ * drawing old col/row ids at the new worldUnitSize looks like the grid is
+ * scaling around the origin.
  *
  * @param layer       The enhanced layer instance (`this`)
  * @param ParentClass The deck.gl parent class (HexagonLayer or GridLayer)
@@ -156,5 +205,32 @@ export function enrichedRenderLayers(layer: any, ParentClass: any): any {
   if (props.colorMap && colors && rawColorBinValues && aggregator?.binCount > 0) {
     classifyBinsByCustomBreaks(colors, aggregator.binCount, props.colorMap, rawColorBinValues);
   }
-  return (ParentClass.prototype as any).renderLayers.call(layer);
+
+  const displayed = aggregator?.displayedBinOptions as
+    | DisplayedAggregationLayout
+    | null
+    | undefined;
+  if (!displayed) {
+    return (ParentClass.prototype as any).renderLayers.call(layer);
+  }
+
+  const saved = {
+    cellSizeCommon: layer.state.cellSizeCommon,
+    cellOriginCommon: layer.state.cellOriginCommon,
+    radiusCommon: layer.state.radiusCommon,
+    hexOriginCommon: layer.state.hexOriginCommon
+  };
+  if (displayed.cellSizeCommon) {
+    layer.state.cellSizeCommon = displayed.cellSizeCommon;
+    layer.state.cellOriginCommon = displayed.cellOriginCommon;
+  }
+  if (displayed.radiusCommon != null) {
+    layer.state.radiusCommon = displayed.radiusCommon;
+    layer.state.hexOriginCommon = displayed.hexOriginCommon;
+  }
+  try {
+    return (ParentClass.prototype as any).renderLayers.call(layer);
+  } finally {
+    Object.assign(layer.state, saved);
+  }
 }

--- a/src/deckgl-layers/src/layer-utils/aggregation-worker.ts
+++ b/src/deckgl-layers/src/layer-utils/aggregation-worker.ts
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {
+  aggregatePointsToBins,
+  AggregationWorkerRequest,
+  AggregationWorkerResult
+} from './cpu-aggregation-core';
+
+type PendingJob = {
+  request: AggregationWorkerRequest;
+  resolve: (result: AggregationWorkerResult) => void;
+  reject: (error: Error) => void;
+};
+
+let worker: Worker | null | undefined;
+let workerObjectUrl: string | null = null;
+let nextJobId = 1;
+const pending = new Map<number, PendingJob>();
+
+// Worker source is a literal script. Bundled function.toString() is unsafe:
+// esbuild rewrites constants and can inject PURE comments into the body.
+const WORKER_SOURCE = `
+var WEB_MERCATOR_TILE_SIZE = 512;
+var THIRD_PI = Math.PI / 3;
+var HEX_DIST_X = 2 * Math.sin(THIRD_PI);
+var HEX_DIST_Y = 1.5;
+
+function lngLatToWorld(lng, lat, scale) {
+  if (scale === void 0) scale = 1;
+  var lambda = (lng * Math.PI) / 180;
+  var phi = (lat * Math.PI) / 180;
+  var x = (WEB_MERCATOR_TILE_SIZE * (lambda + Math.PI)) / (2 * Math.PI);
+  var y =
+    (WEB_MERCATOR_TILE_SIZE * (Math.PI + Math.log(Math.tan(Math.PI * 0.25 + phi * 0.5)))) /
+    (2 * Math.PI);
+  y = Math.max(-318, Math.min(830, y));
+  return [x * scale, y * scale];
+}
+
+function pointToHexbin(px, py, radius) {
+  py = py / radius / HEX_DIST_Y;
+  var pj = Math.round(py);
+  px = px / radius / HEX_DIST_X - (pj & 1) / 2;
+  var pi = Math.round(px);
+  var py1 = py - pj;
+  if (Math.abs(py1) * 3 > 1) {
+    var px1 = px - pi;
+    var pi2 = pi + (px < pi ? -1 : 1) / 2;
+    var pj2 = pj + (py < pj ? -1 : 1);
+    var px2 = px - pi2;
+    var py2 = py - pj2;
+    if (px1 * px1 + py1 * py1 > px2 * px2 + py2 * py2) {
+      pi = pi2 + (pj & 1 ? 1 : -1) / 2;
+      pj = pj2;
+    }
+  }
+  return [pi, pj];
+}
+
+function reduceChannel(indices, getValue, operation) {
+  if (operation === 'COUNT') return indices.length;
+  var sum = 0;
+  var valid = 0;
+  var min = Infinity;
+  var max = -Infinity;
+  for (var i = 0; i < indices.length; i++) {
+    var value = getValue(indices[i]);
+    if (!Number.isFinite(value)) continue;
+    valid++;
+    sum += value;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+  if (valid === 0) return operation === 'SUM' ? 0 : NaN;
+  if (operation === 'SUM') return sum;
+  if (operation === 'MEAN') return sum / valid;
+  if (operation === 'MIN') return min;
+  if (operation === 'MAX') return max;
+  return valid;
+}
+
+function domainOf(values, count) {
+  var min = Infinity;
+  var max = -Infinity;
+  for (var i = 0; i < count; i++) {
+    var v = values[i];
+    if (!Number.isFinite(v)) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (min === Infinity) return [NaN, NaN];
+  return [min, max];
+}
+
+function aggregatePointsToBins(request) {
+  var id = request.id;
+  var binType = request.binType;
+  var pointCount = request.pointCount;
+  var positions = request.positions;
+  var positionSize = request.positionSize;
+  var colorWeights = request.colorWeights;
+  var elevationWeights = request.elevationWeights;
+  var colorOperation = request.colorOperation;
+  var elevationOperation = request.elevationOperation;
+  var scale = request.scale;
+  var originX = request.originX;
+  var originY = request.originY;
+  var cellSizeX = request.cellSizeX;
+  var cellSizeY = request.cellSizeY;
+  var radiusCommon = request.radiusCommon;
+  var binPoints = new Map();
+  var binIdsByKey = new Map();
+
+  for (var i = 0; i < pointCount; i++) {
+    var x;
+    var y;
+    if (request.preprojected) {
+      x = positions[i * positionSize];
+      y = positions[i * positionSize + 1];
+    } else {
+      var lng = positions[i * positionSize];
+      var lat = positions[i * positionSize + 1];
+      if (!Number.isFinite(lng) || !Number.isFinite(lat)) continue;
+      var world = lngLatToWorld(lng, lat, scale);
+      x = world[0];
+      y = world[1];
+    }
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+
+    var col;
+    var row;
+    if (binType === 'hexagon') {
+      var hex = pointToHexbin(x - originX, y - originY, radiusCommon);
+      col = hex[0];
+      row = hex[1];
+    } else {
+      col = Math.floor((x - originX) / cellSizeX);
+      row = Math.floor((y - originY) / cellSizeY);
+    }
+
+    var key = col + ',' + row;
+    var points = binPoints.get(key);
+    if (!points) {
+      points = [];
+      binPoints.set(key, points);
+      binIdsByKey.set(key, [col, row]);
+    }
+    points.push(i);
+  }
+
+  var binCount = binPoints.size;
+  var binIds = new Float32Array(binCount * 2);
+  var colorValues = new Float32Array(binCount);
+  var elevationValues = new Float32Array(binCount);
+  var counts = new Uint32Array(binCount);
+  var pointIndexOffsets = new Uint32Array(binCount + 1);
+  var totalPoints = 0;
+  var binIndex = 0;
+  binPoints.forEach(function (pts, k) {
+    var idPair = binIdsByKey.get(k);
+    binIds[binIndex * 2] = idPair[0];
+    binIds[binIndex * 2 + 1] = idPair[1];
+    counts[binIndex] = pts.length;
+    colorValues[binIndex] = reduceChannel(pts, function (j) { return colorWeights[j]; }, colorOperation);
+    elevationValues[binIndex] = reduceChannel(pts, function (j) { return elevationWeights[j]; }, elevationOperation);
+    pointIndexOffsets[binIndex] = totalPoints;
+    totalPoints += pts.length;
+    binIndex++;
+  });
+  pointIndexOffsets[binCount] = totalPoints;
+
+  var pointIndices = new Uint32Array(0);
+
+  return {
+    id: id,
+    binCount: binCount,
+    binIds: binIds,
+    colorValues: colorValues,
+    elevationValues: elevationValues,
+    counts: counts,
+    colorDomain: domainOf(colorValues, binCount),
+    elevationDomain: domainOf(elevationValues, binCount),
+    pointIndexOffsets: pointIndexOffsets,
+    pointIndices: pointIndices
+  };
+}
+
+self.onmessage = function (event) {
+  try {
+    var result = aggregatePointsToBins(event.data);
+    self.postMessage(result, [
+      result.binIds.buffer,
+      result.colorValues.buffer,
+      result.elevationValues.buffer,
+      result.counts.buffer,
+      result.pointIndexOffsets.buffer,
+      result.pointIndices.buffer
+    ]);
+  } catch (err) {
+    self.postMessage({
+      id: event.data && event.data.id,
+      error: String(err && err.message ? err.message : err)
+    });
+  }
+};
+`;
+
+function handleWorkerMessage(event: MessageEvent): void {
+  const data = event.data as AggregationWorkerResult & {error?: string};
+  const job = pending.get(data.id);
+  if (!job) return;
+  pending.delete(data.id);
+  if (data.error) {
+    job.reject(new Error(data.error));
+    return;
+  }
+  job.resolve(data);
+}
+
+export function isAggregationWorkerAvailable(): boolean {
+  return typeof Worker !== 'undefined' && typeof Blob !== 'undefined' && typeof URL !== 'undefined';
+}
+
+function getWorker(): Worker | null {
+  if (worker === undefined) {
+    if (!isAggregationWorkerAvailable()) {
+      worker = null;
+      return worker;
+    }
+    try {
+      workerObjectUrl = URL.createObjectURL(
+        new Blob([WORKER_SOURCE], {type: 'application/javascript'})
+      );
+      worker = new Worker(workerObjectUrl);
+      worker.onmessage = handleWorkerMessage;
+      worker.onerror = event => {
+        pending.forEach(job => job.reject(new Error(event.message || 'Aggregation worker error')));
+        pending.clear();
+      };
+    } catch {
+      worker = null;
+    }
+  }
+  return worker;
+}
+
+export function runAggregationInWorker(
+  request: Omit<AggregationWorkerRequest, 'id'>
+): Promise<AggregationWorkerResult> {
+  const w = getWorker();
+  if (!w) {
+    // Sync fallback for tests / missing Worker. Copies are cheap vs a 600k freeze
+    // in the browser; callers should prefer the worker path.
+    return Promise.resolve(aggregatePointsToBins({...request, id: 0}));
+  }
+
+  const id = nextJobId++;
+  const payload: AggregationWorkerRequest = {...request, id};
+  return new Promise((resolve, reject) => {
+    pending.set(id, {request: payload, resolve, reject});
+    w.postMessage(payload, [
+      payload.positions.buffer,
+      payload.colorWeights.buffer,
+      payload.elevationWeights.buffer
+    ]);
+  });
+}
+
+export function destroyAggregationWorker(): void {
+  pending.forEach(job => job.reject(new Error('Aggregation worker destroyed')));
+  pending.clear();
+  if (worker) {
+    worker.terminate();
+  }
+  if (workerObjectUrl) {
+    URL.revokeObjectURL(workerObjectUrl);
+  }
+  worker = undefined;
+  workerObjectUrl = null;
+}

--- a/src/deckgl-layers/src/layer-utils/cpu-aggregation-core.spec.ts
+++ b/src/deckgl-layers/src/layer-utils/cpu-aggregation-core.spec.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {
+  aggregatePointsToBins,
+  isWorkerCompatibleAggregation,
+  lngLatToWorld,
+  pointToHexbin,
+  reduceChannel,
+  shouldUseAsyncCpuAggregation,
+  toDeckAggregationOperation,
+  ASYNC_CPU_AGGREGATION_THRESHOLD,
+  WEB_MERCATOR_TILE_SIZE
+} from './cpu-aggregation-core';
+
+describe('cpu-aggregation-core', () => {
+  test('lngLatToWorld maps 0,0 to the mercator origin', () => {
+    const [x, y] = lngLatToWorld(0, 0, 1);
+    expect(x).toBeCloseTo(WEB_MERCATOR_TILE_SIZE / 2, 6);
+    expect(y).toBeCloseTo(WEB_MERCATOR_TILE_SIZE / 2, 6);
+  });
+
+  test('lngLatToWorld scales linearly with zoom scale', () => {
+    const [x1, y1] = lngLatToWorld(-122.4, 37.8, 1);
+    const [x2, y2] = lngLatToWorld(-122.4, 37.8, 4096);
+    expect(x2 / x1).toBeCloseTo(4096, 6);
+    expect(y2 / y1).toBeCloseTo(4096, 6);
+  });
+
+  test('pointToHexbin is stable for a cell center and a nearby point', () => {
+    const radius = 1000;
+    const a = pointToHexbin(0, 0, radius);
+    const b = pointToHexbin(10, 10, radius);
+    expect(a).toEqual(b);
+  });
+
+  test('reduceChannel COUNT / SUM / MAX skip or include values as documented', () => {
+    const values = [1, NaN, 3, 0];
+    const getValue = (i: number) => values[i];
+    const idx = [0, 1, 2, 3];
+    expect(reduceChannel(idx, getValue, 'COUNT')).toBe(4);
+    expect(reduceChannel(idx, getValue, 'SUM')).toBe(4);
+    expect(reduceChannel(idx, getValue, 'MAX')).toBe(3);
+    expect(reduceChannel(idx, getValue, 'MEAN')).toBeCloseTo(4 / 3, 6);
+    expect(reduceChannel([1], getValue, 'MAX')).toBeNaN();
+    expect(reduceChannel([1], getValue, 'SUM')).toBe(0);
+  });
+
+  test('toDeckAggregationOperation maps kepler names', () => {
+    expect(toDeckAggregationOperation('average')).toBe('MEAN');
+    expect(toDeckAggregationOperation('maximum')).toBe('MAX');
+    expect(toDeckAggregationOperation('count')).toBe('COUNT');
+    expect(toDeckAggregationOperation('count', {countAsSum: true})).toBe('SUM');
+    expect(isWorkerCompatibleAggregation('median')).toBe(false);
+    expect(isWorkerCompatibleAggregation('count')).toBe(true);
+    expect(shouldUseAsyncCpuAggregation(ASYNC_CPU_AGGREGATION_THRESHOLD, 'count', 'count')).toBe(
+      true
+    );
+    expect(
+      shouldUseAsyncCpuAggregation(ASYNC_CPU_AGGREGATION_THRESHOLD, 'average', 'average')
+    ).toBe(true);
+    // No color field is treated as count by formatLayerData.
+    expect(shouldUseAsyncCpuAggregation(ASYNC_CPU_AGGREGATION_THRESHOLD, 'count', 'count')).toBe(
+      true
+    );
+    expect(
+      shouldUseAsyncCpuAggregation(ASYNC_CPU_AGGREGATION_THRESHOLD - 1, 'count', 'count')
+    ).toBe(false);
+    expect(shouldUseAsyncCpuAggregation(ASYNC_CPU_AGGREGATION_THRESHOLD, 'median', 'count')).toBe(
+      false
+    );
+  });
+
+  test('aggregatePointsToBins groups nearby points and counts them', () => {
+    const positions = new Float64Array([-122.4, 37.8, 0, -122.4001, 37.8001, 0, -122.5, 37.9, 0]);
+    const colorWeights = new Float32Array([1, 1, 1]);
+    const elevationWeights = new Float32Array([1, 1, 1]);
+    const origin = lngLatToWorld(-122.45, 37.85, 1);
+    const result = aggregatePointsToBins({
+      id: 1,
+      binType: 'grid',
+      pointCount: 3,
+      positions,
+      positionSize: 3,
+      preprojected: false,
+      colorWeights,
+      elevationWeights,
+      colorOperation: 'SUM',
+      elevationOperation: 'SUM',
+      scale: 1,
+      originX: origin[0],
+      originY: origin[1],
+      cellSizeX: 0.5,
+      cellSizeY: 0.5,
+      radiusCommon: 1
+    });
+
+    expect(result.binCount).toBe(2);
+    const counts = Array.from(result.counts).sort((a, b) => a - b);
+    expect(counts).toEqual([1, 2]);
+    expect(result.pointIndices.length).toBe(3);
+  });
+
+  test('grid bin placement stays in common space when cell size changes', () => {
+    const lng = -122.4;
+    const lat = 37.8;
+    const origin = lngLatToWorld(lng - 0.05, lat - 0.05, 1);
+    const [wx, wy] = lngLatToWorld(lng, lat, 1);
+    const colorWeights = new Float32Array([1]);
+    const elevationWeights = new Float32Array([1]);
+    const positions = new Float64Array([lng, lat, 0]);
+
+    const binAtSize = (cellSize: number) =>
+      aggregatePointsToBins({
+        id: 1,
+        binType: 'grid',
+        pointCount: 1,
+        positions,
+        positionSize: 3,
+        preprojected: false,
+        colorWeights,
+        elevationWeights,
+        colorOperation: 'COUNT',
+        elevationOperation: 'COUNT',
+        scale: 1,
+        originX: origin[0],
+        originY: origin[1],
+        cellSizeX: cellSize,
+        cellSizeY: cellSize,
+        radiusCommon: 1
+      });
+
+    const small = binAtSize(0.01);
+    const large = binAtSize(0.02);
+    const colSmall = small.binIds[0];
+    const colLarge = large.binIds[0];
+    const rowSmall = small.binIds[1];
+    const rowLarge = large.binIds[1];
+
+    const placedSmallX = origin[0] + colSmall * 0.01;
+    const placedLargeX = origin[0] + colLarge * 0.02;
+    expect(Math.abs(placedSmallX - wx)).toBeLessThan(0.01);
+    expect(Math.abs(placedLargeX - wx)).toBeLessThan(0.02);
+    expect(Math.abs(origin[1] + rowSmall * 0.01 - wy)).toBeLessThan(0.01);
+    expect(Math.abs(origin[1] + rowLarge * 0.02 - wy)).toBeLessThan(0.02);
+
+    // Reusing the small-cell col with the large cell size would scale the point away.
+    const wronglyScaledX = origin[0] + colSmall * 0.02;
+    expect(Math.abs(wronglyScaledX - wx)).toBeGreaterThan(0.01);
+  });
+});

--- a/src/deckgl-layers/src/layer-utils/cpu-aggregation-core.ts
+++ b/src/deckgl-layers/src/layer-utils/cpu-aggregation-core.ts
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+/**
+ * Pure CPU grid/hexagon aggregation used both on the main thread (tests / small
+ * data) and inside a Web Worker (large data). This file must stay free of
+ * imports so its functions can be serialized into a Blob worker.
+ */
+
+/** Point count at which grid/hex aggregation is offloaded to a worker. */
+export const ASYNC_CPU_AGGREGATION_THRESHOLD = 20_000;
+
+/** Kepler aggregation types that map onto deck.gl built-in CPU ops. */
+export const WORKER_COMPATIBLE_AGGREGATIONS: Record<string, true> = {
+  count: true,
+  sum: true,
+  average: true,
+  maximum: true,
+  minimum: true
+};
+
+export type DeckAggregationOperation = 'SUM' | 'MEAN' | 'MIN' | 'MAX' | 'COUNT';
+
+export type AggregationBinType = 'grid' | 'hexagon';
+
+export type AggregationWorkerRequest = {
+  id: number;
+  binType: AggregationBinType;
+  pointCount: number;
+  positions: Float64Array;
+  positionSize: number;
+  /**
+   * When true, `positions` are already in deck.gl common space (the same space
+   * as cellOriginCommon / cellSizeCommon). When false they are lng/lat.
+   */
+  preprojected: boolean;
+  colorWeights: Float32Array;
+  elevationWeights: Float32Array;
+  colorOperation: DeckAggregationOperation;
+  elevationOperation: DeckAggregationOperation;
+  /**
+   * Extra scale applied after zoom-0 Web Mercator. Deck.gl 9 `projectFlat` /
+   * `projectPosition` use zoom-independent common space, so this must be `1`
+   * when matching GridLayer / HexagonLayer bin ids.
+   */
+  scale: number;
+  originX: number;
+  originY: number;
+  cellSizeX: number;
+  cellSizeY: number;
+  radiusCommon: number;
+};
+
+export type AggregationWorkerResult = {
+  id: number;
+  binCount: number;
+  binIds: Float32Array;
+  colorValues: Float32Array;
+  elevationValues: Float32Array;
+  counts: Uint32Array;
+  colorDomain: [number, number];
+  elevationDomain: [number, number];
+  pointIndexOffsets: Uint32Array;
+  pointIndices: Uint32Array;
+};
+
+/** math.gl / deck.gl WebMercator TILE_SIZE. */
+export const WEB_MERCATOR_TILE_SIZE = 512;
+
+const THIRD_PI = Math.PI / 3;
+const HEX_DIST_X = 2 * Math.sin(THIRD_PI);
+const HEX_DIST_Y = 1.5;
+
+export function isWorkerCompatibleAggregation(aggregation: string | null | undefined): boolean {
+  return Boolean(aggregation && WORKER_COMPATIBLE_AGGREGATIONS[aggregation]);
+}
+
+export function shouldUseAsyncCpuAggregation(
+  pointCount: number,
+  colorAggregation?: string | null,
+  sizeAggregation?: string | null
+): boolean {
+  return (
+    pointCount >= ASYNC_CPU_AGGREGATION_THRESHOLD &&
+    isWorkerCompatibleAggregation(colorAggregation || 'count') &&
+    isWorkerCompatibleAggregation(sizeAggregation || 'count')
+  );
+}
+
+export function toDeckAggregationOperation(
+  aggregation: string | null | undefined,
+  opts?: {countAsSum?: boolean}
+): DeckAggregationOperation {
+  switch (aggregation) {
+    case 'average':
+      return 'MEAN';
+    case 'sum':
+      return 'SUM';
+    case 'maximum':
+      return 'MAX';
+    case 'minimum':
+      return 'MIN';
+    case 'count':
+    default:
+      return opts?.countAsSum ? 'SUM' : 'COUNT';
+  }
+}
+
+/**
+ * Web Mercator world coordinates matching `@math.gl/web-mercator` lngLatToWorld
+ * and deck.gl 9 `Viewport.projectFlat` (zoom-0 common space when scale is 1).
+ * Y is clamped the same way deck.gl clamps projected latitude.
+ */
+export function lngLatToWorld(lng: number, lat: number, scale = 1): [number, number] {
+  const lambda = (lng * Math.PI) / 180;
+  const phi = (lat * Math.PI) / 180;
+  const x = (WEB_MERCATOR_TILE_SIZE * (lambda + Math.PI)) / (2 * Math.PI);
+  let y =
+    (WEB_MERCATOR_TILE_SIZE * (Math.PI + Math.log(Math.tan(Math.PI * 0.25 + phi * 0.5)))) /
+    (2 * Math.PI);
+  // deck.gl Viewport.projectFlat: shader clamps latitude to +-89.9
+  y = Math.max(-318, Math.min(830, y));
+  return [x * scale, y * scale];
+}
+
+/**
+ * Adapted from d3-hexbin / deck.gl HexagonLayer.pointToHexbin.
+ */
+export function pointToHexbin(px: number, py: number, radius: number): [number, number] {
+  // Match deck.gl HexagonLayer / d3-hexbin, including in-place px/py updates.
+  py = py / radius / HEX_DIST_Y;
+  let pj = Math.round(py);
+  px = px / radius / HEX_DIST_X - (pj & 1) / 2;
+  let pi = Math.round(px);
+  const py1 = py - pj;
+
+  if (Math.abs(py1) * 3 > 1) {
+    const px1 = px - pi;
+    const pi2 = pi + (px < pi ? -1 : 1) / 2;
+    const pj2 = pj + (py < pj ? -1 : 1);
+    const px2 = px - pi2;
+    const py2 = py - pj2;
+    if (px1 * px1 + py1 * py1 > px2 * px2 + py2 * py2) {
+      pi = pi2 + (pj & 1 ? 1 : -1) / 2;
+      pj = pj2;
+    }
+  }
+  return [pi, pj];
+}
+
+export function reduceChannel(
+  indices: number[],
+  getValue: (index: number) => number,
+  operation: DeckAggregationOperation
+): number {
+  if (operation === 'COUNT') {
+    return indices.length;
+  }
+
+  let sum = 0;
+  let valid = 0;
+  let min = Infinity;
+  let max = -Infinity;
+
+  for (let i = 0; i < indices.length; i++) {
+    const value = getValue(indices[i]);
+    if (!Number.isFinite(value)) continue;
+    valid++;
+    sum += value;
+    if (value < min) min = value;
+    if (value > max) max = value;
+  }
+
+  if (valid === 0) {
+    return operation === 'SUM' ? 0 : NaN;
+  }
+
+  switch (operation) {
+    case 'SUM':
+      return sum;
+    case 'MEAN':
+      return sum / valid;
+    case 'MIN':
+      return min;
+    case 'MAX':
+      return max;
+    default:
+      return valid;
+  }
+}
+
+export function domainOf(values: Float32Array, count: number): [number, number] {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let i = 0; i < count; i++) {
+    const v = values[i];
+    if (!Number.isFinite(v)) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (min === Infinity) return [NaN, NaN];
+  return [min, max];
+}
+
+export function aggregatePointsToBins(request: AggregationWorkerRequest): AggregationWorkerResult {
+  const {
+    id,
+    binType,
+    pointCount,
+    positions,
+    positionSize,
+    colorWeights,
+    elevationWeights,
+    colorOperation,
+    elevationOperation,
+    scale,
+    originX,
+    originY,
+    cellSizeX,
+    cellSizeY,
+    radiusCommon
+  } = request;
+
+  const binPoints = new Map<string, number[]>();
+  const binIdsByKey = new Map<string, [number, number]>();
+
+  for (let i = 0; i < pointCount; i++) {
+    let x: number;
+    let y: number;
+    if (request.preprojected) {
+      x = positions[i * positionSize];
+      y = positions[i * positionSize + 1];
+    } else {
+      const lng = positions[i * positionSize];
+      const lat = positions[i * positionSize + 1];
+      if (!Number.isFinite(lng) || !Number.isFinite(lat)) continue;
+      const world = lngLatToWorld(lng, lat, scale);
+      x = world[0];
+      y = world[1];
+    }
+    if (!Number.isFinite(x) || !Number.isFinite(y)) continue;
+
+    let col: number;
+    let row: number;
+    if (binType === 'hexagon') {
+      const hex = pointToHexbin(x - originX, y - originY, radiusCommon);
+      col = hex[0];
+      row = hex[1];
+    } else {
+      col = Math.floor((x - originX) / cellSizeX);
+      row = Math.floor((y - originY) / cellSizeY);
+    }
+
+    const key = `${col},${row}`;
+    let points = binPoints.get(key);
+    if (!points) {
+      points = [];
+      binPoints.set(key, points);
+      binIdsByKey.set(key, [col, row]);
+    }
+    points.push(i);
+  }
+
+  const binCount = binPoints.size;
+  const binIds = new Float32Array(binCount * 2);
+  const colorValues = new Float32Array(binCount);
+  const elevationValues = new Float32Array(binCount);
+  const counts = new Uint32Array(binCount);
+  const pointIndexOffsets = new Uint32Array(binCount + 1);
+
+  let totalPoints = 0;
+  let binIndex = 0;
+  binPoints.forEach((points, key) => {
+    const idPair = binIdsByKey.get(key) as [number, number];
+    binIds[binIndex * 2] = idPair[0];
+    binIds[binIndex * 2 + 1] = idPair[1];
+    counts[binIndex] = points.length;
+    colorValues[binIndex] = reduceChannel(points, j => colorWeights[j], colorOperation);
+    elevationValues[binIndex] = reduceChannel(points, j => elevationWeights[j], elevationOperation);
+    pointIndexOffsets[binIndex] = totalPoints;
+    totalPoints += points.length;
+    binIndex++;
+  });
+  pointIndexOffsets[binCount] = totalPoints;
+
+  const pointIndices = new Uint32Array(totalPoints);
+  binIndex = 0;
+  binPoints.forEach(points => {
+    const offset = pointIndexOffsets[binIndex];
+    for (let p = 0; p < points.length; p++) {
+      pointIndices[offset + p] = points[p];
+    }
+    binIndex++;
+  });
+
+  return {
+    id,
+    binCount,
+    binIds,
+    colorValues,
+    elevationValues,
+    counts,
+    colorDomain: domainOf(colorValues, binCount),
+    elevationDomain: domainOf(elevationValues, binCount),
+    pointIndexOffsets,
+    pointIndices
+  };
+}

--- a/src/deckgl-layers/src/layer-utils/worker-cpu-aggregator.ts
+++ b/src/deckgl-layers/src/layer-utils/worker-cpu-aggregator.ts
@@ -1,0 +1,476 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import {
+  ASYNC_CPU_AGGREGATION_THRESHOLD,
+  AggregationBinType,
+  AggregationWorkerResult,
+  DeckAggregationOperation
+} from './cpu-aggregation-core';
+import {isAggregationWorkerAvailable, runAggregationInWorker} from './aggregation-worker';
+
+const BUILT_IN_OPS = new Set(['SUM', 'MEAN', 'MIN', 'MAX', 'COUNT']);
+
+let aggregationsInProgress = 0;
+
+export function getNumAggregationsBeingLoaded(): number {
+  return aggregationsInProgress;
+}
+
+function beginAggregation(): void {
+  aggregationsInProgress++;
+}
+
+function endAggregation(): void {
+  aggregationsInProgress = Math.max(0, aggregationsInProgress - 1);
+}
+
+type SyncAggregator = {
+  props?: Record<string, any>;
+  binCount: number;
+  setProps(props: Record<string, any>): void;
+  setNeedsUpdate(channel?: number): void;
+  update(): void;
+  preDraw(): void;
+  destroy(): void;
+  getBins(): unknown;
+  getResult(channel: number): unknown;
+  getResultDomain(channel: number): [number, number];
+  getBin(index: number): unknown;
+};
+
+/** Deck.gl 9 common space is zoom-0 Web Mercator (see Viewport.projectFlat). */
+const DECK_COMMON_SPACE_SCALE = 1;
+
+export type DisplayedBinOptions = {
+  cellSizeCommon?: [number, number];
+  cellOriginCommon?: [number, number];
+  radiusCommon?: number;
+  hexOriginCommon?: [number, number];
+};
+
+export type WorkerBackedCPUAggregatorOptions = {
+  syncAggregator: SyncAggregator;
+  binType: AggregationBinType;
+  requestRedraw?: () => void;
+};
+
+function copyPositions(
+  attr: any,
+  pointCount: number
+): {positions: Float64Array; positionSize: number} | null {
+  const value = getAttributeValue(attr);
+  if (!value) return null;
+  const accessor = typeof attr.getAccessor === 'function' ? attr.getAccessor() : {};
+  const size = accessor.size || attr.size || 3;
+  const bytesPerElement = (value as {BYTES_PER_ELEMENT?: number}).BYTES_PER_ELEMENT || 8;
+  const offset = (accessor.offset || 0) / bytesPerElement;
+  const stride = accessor.stride ? accessor.stride / bytesPerElement : size;
+  const needed = pointCount * size;
+
+  if (
+    offset === 0 &&
+    stride === size &&
+    typeof (value as Float64Array).subarray === 'function' &&
+    value.length >= needed
+  ) {
+    const positions = new Float64Array(needed);
+    positions.set((value as Float64Array).subarray(0, needed));
+    return {positions, positionSize: size};
+  }
+
+  const out = new Float64Array(needed);
+  for (let i = 0; i < pointCount; i++) {
+    const src = offset + i * stride;
+    for (let k = 0; k < size; k++) out[i * size + k] = value[src + k];
+  }
+  return {positions: out, positionSize: size};
+}
+
+function copyToFloat32(
+  source: ArrayLike<number> | undefined,
+  length: number,
+  fill = 1
+): Float32Array {
+  const out = new Float32Array(length);
+  if (!source) {
+    out.fill(fill);
+    return out;
+  }
+  if (typeof (source as Float32Array).subarray === 'function' && source.length >= length) {
+    out.set((source as Float32Array).subarray(0, length));
+    return out;
+  }
+  for (let i = 0; i < length; i++) out[i] = i < source.length ? source[i] : fill;
+  return out;
+}
+
+function getAttributeValue(attr: any): ArrayLike<number> | null {
+  if (!attr) return null;
+  const value = attr.value ?? attr.getValue?.();
+  return value && value.length ? value : null;
+}
+
+function binOptionsKey(binOptions: Record<string, any> | undefined): string {
+  if (!binOptions) return '';
+  const origin = binOptions.cellOriginCommon || binOptions.hexOriginCommon || [];
+  const size = binOptions.cellSizeCommon || [];
+  return [origin[0], origin[1], size[0], size[1], binOptions.radiusCommon].join(',');
+}
+
+function cloneBinOptions(binOptions: Record<string, any> | undefined): DisplayedBinOptions | null {
+  if (!binOptions) return null;
+  return {
+    cellSizeCommon: binOptions.cellSizeCommon
+      ? [binOptions.cellSizeCommon[0], binOptions.cellSizeCommon[1]]
+      : undefined,
+    cellOriginCommon: binOptions.cellOriginCommon
+      ? [binOptions.cellOriginCommon[0], binOptions.cellOriginCommon[1]]
+      : undefined,
+    radiusCommon: binOptions.radiusCommon,
+    hexOriginCommon: binOptions.hexOriginCommon
+      ? [binOptions.hexOriginCommon[0], binOptions.hexOriginCommon[1]]
+      : undefined
+  };
+}
+
+function isBuiltInOperation(op: unknown): op is DeckAggregationOperation {
+  return typeof op === 'string' && BUILT_IN_OPS.has(op);
+}
+
+/**
+ * Deck.gl Aggregator that runs CPU grid/hex aggregation in a Web Worker for
+ * large datasets, and delegates to deck.gl's CPUAggregator otherwise.
+ *
+ * While a job is in flight the last successful bins stay on screen, together
+ * with the `binOptions` they were computed with. GridCellLayer places cells as
+ * `origin + col * cellSize`; if those col/row ids are drawn at a new cell size
+ * the layer looks like it is scaling around the origin. `displayedBinOptions`
+ * lets renderLayers keep origin/size in lockstep with the visible bins until
+ * the new result arrives.
+ */
+export default class WorkerBackedCPUAggregator {
+  readonly binType: AggregationBinType;
+  private readonly syncAggregator: SyncAggregator;
+  private readonly requestRedraw?: () => void;
+
+  private needsUpdateFlag: boolean | boolean[] = true;
+  private jobId = 0;
+  private inFlightKey: string | null = null;
+  private result: AggregationWorkerResult | null = null;
+  /** Bin options that match `result` / the currently drawn cells. */
+  displayedBinOptions: DisplayedBinOptions | null = null;
+  private useWorkerOutput = false;
+  isPending = false;
+  private startTimer: ReturnType<typeof setTimeout> | null = null;
+  private destroyed = false;
+
+  constructor(options: WorkerBackedCPUAggregatorOptions) {
+    this.syncAggregator = options.syncAggregator;
+    this.binType = options.binType;
+    this.requestRedraw = options.requestRedraw;
+  }
+
+  get binCount(): number {
+    if (this.useWorkerOutput) {
+      return this.result?.binCount ?? 0;
+    }
+    return this.syncAggregator.binCount;
+  }
+
+  setProps(props: Record<string, any>): void {
+    // CPUAggregator.setProps Object.assign's into `this.props`, so snapshot
+    // values we need to diff before forwarding.
+    const oldProps = this.syncAggregator.props || {};
+    const prevBinKey = binOptionsKey(oldProps.binOptions);
+    const prevPointCount = oldProps.pointCount;
+    const prevOps = oldProps.operations || [];
+    const prevCustom = oldProps.customOperations;
+    this.syncAggregator.setProps(props);
+    if (props.binOptions && binOptionsKey(props.binOptions) !== prevBinKey) {
+      this.setNeedsUpdate();
+    }
+    if (props.pointCount !== undefined && props.pointCount !== prevPointCount) {
+      this.setNeedsUpdate();
+    }
+    if (props.operations) {
+      if (props.operations[0] !== prevOps[0] || props.operations[1] !== prevOps[1]) {
+        this.setNeedsUpdate();
+      }
+    }
+    if (props.customOperations && props.customOperations !== prevCustom) {
+      this.setNeedsUpdate();
+    }
+  }
+
+  setNeedsUpdate(channel?: number): void {
+    this.syncAggregator.setNeedsUpdate(channel);
+    if (channel === undefined) {
+      this.needsUpdateFlag = true;
+    } else if (this.needsUpdateFlag !== true) {
+      this.needsUpdateFlag = this.needsUpdateFlag || [];
+      this.needsUpdateFlag[channel] = true;
+    }
+  }
+
+  update(): void {
+    const dirty =
+      this.needsUpdateFlag === true ||
+      (Array.isArray(this.needsUpdateFlag) && this.needsUpdateFlag.some(Boolean));
+
+    if (this.shouldUseWorker()) {
+      this.useWorkerOutput = true;
+      if (dirty) this.updateAsync();
+      return;
+    }
+
+    this.jobId++;
+    this.inFlightKey = null;
+    if (this.startTimer != null) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    if (this.isPending) {
+      endAggregation();
+      this.isPending = false;
+    }
+    this.useWorkerOutput = false;
+    this.result = null;
+    this.displayedBinOptions = null;
+    this.syncAggregator.update();
+  }
+
+  preDraw(): void {
+    this.syncAggregator.preDraw();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    if (this.startTimer != null) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    if (this.isPending) {
+      endAggregation();
+      this.isPending = false;
+    }
+    this.syncAggregator.destroy();
+  }
+
+  getBins() {
+    if (this.useWorkerOutput) {
+      return {
+        value: this.result?.binIds || new Float32Array(0),
+        type: 'float32' as const,
+        size: 2
+      };
+    }
+    return this.syncAggregator.getBins();
+  }
+
+  getResult(channel: number) {
+    if (this.useWorkerOutput) {
+      const value = this.result
+        ? channel === 0
+          ? this.result.colorValues
+          : this.result.elevationValues
+        : new Float32Array(0);
+      const domain = this.result
+        ? channel === 0
+          ? this.result.colorDomain
+          : this.result.elevationDomain
+        : ([Infinity, -Infinity] as [number, number]);
+      return {value, type: 'float32' as const, size: 1, domain};
+    }
+    return this.syncAggregator.getResult(channel);
+  }
+
+  getResultDomain(channel: number): [number, number] {
+    if (this.useWorkerOutput) {
+      if (!this.result) return [Infinity, -Infinity];
+      return channel === 0 ? this.result.colorDomain : this.result.elevationDomain;
+    }
+    return this.syncAggregator.getResultDomain(channel);
+  }
+
+  getBin(index: number) {
+    if (this.useWorkerOutput) {
+      const result = this.result;
+      if (!result || index < 0 || index >= result.binCount) return null;
+      return {
+        id: [result.binIds[index * 2], result.binIds[index * 2 + 1]],
+        value: [result.colorValues[index], result.elevationValues[index]],
+        count: result.counts[index]
+      };
+    }
+    return this.syncAggregator.getBin(index);
+  }
+
+  /** Typed counts for all bins; avoids getBin() when building the legend map. */
+  getBinCounts(): ArrayLike<number> | null {
+    if (this.useWorkerOutput) {
+      return this.result?.counts ?? null;
+    }
+    return null;
+  }
+
+  private getProps(): Record<string, any> {
+    return this.syncAggregator.props || {};
+  }
+
+  private shouldUseWorker(): boolean {
+    const props = this.getProps();
+    const pointCount = props.pointCount || 0;
+    if (pointCount < ASYNC_CPU_AGGREGATION_THRESHOLD) return false;
+    if (!isAggregationWorkerAvailable()) return false;
+    const custom = props.customOperations || [];
+    if (custom[0] || custom[1]) return false;
+    const ops = props.operations || [];
+    if (!isBuiltInOperation(ops[0]) || !isBuiltInOperation(ops[1])) return false;
+    if (!getAttributeValue(props.attributes?.positions)) return false;
+    return true;
+  }
+
+  private fallbackToSync(): void {
+    this.jobId++;
+    this.inFlightKey = null;
+    if (this.startTimer != null) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    if (this.isPending) {
+      endAggregation();
+      this.isPending = false;
+    }
+    this.useWorkerOutput = false;
+    this.result = null;
+    this.displayedBinOptions = null;
+    try {
+      this.syncAggregator.update();
+    } catch {
+      // Keep the layer drawable; a throw here used to leave colors unset.
+    }
+    this.requestRedraw?.();
+  }
+
+  private makeJobKey(props: Record<string, any>): string | null {
+    const binOptions = props.binOptions || {};
+    const origin =
+      this.binType === 'hexagon' ? binOptions.hexOriginCommon : binOptions.cellOriginCommon;
+    if (!origin) return null;
+    const cellSize = binOptions.cellSizeCommon || [1, 1];
+    const ops = props.operations || [];
+    return [
+      this.binType,
+      props.pointCount,
+      ops[0],
+      ops[1],
+      origin[0],
+      origin[1],
+      cellSize[0] || 1,
+      cellSize[1] || 1,
+      binOptions.radiusCommon || 1
+    ].join(',');
+  }
+
+  /**
+   * Schedule copy + worker post on a later turn so Deck can finish the current
+   * pointer/draw cycle. Copying 2M points inside update() is what freezes the map.
+   */
+  private updateAsync(): void {
+    const props = this.getProps();
+    const jobKey = this.makeJobKey(props);
+    if (!jobKey) {
+      this.fallbackToSync();
+      return;
+    }
+
+    this.needsUpdateFlag = false;
+    if (this.isPending && this.inFlightKey === jobKey) {
+      return;
+    }
+
+    this.inFlightKey = jobKey;
+    const jobId = ++this.jobId;
+    if (!this.isPending) {
+      beginAggregation();
+      this.isPending = true;
+    }
+    if (this.startTimer != null) {
+      clearTimeout(this.startTimer);
+    }
+    this.startTimer = setTimeout(() => {
+      this.startTimer = null;
+      this.postWorkerJob(jobId);
+    }, 0);
+  }
+
+  private postWorkerJob(jobId: number): void {
+    if (this.destroyed || jobId !== this.jobId) return;
+    const props = this.getProps();
+    const pointCount = props.pointCount as number;
+
+    const copied = copyPositions(props.attributes?.positions, pointCount);
+    if (!copied) {
+      this.fallbackToSync();
+      return;
+    }
+    const binOptions = props.binOptions || {};
+    const origin =
+      this.binType === 'hexagon' ? binOptions.hexOriginCommon : binOptions.cellOriginCommon;
+    const cellSize = binOptions.cellSizeCommon || [1, 1];
+    if (!origin) {
+      this.fallbackToSync();
+      return;
+    }
+
+    const colorWeights = copyToFloat32(
+      getAttributeValue(props.attributes?.colorWeights),
+      pointCount,
+      1
+    );
+    const elevationWeights = copyToFloat32(
+      getAttributeValue(props.attributes?.elevationWeights),
+      pointCount,
+      1
+    );
+
+    const request = {
+      binType: this.binType,
+      pointCount,
+      positions: copied.positions,
+      positionSize: copied.positionSize,
+      preprojected: false,
+      colorWeights,
+      elevationWeights,
+      colorOperation: props.operations[0] as DeckAggregationOperation,
+      elevationOperation: props.operations[1] as DeckAggregationOperation,
+      scale: DECK_COMMON_SPACE_SCALE,
+      originX: origin[0],
+      originY: origin[1],
+      cellSizeX: cellSize[0] || 1,
+      cellSizeY: cellSize[1] || 1,
+      radiusCommon: binOptions.radiusCommon || 1
+    };
+
+    const jobBinOptions = cloneBinOptions(binOptions);
+    runAggregationInWorker(request)
+      .then(result => {
+        if (this.destroyed || jobId !== this.jobId) return;
+        this.result = result;
+        this.displayedBinOptions = jobBinOptions;
+        this.inFlightKey = null;
+        this.needsUpdateFlag = false;
+        this.isPending = false;
+        endAggregation();
+        const onUpdate = this.getProps().onUpdate;
+        onUpdate?.({channel: 0});
+        onUpdate?.({channel: 1});
+        this.requestRedraw?.();
+      })
+      .catch(() => {
+        if (this.destroyed || jobId !== this.jobId) return;
+        this.fallbackToSync();
+      });
+  }
+}

--- a/src/layers/src/aggregation-layer.ts
+++ b/src/layers/src/aggregation-layer.ts
@@ -28,6 +28,7 @@ import {booleanWithin} from '@turf/boolean-within';
 import {point as turfPoint} from '@turf/helpers';
 import {Feature, Polygon} from 'geojson';
 
+import {shouldUseAsyncCpuAggregation, toDeckAggregationOperation} from '@kepler.gl/deckgl-layers';
 import {getGeoArrowPointLayerProps, FindDefaultLayerPropsReturnValue} from './layer-utils';
 import {
   parseGeoJsonRawFeature,
@@ -130,6 +131,21 @@ function wrapOrdinalAccessor(
   };
 }
 
+/**
+ * Per-point weight for deck.gl built-in aggregation. Filtered-out points are
+ * 0 for count (SUM of ones) and NaN for field aggregations so MIN/MAX/MEAN skip them.
+ */
+function makeWeightAccessor(field: Field | null | undefined, filterData?: (d: unknown) => boolean) {
+  return (pt: {index: number}) => {
+    if (filterData && !filterData(pt)) {
+      return field ? NaN : 0;
+    }
+    if (!field) return 1;
+    const v = field.valueAccessor(pt);
+    return typeof v === 'number' && Number.isFinite(v) ? v : NaN;
+  };
+}
+
 const getLayerColorRange = (colorRange: ColorRange) => colorRange.colors.map(hexToRgb);
 
 export const aggregateRequiredColumns: ['lat', 'lng'] = ['lat', 'lng'];
@@ -199,7 +215,9 @@ export default class AggregationLayer extends Layer {
       'elevationPercentile',
       'elevationScale',
       'enableElevationZoomFactor',
-      'fixedHeight'
+      'fixedHeight',
+      // Written back from onSetColorDomain after aggregation; must not rebuild layer data.
+      'aggregatedBins'
     ];
   }
 
@@ -309,18 +327,23 @@ export default class AggregationLayer extends Layer {
   getHoverData(object: any, dataContainer: DataContainerInterface, fields: Field[]): any {
     if (!object) return object;
     const measure = this.config.visConfig.colorAggregation;
-    // aggregate all fields for the hovered group
+    const points = object.points;
+    if (!Array.isArray(points)) {
+      const colorField = this.config.colorField;
+      const aggregatedData =
+        colorField != null ? {[colorField.name]: {measure, value: object.colorValue}} : {};
+      return {aggregatedData, ...object, points: []};
+    }
     const aggregatedData = fields.reduce((accu, field) => {
       accu[field.name] = {
         measure,
-        value: aggregate(object.points, measure, (d: {index: number}) => {
+        value: aggregate(points, measure, (d: {index: number}) => {
           return field.valueAccessor(d);
         })
       };
       return accu;
     }, {});
 
-    // return aggregated object
     return {aggregatedData, ...object};
   }
 
@@ -598,6 +621,37 @@ export default class AggregationLayer extends Layer {
       ? getFilterDataFunc(gpuFilter.filterRange, getFilterValue)
       : undefined;
 
+    const {data} = this.updateData(datasets, oldLayerData);
+
+    // Large count/sum/avg/min/max jobs run in a worker using per-point weights.
+    // Custom getColorValue forces deck.gl onto a sync per-bin accessor path.
+    if (
+      shouldUseAsyncCpuAggregation(
+        data.length,
+        this.config.colorField ? this.config.visConfig.colorAggregation : 'count',
+        this.config.sizeField ? this.config.visConfig.sizeAggregation : 'count'
+      )
+    ) {
+      // No color/size field means "count points" (getValueAggrFunc ignores visConfig
+      // aggregation and returns points.length). Using MEAN of 1s makes every cell 1
+      // and the color shader divides by a zero-width domain — the grid is invisible.
+      return {
+        data,
+        getPosition,
+        _filterData: filterData,
+        getColorWeight: makeWeightAccessor(this.config.colorField, filterData),
+        getElevationWeight: makeWeightAccessor(this.config.sizeField, filterData),
+        colorAggregation: toDeckAggregationOperation(
+          this.config.colorField ? this.config.visConfig.colorAggregation : 'count',
+          {countAsSum: true}
+        ),
+        elevationAggregation: toDeckAggregationOperation(
+          this.config.sizeField ? this.config.visConfig.sizeAggregation : 'count',
+          {countAsSum: true}
+        )
+      };
+    }
+
     const aggregatePoints = getValueAggrFunc(this.getPointData);
     let getColorValue = aggregatePoints(
       this.config.colorField,
@@ -638,8 +692,6 @@ export default class AggregationLayer extends Layer {
         ? points => getElevationValue(points.filter(filterData))
         : getElevationValue;
 
-    const {data} = this.updateData(datasets, oldLayerData);
-
     const result = {
       data,
       getPosition,
@@ -667,21 +719,28 @@ export default class AggregationLayer extends Layer {
     const {visConfig} = this.config;
     const eleZoomFactor = this.getElevationZoomFactor(mapState);
 
+    const colorWeightTriggers = {
+      colorField: this.config.colorField,
+      colorAggregation: this.config.visConfig.colorAggregation,
+      filterRange: gpuFilter.filterRange,
+      ...gpuFilter.filterValueUpdateTriggers
+    };
+    const elevationWeightTriggers = {
+      sizeField: this.config.sizeField,
+      sizeAggregation: this.config.visConfig.sizeAggregation,
+      filterRange: gpuFilter.filterRange,
+      ...gpuFilter.filterValueUpdateTriggers
+    };
+
     const updateTriggers = {
       getColorValue: {
-        colorField: this.config.colorField,
-        colorAggregation: this.config.visConfig.colorAggregation,
+        ...colorWeightTriggers,
         colorRange: visConfig.colorRange,
-        colorMap: visConfig.colorRange.colorMap,
-        filterRange: gpuFilter.filterRange,
-        ...gpuFilter.filterValueUpdateTriggers
+        colorMap: visConfig.colorRange.colorMap
       },
-      getElevationValue: {
-        sizeField: this.config.sizeField,
-        sizeAggregation: this.config.visConfig.sizeAggregation,
-        filterRange: gpuFilter.filterRange,
-        ...gpuFilter.filterValueUpdateTriggers
-      }
+      getElevationValue: elevationWeightTriggers,
+      getColorWeight: colorWeightTriggers,
+      getElevationWeight: elevationWeightTriggers
     };
 
     // deck.gl's aggregation shader maps bin values to a color texture using a

--- a/src/layers/src/index.ts
+++ b/src/layers/src/index.ts
@@ -55,6 +55,7 @@ import {default as VectorTileLayer} from './vector-tile/vector-tile-layer';
 export {default as VectorTileIcon} from './vector-tile/vector-tile-icon';
 export {default as VectorTileLayer} from './vector-tile/vector-tile-layer';
 export {getNumVectorTilesBeingLoaded} from './vector-tile/loading-counter';
+export {getNumAggregationsBeingLoaded} from '@kepler.gl/deckgl-layers';
 
 import {default as RasterTileLayer} from './raster-tile/raster-tile-layer';
 export {default as RasterTileIcon} from './raster-tile/raster-tile-icon';

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -46,6 +46,7 @@ export type LayersToRender = {
 
 export type AggregationLayerHoverData = {
   points: any[];
+  count?: number;
   colorValue?: any;
   elevationValue?: any;
   aggregatedData?: Record<


### PR DESCRIPTION
## Summary
- Offload CPU grid and hexagon aggregation to a web worker for datasets of 20k+ points (count, sum, average, min, max), so pan/zoom stay responsive during the hitch that sync aggregation already has on large data.
- Keep the last cells on screen and show the existing loading indicator while the worker runs.
- Sample legend/color-domain bins so a huge occupied-cell count does not allocate millions of UI objects.

Median, mode, and stdev still run on the main thread. Stacked on #3702.

On master, 2M points at 0.01 km already completes with only a short freeze. This PR is about keeping the UI interactive during that work, and about the worse case (very small cells / occupied cells ≈ point count) that can still lock the tab.

<img width="1506" height="1022" alt="Screenshot 2026-09-07 at 4 33 48 AM" src="https://github.com/user-attachments/assets/c1511d67-5e4d-4825-8206-b7911e393ac5" />

## Related issues
- Related to https://github.com/keplergl/kepler.gl/issues/2935 (`[Bug] Keple.gl freezes when layer is changed to grid layer`).

## Test plan
- [ ] On a small dataset (<20k points), grid/hex aggregation behaves as before (sync, no spinner).
- [ ] On a large dataset (e.g. 500k–2M points), changing radius or switching to grid/hexagon shows “aggregating grid / hexagon cells” and the map still responds to pan/zoom.
- [ ] Previous cells stay at the old size until the new aggregation finishes (no cells scaling around the origin).
- [ ] Count / sum / average / min / max match the previous sync results; median / mode / stdev still work (sync).
- [ ] Hover tooltip still shows point count for worker-backed bins.