### PR TITLE
feat: add left and below placement for annotation text

### DIFF
--- a/src/components/src/annotations/annotation-panel.tsx
+++ b/src/components/src/annotations/annotation-panel.tsx
@@ -17,8 +17,13 @@ import {visStateLens, mapStateLens} from '@kepler.gl/reducers';
 import {Annotation} from '@kepler.gl/types';
 import {
   AnnotationKind,
+  AnnotationTextSide,
+  AnnotationTextVerticalPosition,
   ANNOTATION_KINDS,
-  ANNOTATION_LINE_WIDTH_OPTIONS
+  ANNOTATION_LINE_WIDTH_OPTIONS,
+  ANNOTATION_TEXT_SIDES,
+  ANNOTATION_TEXT_VERTICAL_POSITIONS,
+  isAnnotationWithArm
 } from '@kepler.gl/constants';
 import {VisState} from '@kepler.gl/schemas';
 import {MapState} from '@kepler.gl/types';
@@ -30,6 +35,7 @@ import Portaled from '../common/portaled';
 import SingleColorPalette from '../side-panel/layer-panel/single-color-palette';
 import {hexToRgb, rgbToHex} from '@kepler.gl/utils';
 import {FormattedMessage} from '@kepler.gl/localization';
+import {angleForTextPlacement, getTextPlacement} from './annotation-utils';
 
 // Styled components
 
@@ -383,6 +389,28 @@ export default function AnnotationManagerFactory(): React.FC<any> {
       [visStateActions]
     );
 
