### PR TITLE
fix: draw float32 raster tiles

### DIFF
--- a/src/deckgl-layers/src/raster/webgl/texture/mask.ts
+++ b/src/deckgl-layers/src/raster/webgl/texture/mask.ts
@@ -4,7 +4,10 @@
 import type {Texture} from '@luma.gl/core';
 import {GetUniformsOutput, ShaderModule} from '../types';
 
-const inf = Math.pow(2, 62);
+// The "no bound" default for keepMin/keepMax. A tile server writes the mask in the band's own
+// data type and marks valid pixels with that type's maximum — 255 for uint8, 65535 for uint16,
+// FLT_MAX for float32 — so a smaller default discards every valid pixel of a float32 mask.
+const inf = 3.4028234663852886e38;
 
 function getUniforms(
   opts: {imageMask?: Texture; maskKeepMin?: number; maskKeepMax?: number} = {}

--- a/src/layers/src/raster-tile/raster-tile-utils.ts
+++ b/src/layers/src/raster-tile/raster-tile-utils.ts
@@ -156,17 +156,13 @@ function getPixelRange(
   const minPixelValue = 0;
   const maxPixelValue = dtypeMaxValue[dtype];
 
-  // TODO check if this early return is expected
-  if (!maxPixelValue) {
+  // Data types without a fixed maximum, such as floats, can only be rescaled from the
+  // statistics reported by the STAC metadata.
+  if (maxPixelValue === null || !Number.isFinite(maxPixelValue)) {
+    if (typeof minRasterStatsValue === 'number' && typeof maxRasterStatsValue === 'number') {
+      return [minRasterStatsValue, maxRasterStatsValue];
+    }
     return null;
-  }
-
-  if (
-    !Number.isFinite(maxPixelValue) &&
-    typeof minRasterStatsValue === 'number' &&
-    typeof maxRasterStatsValue === 'number'
-  ) {
-    return [minRasterStatsValue, maxRasterStatsValue];
   }
 
   return [minPixelValue, maxPixelValue];

--- a/test/browser/layer-tests/raster-tile-layer-specs.js
+++ b/test/browser/layer-tests/raster-tile-layer-specs.js
@@ -8,8 +8,10 @@ import {
   findAssetWithName,
   getUsableAssets,
   getRasterStatisticsMinMax,
-  filterAvailablePresets
+  filterAvailablePresets,
+  getDataSourceParams
 } from '@kepler.gl/layers';
+import {RasterWebGL} from '@kepler.gl/deckgl-layers';
 import {parseRasterMetadata} from '@kepler.gl/table';
 import {testCreateCases} from 'test/helpers/layer-utils';
 
@@ -736,6 +738,86 @@ test('#RasterTileLayer -> showTileBorders default config', t => {
     layer.config.visConfig.showTileBorders,
     true,
     'showTileBorders should be updatable to true'
+  );
+  t.end();
+});
+
+const MOCK_STAC_FLOAT32_METADATA = {
+  type: 'Feature',
+  stac_version: '1.0.0',
+  stac_extensions: ['https://stac-extensions.github.io/raster/v1.1.0/schema.json'],
+  id: 'test-float32-cog',
+  geometry: {type: 'Point', coordinates: [0, 0]},
+  bbox: [-122.5, 37.5, -122.0, 38.0],
+  links: [],
+  properties: {datetime: '2023-01-01T00:00:00Z'},
+  assets: {
+    ndvi: {
+      href: 'https://example.com/ndvi.tif',
+      type: 'image/tiff; application=geotiff',
+      'raster:bands': [
+        {
+          data_type: 'float32',
+          statistics: {minimum: -0.2, maximum: 0.92}
+        }
+      ]
+    }
+  }
+};
+
+test('#RasterTileLayer -> getDataSourceParams float32 band with statistics', t => {
+  const params = getDataSourceParams(MOCK_STAC_FLOAT32_METADATA, 'singleBand', {
+    singleBand: {assetId: 'ndvi'}
+  });
+
+  t.ok(params, 'should return data source params for a float32 band');
+  t.equal(params?.dataType, 'float32', 'should keep the float32 data type');
+  t.equal(params?.minPixelValue, -0.2, 'should take the minimum from the band statistics');
+  t.equal(params?.maxPixelValue, 0.92, 'should take the maximum from the band statistics');
+  t.end();
+});
+
+test('#RasterTileLayer -> getDataSourceParams float32 band without statistics', t => {
+  const noStatsStac = {
+    ...MOCK_STAC_FLOAT32_METADATA,
+    assets: {
+      ndvi: {
+        ...MOCK_STAC_FLOAT32_METADATA.assets.ndvi,
+        'raster:bands': [{data_type: 'float32'}]
+      }
+    }
+  };
+
+  const params = getDataSourceParams(noStatsStac, 'singleBand', {singleBand: {assetId: 'ndvi'}});
+
+  t.equal(params, null, 'should return null when there is no range to rescale against');
+  t.end();
+});
+
+test('#RasterTileLayer -> getDataSourceParams integer band uses the data type range', t => {
+  const params = getDataSourceParams(MOCK_STAC_110_METADATA, 'singleBand', {
+    singleBand: {assetId: 'data'}
+  });
+
+  t.ok(params, 'should return data source params for a uint8 band');
+  t.equal(params?.minPixelValue, 0, 'should keep the data type minimum');
+  t.equal(params?.maxPixelValue, 255, 'should keep the data type maximum');
+  t.end();
+});
+
+test('#RasterTileLayer -> float mask keeps the pixels a float32 mask marks as valid', t => {
+  // A tile server writes the mask in the band's own data type, marking valid pixels with that
+  // type's maximum: 255 for uint8, 65535 for uint16, and FLT_MAX for float32. The default upper
+  // bound therefore has to sit at or above FLT_MAX, or every valid pixel of a float raster is
+  // discarded and the layer draws nothing.
+  const FLOAT32_MAX = 3.4028234663852886e38;
+  const uniforms = RasterWebGL.maskFloat.getUniforms({imageMask: {}, maskKeepMin: 1});
+
+  t.ok(uniforms, 'should return uniforms for a mask texture');
+  t.equal(uniforms.keepMin, 1, 'should keep the given lower bound');
+  t.ok(
+    uniforms.keepMax >= FLOAT32_MAX,
+    `should not discard valid float pixels: keepMax ${uniforms.keepMax} < ${FLOAT32_MAX}`
   );
   t.end();
 });


### PR DESCRIPTION
## Problem

A `float32` raster never draws through `RasterTileLayer`. The layer mounts, the
STAC metadata is read, and then nothing happens: no tiles are requested, no
error is logged, no warning is shown. There are **two** guards in the way, and
the first hides the second.

### 1. `getPixelRange` gives up on any data type without a fixed maximum

`dtypeMaxValue.float32` is `null` (as are `float64`, `int64`, `uint64`), so
`getPixelRange` returns before it can look anywhere else:

```js
const maxPixelValue = dtypeMaxValue[dtype];

// TODO check if this early return is expected
if (!maxPixelValue) {
  return null;
}

if (
  !Number.isFinite(maxPixelValue) &&        // unreachable
  typeof minRasterStatsValue === 'number' &&
  typeof maxRasterStatsValue === 'number'
) {
  return [minRasterStatsValue, maxRasterStatsValue];
}
```

The fallback for exactly this case — the band statistics carried by the STAC
metadata — is written on the next line and can never run: no entry in
`dtypeMaxValue` is both truthy and non-finite, so `!Number.isFinite(maxPixelValue)`
is unreachable. The statistics path is there and disabled.

`getDataSourceParams` then returns `null`, and the layer requests no tiles at all.

### 2. The float mask discards every valid pixel

`raster/webgl/texture/mask.ts` uses `Math.pow(2, 62)` as its "no bound" default:

```js
const inf = Math.pow(2, 62);   // 4.6e18
...
if (mask_value > mask_image_float.keepMax) discard;
```

A tile server writes the mask in the band's own data type and marks valid pixels
with that type's maximum — 255 for `uint8`, 65535 for `uint16`, and `FLT_MAX`
(3.4028235e38) for `float32`. kepler's own comment in `gpu-utils.ts` says as much:

```js
// In general, data masks are 0 for nodata and the maximum value for valid data,
// e.g. 255 or 65535 for uint8 or uint16 data, respectively
moduleProps.maskKeepMin = 1;
```

3.4e38 is greater than 4.6e18, so for a float32 mask the upper bound discards
every valid pixel and the tile disappears — again with no error.

### Reproduced

A float32 NDVI COG served by TiTiler 2.2.1, whose `/cog/stac` carries
`raster:bands[0].statistics` (`{"minimum": -0.0131, "maximum": 0.7516}`), loaded
as a `raster-tile` dataset:

| | `/cog/stac` requests | tile requests | pixels drawn |
|---|---|---|---|
| master | 1 | 0 | 0 |
| with fix 1 only | 1 | 4 | 0 |
| with both fixes | 1 | 4 | 409,045 |

The same COG rewritten as `uint16` draws on master, which is the workaround this
has been costing users.

## Fix

- **`getPixelRange`**: when the data type has no fixed maximum, use the STAC band
  statistics, and return `null` only when there are none — nothing to rescale
  against. Integer types keep their current `[0, dtypeMaxValue]` range.
- **`mask.ts`**: raise the unbounded sentinel to `FLT_MAX`, so "no upper bound"
  really is no upper bound for a float32 mask. Anything a mask can carry is now
  inside it.

## Not fixed here

`getRasterStatisticsMinMax` returns statistics only for the `singleBand` preset,
so a float32 **multi-band** composite (`trueColor` and friends) still has no
range and still will not draw. That looked like a separate decision about where
the range for a composite should come from, so this PR leaves it alone. Happy to
widen it if you would rather have both in one change.

## Tests

Four cases in `test/browser/layer-tests/raster-tile-layer-specs.js`:

- `getDataSourceParams float32 band with statistics` — fails on master
- `getDataSourceParams float32 band without statistics` — still `null`
- `getDataSourceParams integer band uses the data type range` — unchanged behaviour
- `float mask keeps the pixels a float32 mask marks as valid` — fails on master

Full browser suite: 3597 → 3600 passing, no failures. `tsc --noEmit` clean,
`eslint` clean on the touched files.