+    const handleChangeTextPlacement = useCallback(
+      (
+        annotation: Annotation,
+        next: {
+          textSide?: AnnotationTextSide;
+          textVerticalPosition?: AnnotationTextVerticalPosition;
+        }
+      ) => {
+        const current = getTextPlacement(annotation);
+        const textSide = next.textSide ?? current.side;
+        const textVerticalPosition = next.textVerticalPosition ?? current.vertical;
+        visStateActions.updateAnnotation(annotation.id, {
+          textSide,
+          textVerticalPosition,
+          ...(isAnnotationWithArm(annotation)
+            ? {angle: angleForTextPlacement(textSide, textVerticalPosition)}
+            : {})
+        });
+      },
+      [visStateActions]
+    );
+
     return (
       <StyledAnnotationPanelContainer className="annotation-manager">
         <StyledAnnotationPanel>
@@ -400,6 +428,7 @@ export default function AnnotationManagerFactory(): React.FC<any> {
           <StyledAnnotationPanelContent>
             {annotations.map(annotation => {
               const isSelected = annotation.id === selectedAnnotationId;
+              const textPlacement = getTextPlacement(annotation);
               return (
                 <StyledAnnotationItemWrapper key={annotation.id}>
                   <StyledAnnotationItemHeader
@@ -553,6 +582,50 @@ export default function AnnotationManagerFactory(): React.FC<any> {
                           color={hexToRgb(annotation.lineColor)}
                           onSetColor={rgb => handleChangeLineColor(annotation.id, rgb)}
                         />
+                      </StyledConfigRow>
+                      <StyledConfigRow>
+                        <StyledConfigLabel>
+                          {intl.formatMessage({
+                            id: 'annotationManager.textSide',
+                            defaultMessage: 'Text Side'
+                          })}
+                        </StyledConfigLabel>
+                        <StyledSelect
+                          value={textPlacement.side}
+                          onChange={e =>
+                            handleChangeTextPlacement(annotation, {
+                              textSide: e.target.value as AnnotationTextSide
+                            })
+                          }
+                        >
+                          {ANNOTATION_TEXT_SIDES.map(s => (
+                            <option key={s.id} value={s.id}>
+                              {s.label}
+                            </option>
+                          ))}
+                        </StyledSelect>
+                      </StyledConfigRow>
+                      <StyledConfigRow>
+                        <StyledConfigLabel>
+                          {intl.formatMessage({
+                            id: 'annotationManager.textPlacement',
+                            defaultMessage: 'Placement'
+                          })}
+                        </StyledConfigLabel>
+                        <StyledSelect
+                          value={textPlacement.vertical}
+                          onChange={e =>
+                            handleChangeTextPlacement(annotation, {
+                              textVerticalPosition: e.target.value as AnnotationTextVerticalPosition
+                            })
+                          }
+                        >
+                          {ANNOTATION_TEXT_VERTICAL_POSITIONS.map(p => (
+                            <option key={p.id} value={p.id}>
+                              {p.label}
+                            </option>
+                          ))}
+                        </StyledSelect>
                       </StyledConfigRow>
                     </StyledConfigSection>
                   ) : null}

--- a/src/components/src/annotations/annotation-text.tsx
+++ b/src/components/src/annotations/annotation-text.tsx
@@ -4,9 +4,8 @@
 import React, {FC, useCallback, useEffect, useMemo} from 'react';
 import styled from 'styled-components';
 import {useDraggable} from '@dnd-kit/core';
-import {Annotation, AnnotationWithArm} from '@kepler.gl/types';
-import {AnnotationKind} from '@kepler.gl/constants';
-import {makeMarker, isLeftOriented, MapViewport} from './annotation-utils';
+import {Annotation} from '@kepler.gl/types';
+import {getAnnotationTextBoxStyle, MapViewport} from './annotation-utils';
 import {LexicalRichTextEditor, LexicalToolbar} from './lexical-editor';
 import {SerializedEditorState} from 'lexical';
 
@@ -101,38 +100,11 @@ const AnnotationText: FC<AnnotationTextProps> = ({
     id: `${annotation.id}:MOVE_TEXT`
   });
 
-  const {textWidth, textHeight, lineColor, lineWidth, textVerticalAlign, autoSize, kind} =
-    annotation;
-  const {x, y, tx, ty} = makeMarker(annotation, viewport);
-
-  const isArm = 'armLength' in annotation;
-  const isLeft = isArm && isLeftOriented((annotation as AnnotationWithArm).angle);
+  const {textWidth, textHeight, textVerticalAlign} = annotation;
 
   const style = useMemo(
-    () => ({
-      ...(autoSize ? {minWidth: 80} : {width: textWidth || 120}),
-      bottom: viewport.height - (y + ty),
-      borderBottom: kind !== AnnotationKind.TEXT ? `${lineWidth}px solid ${lineColor}` : undefined,
-      ...(kind === AnnotationKind.TEXT
-        ? {left: x + tx - (textWidth || 80) / 2}
-        : isLeft
-        ? {right: viewport.width - x - tx}
-        : {left: x + tx})
-    }),
-    [
-      autoSize,
-      kind,
-      textWidth,
-      tx,
-      ty,
-      viewport.width,
-      viewport.height,
-      x,
-      y,
-      isLeft,
-      lineWidth,
-      lineColor
-    ]
+    () => getAnnotationTextBoxStyle(annotation, viewport),
+    [annotation, viewport]
   );
 
   const handleEditorChange = useCallback(

--- a/src/components/src/annotations/annotation-utils.ts
+++ b/src/components/src/annotations/annotation-utils.ts
@@ -8,7 +8,10 @@ import {
   AnnotationTextSide,
   AnnotationTextVerticalPosition,
   ANNOTATION_ANGLE_BY_PLACEMENT,
-  isAnnotationWithArm
+  isAnnotationWithArm,
+  isLeftOriented,
+  isBelowOriented,
+  textPlacementFromAngle
 } from '@kepler.gl/constants';
 
 export type MapViewport = {
@@ -80,13 +83,7 @@ export function makeMarker(annotation: Annotation, viewport: MapViewport): Annot
   }
 }
 
-export function isLeftOriented(angle: number): boolean {
-  return angle > 90 || angle < -90;
-}
-
-export function isBelowOriented(angle: number): boolean {
-  return angle > 0 && angle < 180;
-}
+export {isLeftOriented, isBelowOriented, textPlacementFromAngle};
 
 export type AnnotationTextPlacement = {
   side: AnnotationTextSide;
@@ -108,13 +105,6 @@ export function angleForTextPlacement(
   vertical: AnnotationTextVerticalPosition
 ): number {
   return ANNOTATION_ANGLE_BY_PLACEMENT[`${side}-${vertical}`];
-}
-
-export function textPlacementFromAngle(angle: number): AnnotationTextPlacement {
-  return {
-    side: isLeftOriented(angle) ? 'left' : 'right',
-    vertical: isBelowOriented(angle) ? 'below' : 'above'
-  };
 }
 
 export type AnnotationTextBoxStyle = {
@@ -151,7 +141,11 @@ export function getAnnotationTextBoxStyle(
     }
   }
 
-  if (side === 'left') {
+  if (kind === AnnotationKind.TEXT && side !== 'left') {
+    // TEXT has no leader; keep the box centered on the anchor unless it is
+    // explicitly placed on the left (matches pre-placement TEXT rendering).
+    style.left = px - (textWidth || 80) / 2;
+  } else if (side === 'left') {
     style.right = viewport.width - px;
   } else {
     style.left = px;

--- a/src/components/src/annotations/annotation-utils.ts
+++ b/src/components/src/annotations/annotation-utils.ts
@@ -3,7 +3,13 @@
 
 import {addMetersToLngLat} from '@math.gl/web-mercator';
 import {Annotation, AnnotationWithArm} from '@kepler.gl/types';
-import {AnnotationKind, isAnnotationWithArm} from '@kepler.gl/constants';
+import {
+  AnnotationKind,
+  AnnotationTextSide,
+  AnnotationTextVerticalPosition,
+  ANNOTATION_ANGLE_BY_PLACEMENT,
+  isAnnotationWithArm
+} from '@kepler.gl/constants';
 
 export type MapViewport = {
   project: (lngLat: [number, number]) => [number, number];
@@ -78,6 +84,82 @@ export function isLeftOriented(angle: number): boolean {
   return angle > 90 || angle < -90;
 }
 
+export function isBelowOriented(angle: number): boolean {
+  return angle > 0 && angle < 180;
+}
+
+export type AnnotationTextPlacement = {
+  side: AnnotationTextSide;
+  vertical: AnnotationTextVerticalPosition;
+};
+
+export function getTextPlacement(annotation: Annotation): AnnotationTextPlacement {
+  const side: AnnotationTextSide =
+    annotation.textSide ??
+    (isAnnotationWithArm(annotation) && isLeftOriented(annotation.angle) ? 'left' : 'right');
+  const vertical: AnnotationTextVerticalPosition =
+    annotation.textVerticalPosition ??
+    (isAnnotationWithArm(annotation) && isBelowOriented(annotation.angle) ? 'below' : 'above');
+  return {side, vertical};
+}
+
+export function angleForTextPlacement(
+  side: AnnotationTextSide,
+  vertical: AnnotationTextVerticalPosition
+): number {
+  return ANNOTATION_ANGLE_BY_PLACEMENT[`${side}-${vertical}`];
+}
+
+export function textPlacementFromAngle(angle: number): AnnotationTextPlacement {
+  return {
+    side: isLeftOriented(angle) ? 'left' : 'right',
+    vertical: isBelowOriented(angle) ? 'below' : 'above'
+  };
+}
+
+export type AnnotationTextBoxStyle = {
+  minWidth?: number;
+  width?: number;
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+  borderTop?: string;
+  borderBottom?: string;
+};
+
+export function getAnnotationTextBoxStyle(
+  annotation: Annotation,
+  viewport: MapViewport
+): AnnotationTextBoxStyle {
+  const {textWidth, lineColor, lineWidth, autoSize, kind} = annotation;
+  const {x, y, tx, ty} = makeMarker(annotation, viewport);
+  const {side, vertical} = getTextPlacement(annotation);
+  const px = x + tx;
+  const py = y + ty;
+  const style: AnnotationTextBoxStyle = autoSize ? {minWidth: 80} : {width: textWidth || 120};
+
+  if (vertical === 'below') {
+    style.top = py;
+    if (kind !== AnnotationKind.TEXT) {
+      style.borderTop = `${lineWidth}px solid ${lineColor}`;
+    }
+  } else {
+    style.bottom = viewport.height - py;
+    if (kind !== AnnotationKind.TEXT) {
+      style.borderBottom = `${lineWidth}px solid ${lineColor}`;
+    }
+  }
+
+  if (side === 'left') {
+    style.right = viewport.width - px;
+  } else {
+    style.left = px;
+  }
+
+  return style;
+}
+
 /** Great-circle angular distance between two lng/lat points, in degrees. */
 function angularDistanceDeg(a: [number, number], b: [number, number]): number {
   const toRad = Math.PI / 180;
@@ -147,6 +229,7 @@ export function moveText(
 
   const [tx1, ty1] = [tx + delta.x, ty + delta.y];
   const nextAngle = radiansToDegrees(Math.atan2(ty1, tx1));
+  const {side, vertical} = textPlacementFromAngle(nextAngle);
   let nextArm: number;
 
   switch (kind) {
@@ -160,7 +243,12 @@ export function moveText(
     default:
       nextArm = (annotation as AnnotationWithArm).armLength;
   }
-  return {angle: nextAngle, armLength: nextArm};
+  return {
+    angle: nextAngle,
+    armLength: nextArm,
+    textSide: side,
+    textVerticalPosition: vertical
+  };
 }
 
 export function resizeCircle(

--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -386,6 +386,7 @@ export {
   isBelowOriented,
   getTextPlacement,
   angleForTextPlacement,
+  textPlacementFromAngle,
   getAnnotationTextBoxStyle,
   isPointVisibleOnGlobe
 } from './annotations';

--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -383,6 +383,10 @@ export {
   moveText,
   resizeCircle,
   isLeftOriented,
+  isBelowOriented,
+  getTextPlacement,
+  angleForTextPlacement,
+  getAnnotationTextBoxStyle,
   isPointVisibleOnGlobe
 } from './annotations';
 export type {MapViewport, AnnotationMarker} from './annotations';

--- a/src/constants/src/annotation.ts
+++ b/src/constants/src/annotation.ts
@@ -26,6 +26,12 @@ export const INITIAL_ANNOTATION_TEXT_HEIGHT = 0;
 export const INITIAL_ANNOTATION_LINE_WIDTH = 2;
 export const INITIAL_ANNOTATION_LINE_COLOR = '#FFFFFF';
 
+export type AnnotationTextSide = 'left' | 'right';
+export type AnnotationTextVerticalPosition = 'above' | 'below';
+
+export const INITIAL_ANNOTATION_TEXT_SIDE: AnnotationTextSide = 'right';
+export const INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION: AnnotationTextVerticalPosition = 'above';
+
 export const ANNOTATION_KINDS = [
   {id: AnnotationKind.TEXT, label: 'Text'},
   {id: AnnotationKind.POINT, label: 'Point'},
@@ -34,3 +40,27 @@ export const ANNOTATION_KINDS = [
 ];
 
 export const ANNOTATION_LINE_WIDTH_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+export const ANNOTATION_TEXT_SIDES: Array<{id: AnnotationTextSide; label: string}> = [
+  {id: 'right', label: 'Right'},
+  {id: 'left', label: 'Left'}
+];
+
+export const ANNOTATION_TEXT_VERTICAL_POSITIONS: Array<{
+  id: AnnotationTextVerticalPosition;
+  label: string;
+}> = [
+  {id: 'above', label: 'Above'},
+  {id: 'below', label: 'Below'}
+];
+
+/** Canonical arm angle for a text-side + vertical-position pair (screen y-down). */
+export const ANNOTATION_ANGLE_BY_PLACEMENT: Record<
+  `${AnnotationTextSide}-${AnnotationTextVerticalPosition}`,
+  number
+> = {
+  'right-above': INITIAL_ANNOTATION_ANGLE,
+  'left-above': -135,
+  'right-below': 45,
+  'left-below': 135
+};

--- a/src/constants/src/annotation.ts
+++ b/src/constants/src/annotation.ts
@@ -64,3 +64,21 @@ export const ANNOTATION_ANGLE_BY_PLACEMENT: Record<
   'right-below': 45,
   'left-below': 135
 };
+
+export function isLeftOriented(angle: number): boolean {
+  return angle > 90 || angle < -90;
+}
+
+export function isBelowOriented(angle: number): boolean {
+  return angle > 0 && angle < 180;
+}
+
+export function textPlacementFromAngle(angle: number): {
+  side: AnnotationTextSide;
+  vertical: AnnotationTextVerticalPosition;
+} {
+  return {
+    side: isLeftOriented(angle) ? 'left' : 'right',
+    vertical: isBelowOriented(angle) ? 'below' : 'above'
+  };
+}

--- a/src/localization/src/translations/ca.ts
+++ b/src/localization/src/translations/ca.ts
@@ -241,7 +241,9 @@ export default {
     addAnnotation: 'Afegir',
     type: 'Tipus',
     lineWidth: 'Amplada de línia',
-    color: 'Color'
+    color: 'Color',
+    textSide: 'Costat del text',
+    textPlacement: 'Col·locació'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/cn.ts
+++ b/src/localization/src/translations/cn.ts
@@ -237,7 +237,9 @@ export default {
     addAnnotation: '添加',
     type: '类型',
     lineWidth: '线宽',
-    color: '颜色'
+    color: '颜色',
+    textSide: '文本位置',
+    textPlacement: '对齐'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/en.ts
+++ b/src/localization/src/translations/en.ts
@@ -285,7 +285,9 @@ export default {
     addAnnotation: 'Add',
     type: 'Type',
     lineWidth: 'Line Width',
-    color: 'Color'
+    color: 'Color',
+    textSide: 'Text Side',
+    textPlacement: 'Placement'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/es.ts
+++ b/src/localization/src/translations/es.ts
@@ -242,7 +242,9 @@ export default {
     addAnnotation: 'Añadir',
     type: 'Tipo',
     lineWidth: 'Ancho de línea',
-    color: 'Color'
+    color: 'Color',
+    textSide: 'Lado del texto',
+    textPlacement: 'Colocación'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/fi.ts
+++ b/src/localization/src/translations/fi.ts
@@ -240,7 +240,9 @@ export default {
     addAnnotation: 'Lisää',
     type: 'Tyyppi',
     lineWidth: 'Viivan leveys',
-    color: 'Väri'
+    color: 'Väri',
+    textSide: 'Tekstin puoli',
+    textPlacement: 'Sijoittelu'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/ja.ts
+++ b/src/localization/src/translations/ja.ts
@@ -239,7 +239,9 @@ export default {
     addAnnotation: '追加',
     type: 'タイプ',
     lineWidth: '線幅',
-    color: '色'
+    color: '色',
+    textSide: 'テキストの位置',
+    textPlacement: '配置'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/pt.ts
+++ b/src/localization/src/translations/pt.ts
@@ -242,7 +242,9 @@ export default {
     addAnnotation: 'Adicionar',
     type: 'Tipo',
     lineWidth: 'Largura da linha',
-    color: 'Cor'
+    color: 'Cor',
+    textSide: 'Lado do texto',
+    textPlacement: 'Posição'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/localization/src/translations/ru.ts
+++ b/src/localization/src/translations/ru.ts
@@ -241,7 +241,9 @@ export default {
     addAnnotation: 'Добавить',
     type: 'Тип',
     lineWidth: 'Толщина линии',
-    color: 'Цвет'
+    color: 'Цвет',
+    textSide: 'Сторона текста',
+    textPlacement: 'Размещение'
   },
   effectDescription: {
     lightAndShadow:

--- a/src/reducers/src/vis-state-merger.ts
+++ b/src/reducers/src/vis-state-merger.ts
@@ -24,7 +24,9 @@ import {
   OVERLAY_BLENDINGS,
   isAnnotationKind,
   INITIAL_ANNOTATION_LINE_COLOR,
-  INITIAL_ANNOTATION_LINE_WIDTH
+  INITIAL_ANNOTATION_LINE_WIDTH,
+  INITIAL_ANNOTATION_TEXT_SIDE,
+  INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION
 } from '@kepler.gl/constants';
 import {CURRENT_VERSION, VisState, VisStateMergers, KeplerGLSchemaClass} from '@kepler.gl/schemas';
 
@@ -744,6 +746,8 @@ export function mergeAnnotations<S extends VisState>(state: S, annotations: any[
       lineWidth: INITIAL_ANNOTATION_LINE_WIDTH,
       textWidth: 0,
       textHeight: 0,
+      textSide: INITIAL_ANNOTATION_TEXT_SIDE,
+      textVerticalPosition: INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION,
       ...a
     }));
   if (!validAnnotations.length) {

--- a/src/reducers/src/vis-state-merger.ts
+++ b/src/reducers/src/vis-state-merger.ts
@@ -24,9 +24,7 @@ import {
   OVERLAY_BLENDINGS,
   isAnnotationKind,
   INITIAL_ANNOTATION_LINE_COLOR,
-  INITIAL_ANNOTATION_LINE_WIDTH,
-  INITIAL_ANNOTATION_TEXT_SIDE,
-  INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION
+  INITIAL_ANNOTATION_LINE_WIDTH
 } from '@kepler.gl/constants';
 import {CURRENT_VERSION, VisState, VisStateMergers, KeplerGLSchemaClass} from '@kepler.gl/schemas';
 
@@ -746,8 +744,6 @@ export function mergeAnnotations<S extends VisState>(state: S, annotations: any[
       lineWidth: INITIAL_ANNOTATION_LINE_WIDTH,
       textWidth: 0,
       textHeight: 0,
-      textSide: INITIAL_ANNOTATION_TEXT_SIDE,
-      textVerticalPosition: INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION,
       ...a
     }));
   if (!validAnnotations.length) {

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -117,6 +117,9 @@ import {
   INITIAL_ANNOTATION_TEXT_HEIGHT,
   INITIAL_ANNOTATION_LINE_WIDTH,
   INITIAL_ANNOTATION_LINE_COLOR,
+  INITIAL_ANNOTATION_TEXT_SIDE,
+  INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION,
+  ANNOTATION_ANGLE_BY_PLACEMENT,
   AnnotationKind,
   DatasetType,
   getDatasetRefreshIntervalMs,
@@ -2472,6 +2475,9 @@ export const updateEffectUpdater = (
 
 function makeNewAnnotation(config?: AnnotationPropsPartial): Annotation {
   const kind = config?.kind ?? INITIAL_ANNOTATION_KIND;
+  const textSide = config?.textSide ?? INITIAL_ANNOTATION_TEXT_SIDE;
+  const textVerticalPosition =
+    config?.textVerticalPosition ?? INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION;
   const base = {
     id: config?.id ?? generateHashId(6),
     kind,
@@ -2485,8 +2491,14 @@ function makeNewAnnotation(config?: AnnotationPropsPartial): Annotation {
     textWidth: config?.textWidth ?? INITIAL_ANNOTATION_TEXT_WIDTH,
     textHeight: config?.textHeight ?? INITIAL_ANNOTATION_TEXT_HEIGHT,
     textVerticalAlign: config?.textVerticalAlign ?? ('bottom' as const),
+    textSide,
+    textVerticalPosition,
     mapIndex: config?.mapIndex
   };
+
+  const defaultAngle =
+    ANNOTATION_ANGLE_BY_PLACEMENT[`${textSide}-${textVerticalPosition}`] ??
+    INITIAL_ANNOTATION_ANGLE;
 
   switch (kind) {
     case AnnotationKind.POINT:
@@ -2494,21 +2506,21 @@ function makeNewAnnotation(config?: AnnotationPropsPartial): Annotation {
         ...base,
         kind: AnnotationKind.POINT,
         armLength: (config as any)?.armLength ?? INITIAL_ANNOTATION_ARM_LENGTH,
-        angle: (config as any)?.angle ?? INITIAL_ANNOTATION_ANGLE
+        angle: (config as any)?.angle ?? defaultAngle
       };
     case AnnotationKind.ARROW:
       return {
         ...base,
         kind: AnnotationKind.ARROW,
         armLength: (config as any)?.armLength ?? INITIAL_ANNOTATION_ARM_LENGTH,
-        angle: (config as any)?.angle ?? INITIAL_ANNOTATION_ANGLE
+        angle: (config as any)?.angle ?? defaultAngle
       };
     case AnnotationKind.CIRCLE:
       return {
         ...base,
         kind: AnnotationKind.CIRCLE,
         armLength: (config as any)?.armLength ?? INITIAL_ANNOTATION_ARM_LENGTH,
-        angle: (config as any)?.angle ?? INITIAL_ANNOTATION_ANGLE,
+        angle: (config as any)?.angle ?? defaultAngle,
         radiusInMeters: (config as any)?.radiusInMeters ?? 1000
       };
     case AnnotationKind.TEXT:

--- a/src/reducers/src/vis-state-updaters.ts
+++ b/src/reducers/src/vis-state-updaters.ts
@@ -120,6 +120,7 @@ import {
   INITIAL_ANNOTATION_TEXT_SIDE,
   INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION,
   ANNOTATION_ANGLE_BY_PLACEMENT,
+  textPlacementFromAngle,
   AnnotationKind,
   DatasetType,
   getDatasetRefreshIntervalMs,
@@ -2475,9 +2476,17 @@ export const updateEffectUpdater = (
 
 function makeNewAnnotation(config?: AnnotationPropsPartial): Annotation {
   const kind = config?.kind ?? INITIAL_ANNOTATION_KIND;
-  const textSide = config?.textSide ?? INITIAL_ANNOTATION_TEXT_SIDE;
+  const providedAngle = Number.isFinite((config as any)?.angle) ? (config as any).angle : undefined;
+  const derivedFromAngle =
+    providedAngle != null ? textPlacementFromAngle(providedAngle) : undefined;
+  const textSide =
+    config?.textSide ??
+    derivedFromAngle?.side ??
+    (kind === AnnotationKind.TEXT ? undefined : INITIAL_ANNOTATION_TEXT_SIDE);
   const textVerticalPosition =
-    config?.textVerticalPosition ?? INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION;
+    config?.textVerticalPosition ??
+    derivedFromAngle?.vertical ??
+    (kind === AnnotationKind.TEXT ? undefined : INITIAL_ANNOTATION_TEXT_VERTICAL_POSITION);
   const base = {
     id: config?.id ?? generateHashId(6),
     kind,
@@ -2491,14 +2500,15 @@ function makeNewAnnotation(config?: AnnotationPropsPartial): Annotation {
     textWidth: config?.textWidth ?? INITIAL_ANNOTATION_TEXT_WIDTH,
     textHeight: config?.textHeight ?? INITIAL_ANNOTATION_TEXT_HEIGHT,
     textVerticalAlign: config?.textVerticalAlign ?? ('bottom' as const),
-    textSide,
-    textVerticalPosition,
+    ...(textSide ? {textSide} : {}),
+    ...(textVerticalPosition ? {textVerticalPosition} : {}),
     mapIndex: config?.mapIndex
   };
 
   const defaultAngle =
-    ANNOTATION_ANGLE_BY_PLACEMENT[`${textSide}-${textVerticalPosition}`] ??
-    INITIAL_ANNOTATION_ANGLE;
+    textSide && textVerticalPosition
+      ? ANNOTATION_ANGLE_BY_PLACEMENT[`${textSide}-${textVerticalPosition}`]
+      : INITIAL_ANNOTATION_ANGLE;
 
   switch (kind) {
     case AnnotationKind.POINT:
@@ -2506,21 +2516,21 @@ function makeNewAnnotation(config?: AnnotationPropsPartial): Annotation {
         ...base,
         kind: AnnotationKind.POINT,
         armLength: (config as any)?.armLength ?? INITIAL_ANNOTATION_ARM_LENGTH,
-        angle: (config as any)?.angle ?? defaultAngle
+        angle: providedAngle ?? defaultAngle
       };
     case AnnotationKind.ARROW:
       return {
         ...base,
         kind: AnnotationKind.ARROW,
         armLength: (config as any)?.armLength ?? INITIAL_ANNOTATION_ARM_LENGTH,
-        angle: (config as any)?.angle ?? defaultAngle
+        angle: providedAngle ?? defaultAngle
       };
     case AnnotationKind.CIRCLE:
       return {
         ...base,
         kind: AnnotationKind.CIRCLE,
         armLength: (config as any)?.armLength ?? INITIAL_ANNOTATION_ARM_LENGTH,
-        angle: (config as any)?.angle ?? defaultAngle,
+        angle: providedAngle ?? defaultAngle,
         radiusInMeters: (config as any)?.radiusInMeters ?? 1000
       };
     case AnnotationKind.TEXT:

--- a/src/schemas/src/vis-state-schema.ts
+++ b/src/schemas/src/vis-state-schema.ts
@@ -872,6 +872,8 @@ const annotationPropsV1 = {
   textWidth: null,
   textHeight: null,
   textVerticalAlign: null,
+  textSide: null,
+  textVerticalPosition: null,
   armLength: null,
   angle: null,
   radiusInMeters: null

--- a/src/types/annotations.d.ts
+++ b/src/types/annotations.d.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright contributors to the kepler.gl project
 
-import {AnnotationKind} from '@kepler.gl/constants';
+import {
+  AnnotationKind,
+  AnnotationTextSide,
+  AnnotationTextVerticalPosition
+} from '@kepler.gl/constants';
 
 export {AnnotationKind} from '@kepler.gl/constants';
 export {isAnnotationKind, isAnnotationWithArm} from '@kepler.gl/constants';
@@ -21,6 +25,8 @@ export type BaseAnnotation = {
   textWidth: number;
   textHeight: number;
   textVerticalAlign?: 'top' | 'middle' | 'bottom';
+  textSide?: AnnotationTextSide;
+  textVerticalPosition?: AnnotationTextVerticalPosition;
 };
 
 export type AnnotationWithArm = BaseAnnotation & {

--- a/test/node/reducers/annotation-merger-test.js
+++ b/test/node/reducers/annotation-merger-test.js
@@ -112,6 +112,25 @@ test('#mergeAnnotations -> should validate annotation kind', t => {
   t.end();
 });
 
+test('#mergeAnnotations -> should not stamp default text placement on legacy annotations', t => {
+  const state = makeState();
+  const annotations = [
+    makeAnnotation({id: 'legacy', angle: 180, textSide: undefined, textVerticalPosition: undefined})
+  ];
+  // omit the new fields the way saved maps without them look
+  delete annotations[0].textSide;
+  delete annotations[0].textVerticalPosition;
+
+  const result = mergeAnnotations(state, annotations);
+
+  t.equal(result.annotations.length, 1, 'should merge the legacy annotation');
+  t.notOk(result.annotations[0].textSide, 'should not default textSide');
+  t.notOk(result.annotations[0].textVerticalPosition, 'should not default textVerticalPosition');
+  t.equal(result.annotations[0].angle, 180, 'should keep saved angle');
+
+  t.end();
+});
+
 test('#mergeAnnotations -> should return same state when all annotations are invalid', t => {
   const state = makeState();
   const annotations = [

--- a/test/node/reducers/annotation-updater-test.js
+++ b/test/node/reducers/annotation-updater-test.js
@@ -21,6 +21,8 @@ test('#visStateReducer -> ADD_ANNOTATION', t => {
   t.equal(state.annotations[0].kind, AnnotationKind.POINT, 'should default to POINT kind');
   t.equal(state.annotations[0].isVisible, true, 'should be visible by default');
   t.equal(state.annotations[0].label, 'New Annotation', 'should have default label');
+  t.equal(state.annotations[0].textSide, 'right', 'should default text to the right');
+  t.equal(state.annotations[0].textVerticalPosition, 'above', 'should default text above');
   t.equal(state.selectedAnnotationId, state.annotations[0].id, 'should select new annotation');
   t.equal(state.isEditingAnnotationText, true, 'should start editing text');
 
@@ -145,6 +147,32 @@ test('#visStateReducer -> UPDATE_ANNOTATION with kind change', t => {
 
   t.equal(state.annotations[0].kind, AnnotationKind.CIRCLE, 'should change kind');
   t.ok('radiusInMeters' in state.annotations[0], 'should add CIRCLE-specific properties');
+
+  t.end();
+});
+
+test('#visStateReducer -> UPDATE_ANNOTATION text placement snaps arm angle', t => {
+  let state = reducer(
+    initialState,
+    VisStateActions.addAnnotation({
+      anchorPoint: [0, 0],
+      kind: AnnotationKind.POINT
+    })
+  );
+  const id = state.annotations[0].id;
+
+  state = reducer(
+    state,
+    VisStateActions.updateAnnotation(id, {
+      textSide: 'left',
+      textVerticalPosition: 'below',
+      angle: 135
+    })
+  );
+
+  t.equal(state.annotations[0].textSide, 'left', 'should set text side');
+  t.equal(state.annotations[0].textVerticalPosition, 'below', 'should set vertical position');
+  t.equal(state.annotations[0].angle, 135, 'should snap arm toward bottom-left');
 
   t.end();
 });

--- a/test/node/reducers/annotation-updater-test.js
+++ b/test/node/reducers/annotation-updater-test.js
@@ -63,6 +63,11 @@ test('#visStateReducer -> ADD_ANNOTATION with TEXT kind', t => {
   t.equal(state.annotations[0].kind, AnnotationKind.TEXT, 'should create TEXT annotation');
   t.notOk('armLength' in state.annotations[0], 'TEXT should not have armLength');
   t.notOk('angle' in state.annotations[0], 'TEXT should not have angle');
+  t.notOk(state.annotations[0].textSide, 'TEXT should not stamp a default textSide');
+  t.notOk(
+    state.annotations[0].textVerticalPosition,
+    'TEXT should not stamp a default textVerticalPosition'
+  );
 
   t.end();
 });
@@ -79,6 +84,23 @@ test('#visStateReducer -> ADD_ANNOTATION with ARROW kind', t => {
   t.equal(state.annotations[0].kind, AnnotationKind.ARROW, 'should create ARROW annotation');
   t.ok('armLength' in state.annotations[0], 'ARROW should have armLength');
   t.ok('angle' in state.annotations[0], 'ARROW should have angle');
+
+  t.end();
+});
+
+test('#visStateReducer -> ADD_ANNOTATION derives placement from angle', t => {
+  const state = reducer(
+    initialState,
+    VisStateActions.addAnnotation({
+      anchorPoint: [0, 0],
+      kind: AnnotationKind.POINT,
+      angle: 135
+    })
+  );
+
+  t.equal(state.annotations[0].angle, 135, 'should keep provided angle');
+  t.equal(state.annotations[0].textSide, 'left', 'should derive left from angle 135');
+  t.equal(state.annotations[0].textVerticalPosition, 'below', 'should derive below from angle 135');
 
   t.end();
 });

--- a/test/node/schemas/annotation-schema-test.js
+++ b/test/node/schemas/annotation-schema-test.js
@@ -21,6 +21,8 @@ const annotationPropsV1 = {
   textWidth: null,
   textHeight: null,
   textVerticalAlign: null,
+  textSide: null,
+  textVerticalPosition: null,
   armLength: null,
   angle: null,
   radiusInMeters: null
@@ -48,6 +50,8 @@ const makePointAnnotation = (overrides = {}) => ({
   textWidth: 120,
   textHeight: 40,
   textVerticalAlign: 'bottom',
+  textSide: 'right',
+  textVerticalPosition: 'above',
   armLength: 60,
   angle: -30,
   radiusInMeters: null,
@@ -69,6 +73,8 @@ const makeCircleAnnotation = (overrides = {}) => ({
   textWidth: 0,
   textHeight: 0,
   textVerticalAlign: 'bottom',
+  textSide: 'left',
+  textVerticalPosition: 'below',
   armLength: 50,
   angle: -45,
   radiusInMeters: 5000,
@@ -171,6 +177,12 @@ test('#AnnotationsSchema -> save/load round-trip', t => {
   t.deepEqual(loaded.annotations[0].anchorPoint, [10, 20], 'point anchorPoint round-trips');
   t.equal(loaded.annotations[0].armLength, 60, 'point armLength round-trips');
   t.equal(loaded.annotations[0].textVerticalAlign, 'bottom', 'point textVerticalAlign round-trips');
+  t.equal(loaded.annotations[0].textSide, 'right', 'point textSide round-trips');
+  t.equal(
+    loaded.annotations[0].textVerticalPosition,
+    'above',
+    'point textVerticalPosition round-trips'
+  );
   t.deepEqual(
     loaded.annotations[0].editorState,
     {root: {children: [], direction: null, format: '', indent: 0, type: 'root', version: 1}},
@@ -180,6 +192,12 @@ test('#AnnotationsSchema -> save/load round-trip', t => {
   // Check circle
   t.equal(loaded.annotations[1].id, 'ann-circle-1', 'circle id round-trips');
   t.equal(loaded.annotations[1].radiusInMeters, 5000, 'circle radiusInMeters round-trips');
+  t.equal(loaded.annotations[1].textSide, 'left', 'circle textSide round-trips');
+  t.equal(
+    loaded.annotations[1].textVerticalPosition,
+    'below',
+    'circle textVerticalPosition round-trips'
+  );
 
   // Check text
   t.equal(loaded.annotations[2].id, 'ann-text-1', 'text id round-trips');

--- a/test/node/utils/annotation-utils-test.js
+++ b/test/node/utils/annotation-utils-test.js
@@ -173,6 +173,33 @@ test('#getAnnotationTextBoxStyle -> left/below uses right + top', t => {
   t.end();
 });
 
+test('#getAnnotationTextBoxStyle -> TEXT without explicit side stays centered', t => {
+  const annotation = makeTextAnnotation({autoSize: false, textWidth: 100});
+  const style = getAnnotationTextBoxStyle(annotation, mockViewport);
+
+  t.equal(style.left, 450, 'TEXT should be centered on the anchor (x - width/2)');
+  t.equal(style.bottom, 300, 'TEXT should sit above the anchor');
+  t.notOk(style.right, 'should not set right when centered');
+  t.notOk(style.borderBottom, 'TEXT should not draw a leader');
+
+  t.end();
+});
+
+test('#getAnnotationTextBoxStyle -> TEXT left uses right edge at the anchor', t => {
+  const annotation = makeTextAnnotation({
+    autoSize: false,
+    textWidth: 100,
+    textSide: 'left',
+    textVerticalPosition: 'above'
+  });
+  const style = getAnnotationTextBoxStyle(annotation, mockViewport);
+
+  t.equal(style.right, 500, 'left-placed TEXT is anchored from the right');
+  t.notOk(style.left, 'should not set left when on the left');
+
+  t.end();
+});
+
 test('#makeMarker -> POINT annotation', t => {
   const annotation = makePointAnnotation({anchorPoint: [10, 20], armLength: 50, angle: 0});
   const marker = makeMarker(annotation, mockViewport);

--- a/test/node/utils/annotation-utils-test.js
+++ b/test/node/utils/annotation-utils-test.js
@@ -9,6 +9,9 @@ import {
   moveText,
   resizeCircle,
   isLeftOriented,
+  isBelowOriented,
+  getTextPlacement,
+  getAnnotationTextBoxStyle,
   isPointVisibleOnGlobe
 } from '@kepler.gl/components';
 
@@ -81,6 +84,91 @@ test('#isLeftOriented', t => {
   t.equal(isLeftOriented(-90), false, '-90 degrees is right-oriented');
   t.equal(isLeftOriented(-91), true, '-91 degrees is left-oriented');
   t.equal(isLeftOriented(-180), true, '-180 degrees is left-oriented');
+
+  t.end();
+});
+
+test('#isBelowOriented', t => {
+  t.equal(isBelowOriented(-45), false, 'default -45 is above');
+  t.equal(isBelowOriented(-90), false, '-90 (up) is above');
+  t.equal(isBelowOriented(0), false, '0 (right) is not below');
+  t.equal(isBelowOriented(45), true, '45 is below');
+  t.equal(isBelowOriented(90), true, '90 (down) is below');
+  t.equal(isBelowOriented(135), true, '135 is below');
+  t.equal(isBelowOriented(180), false, '180 (left) is not below');
+
+  t.end();
+});
+
+test('#getTextPlacement -> stored values win over angle', t => {
+  const annotation = makePointAnnotation({
+    angle: 0,
+    textSide: 'left',
+    textVerticalPosition: 'below'
+  });
+  t.deepEqual(
+    getTextPlacement(annotation),
+    {side: 'left', vertical: 'below'},
+    'should use stored placement'
+  );
+  t.end();
+});
+
+test('#getTextPlacement -> derives from arm angle when unset', t => {
+  t.deepEqual(
+    getTextPlacement(makePointAnnotation({angle: -45})),
+    {side: 'right', vertical: 'above'},
+    'default angle is right + above'
+  );
+  t.deepEqual(
+    getTextPlacement(makePointAnnotation({angle: 180})),
+    {side: 'left', vertical: 'above'},
+    '180 degrees is left + above'
+  );
+  t.deepEqual(
+    getTextPlacement(makePointAnnotation({angle: 90})),
+    {side: 'right', vertical: 'below'},
+    '90 degrees is right + below'
+  );
+  t.end();
+});
+
+test('#getAnnotationTextBoxStyle -> right/above uses left + bottom', t => {
+  const annotation = makePointAnnotation({
+    autoSize: false,
+    textWidth: 100,
+    angle: 0,
+    armLength: 50,
+    textSide: 'right',
+    textVerticalPosition: 'above'
+  });
+  const style = getAnnotationTextBoxStyle(annotation, mockViewport);
+
+  t.equal(style.left, 550, 'text starts at arm endpoint x');
+  t.equal(style.bottom, 300, 'text sits above the arm endpoint');
+  t.ok(style.borderBottom, 'connector is on the bottom edge');
+  t.notOk(style.right, 'should not set right when on the right');
+  t.notOk(style.top, 'should not set top when above');
+
+  t.end();
+});
+
+test('#getAnnotationTextBoxStyle -> left/below uses right + top', t => {
+  const annotation = makePointAnnotation({
+    autoSize: false,
+    textWidth: 100,
+    angle: 135,
+    armLength: 50,
+    textSide: 'left',
+    textVerticalPosition: 'below'
+  });
+  const style = getAnnotationTextBoxStyle(annotation, mockViewport);
+
+  t.ok(typeof style.right === 'number', 'text is anchored from the right');
+  t.ok(typeof style.top === 'number', 'text sits below the arm endpoint');
+  t.ok(style.borderTop, 'connector is on the top edge');
+  t.notOk(style.left, 'should not set left when on the left');
+  t.notOk(style.bottom, 'should not set bottom when below');
 
   t.end();
 });
@@ -172,6 +260,8 @@ test('#moveText -> POINT annotation changes angle and armLength', t => {
 
   t.ok('angle' in changes, 'should return angle');
   t.ok('armLength' in changes, 'should return armLength');
+  t.ok('textSide' in changes, 'should return textSide');
+  t.ok('textVerticalPosition' in changes, 'should return textVerticalPosition');
   t.notOk('anchorPoint' in changes, 'should not return anchorPoint');
 
   t.end();


### PR DESCRIPTION
Annotation text was always drawn to the right of the point. This adds Text Side (Right/Left) and Placement (Above/Below) controls in the Annotations panel so the label can sit on any side of the leader.

Dragging the text around the point still updates the placement, and the leader arm snaps to match.

<img width="768" height="528" alt="Screenshot 2026-09-08 at 5 28 55 AM" src="https://github.com/user-attachments/assets/5649cac0-50d9-450f-a4ef-8e3bf6ced035" />
