### PR TITLE
fix: filter Trip and GeoJSON layers in table column mode

### DIFF
--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -203,8 +203,10 @@ const geoColumnAccessor =
   (dc: DataContainerInterface): arrow.Vector | null =>
     dc.getColumn?.(geojson.fieldIdx) as arrow.Vector;
 
-const getTableModeValueAccessor = feature => {
-  // Called from gpu-filter-utils.getFilterValueAccessor()
+const getTableModeValueAccessor = (dc, feature) => {
+  // Called from gpu-filter-utils.getFilterValueAccessor(), which passes
+  // (dataContainer, feature, fieldIndex). The feature carries its own
+  // materialised rows in properties.values, so the data container is not needed.
   return field => feature.properties.values.map(v => field.valueAccessor(v));
 };
 

--- a/src/layers/src/trip-layer/trip-layer.ts
+++ b/src/layers/src/trip-layer/trip-layer.ts
@@ -603,7 +603,10 @@ export default class TripLayer extends Layer {
     });
   }
 
-  _getColumnModeValueAccessor = feature => {
+  // Called from gpu-filter-utils.getFilterValueAccessor(), which passes
+  // (dataContainer, feature, fieldIndex). The trip carries its own materialised
+  // rows in properties.values, so the data container is not needed here.
+  _getColumnModeValueAccessor = (dc, feature) => {
     return field => {
       if (field.fieldIdx === this.config.columns.timestamp?.fieldIdx) {
         return this.dataToTimeStamp[feature.properties.index];

--- a/test/browser/layer-tests/geojson-layer-specs.js
+++ b/test/browser/layer-tests/geojson-layer-specs.js
@@ -15,6 +15,8 @@ import {
   testFormatLayerDataCases,
   testRenderLayerCases,
   prepareGeojsonDataset,
+  prepareTripTableDataset,
+  speedFilterDomain0,
   geoFilterDomain0,
   geojsonFilterDomain0
 } from 'test/helpers/layer-utils';
@@ -506,6 +508,58 @@ test('#GeojsonLayer -> formatLayerData', async t => {
           layer.dataToFeature,
           expectedDataToFeature,
           'should format correct geojson layer dataToFeature'
+        );
+      }
+    }
+  ];
+
+  testFormatLayerDataCases(t, GeojsonLayer, TEST_CASES);
+  t.end();
+});
+
+test('#GeojsonLayer -> formatLayerData -> table column mode with gpu filter', t => {
+  // The GPU filter reads a layer's values through the accessor the layer hands
+  // it, called as getData(dataContainer, feature, fieldIndex). Table column mode
+  // groups rows by id, so the value of each channel is an array, one entry per
+  // point of the grouped feature.
+  const TEST_CASES = [
+    {
+      name: 'Geojson Table.1',
+      layer: {
+        type: 'geojson',
+        id: 'test_geojson_table_layer',
+        config: {
+          dataId,
+          label: 'gps tracks',
+          columnMode: 'table',
+          columns: {
+            id: 'name',
+            lat: 'location-lat',
+            lng: 'location-lng',
+            altitude: 'location-alt'
+          }
+        }
+      },
+      datasets: {
+        [dataId]: prepareTripTableDataset
+      },
+      assert: result => {
+        const {layerData} = result;
+
+        let filterValues;
+        t.doesNotThrow(() => {
+          filterValues = layerData.data.map(layerData.getFilterValue);
+        }, 'getFilterValue should not throw in table column mode');
+
+        // The first feature groups the 8 rows named Thuub that carry a
+        // coordinate; the row with an empty location is dropped.
+        const round = v => Math.round(v * 100) / 100;
+        const groundSpeeds = [0.22, 0.27, 0.32, 0.46, 0.51, 0.3, 0.33, 0.43];
+
+        t.deepEqual(
+          (filterValues?.[0] ?? []).map(point => round(point[0])),
+          groundSpeeds.map(speed => round(speed - speedFilterDomain0)),
+          'getFilterValue should return one filter value per point of the feature'
         );
       }
     }

--- a/test/browser/layer-tests/trip-layer-specs.js
+++ b/test/browser/layer-tests/trip-layer-specs.js
@@ -20,6 +20,8 @@ import {
   testFormatLayerDataCases,
   testRenderLayerCases,
   prepareTripGeoDataset,
+  prepareTripTableDataset,
+  speedFilterDomain0,
   valueFilterDomain0,
   animationConfig
 } from 'test/helpers/layer-utils';
@@ -238,6 +240,59 @@ test('#TripLayer -> formatLayerData', t => {
           layer.dataToFeature,
           dataToFeature,
           'should format correct geojson dataToFeature'
+        );
+      }
+    }
+  ];
+
+  testFormatLayerDataCases(t, TripLayer, TEST_CASES);
+  t.end();
+});
+
+test('#TripLayer -> formatLayerData -> table column mode with gpu filter', t => {
+  // The GPU filter reads a layer's values through the accessor the layer hands
+  // it, called as getData(dataContainer, feature, fieldIndex). Table column mode
+  // groups rows into trips, so the value of each channel is an array, one entry
+  // per vertex of the trip.
+  const TEST_CASES = [
+    {
+      name: 'Trip Table.1',
+      layer: {
+        type: 'trip',
+        id: 'test_trip_table_layer',
+        config: {
+          dataId,
+          label: 'gps trips',
+          columnMode: 'table',
+          columns: {
+            id: 'name',
+            lat: 'location-lat',
+            lng: 'location-lng',
+            timestamp: 'timestamp',
+            altitude: 'location-alt'
+          }
+        }
+      },
+      datasets: {
+        [dataId]: prepareTripTableDataset
+      },
+      assert: result => {
+        const {layerData} = result;
+
+        let filterValues;
+        t.doesNotThrow(() => {
+          filterValues = layerData.data.map(layerData.getFilterValue);
+        }, 'getFilterValue should not throw in table column mode');
+
+        // The first trip groups the 8 rows named Thuub that carry a coordinate
+        // and a timestamp; the row with an empty location is dropped.
+        const round = v => Math.round(v * 100) / 100;
+        const groundSpeeds = [0.22, 0.27, 0.32, 0.46, 0.51, 0.3, 0.33, 0.43];
+
+        t.deepEqual(
+          (filterValues?.[0] ?? []).map(vertex => round(vertex[0])),
+          groundSpeeds.map(speed => round(speed - speedFilterDomain0)),
+          'getFilterValue should return one filter value per vertex of the trip'
         );
       }
     }

--- a/test/helpers/layer-utils.js
+++ b/test/helpers/layer-utils.js
@@ -29,6 +29,7 @@ import csvData, {wktCsv} from '../fixtures/test-csv-data';
 import testLayerData, {bounds, fieldDomain, iconGeometry} from '../fixtures/test-layer-data';
 import {geojsonData} from '../fixtures/geojson';
 import tripGeoJson from '../fixtures/trip-geojson';
+import tripCsvData from '../fixtures/test-trip-csv-data';
 import {IntlWrapper} from './component-utils';
 
 import {logStep} from '../../scripts/log';
@@ -479,3 +480,18 @@ export const prepareTripGeoDataset = stateWithTripGeojsonFilter.datasets[dataId]
 export const prepareTripGeoDatasetFilter = stateWithTripGeojsonFilter.filters[0];
 export const valueFilterDomain0 = prepareTripGeoDatasetFilter.domain[0];
 export const {animationConfig} = stateWithTripGeojsonFilter;
+
+/*
+ * trip table dataset (id / lat / lng / timestamp columns) with gpu filter
+ */
+export const {rows: tripCsvRows, fields: tripCsvFields} = processCsvData(tripCsvData);
+
+const stateWithTripTableFilter = addFilterToData(
+  {fields: tripCsvFields, rows: tripCsvRows},
+  dataId,
+  [{name: 'ground-speed', value: [0.3, 16]}]
+);
+
+export const prepareTripTableDataset = stateWithTripTableFilter.datasets[dataId];
+export const prepareTripTableDatasetFilter = stateWithTripTableFilter.filters[0];
+export const speedFilterDomain0 = prepareTripTableDatasetFilter.domain[0];


### PR DESCRIPTION
Adding any filter to a dataset drawn by a Trip or GeoJSON layer in **table column
mode** takes the layer down. kepler.gl catches the deck.gl error and shows:

> An error in deck.gl: update of TripsLayer({id: '…'}): Cannot read properties of
> undefined (reading 'index') in … layer. The layer has been disabled and highlighted.

…and the layer is switched off. For a Trip layer the filter in question is usually
the time filter it needs to animate, so the layer breaks in the one setup it exists for.

### Steps to reproduce

1. Save this as `trips.csv`:

   ```csv
   id,timestamp,latitude,longitude,speed
   a,2024-01-01 08:00:00,37.7749,-122.4194,12
   a,2024-01-01 08:01:00,37.7760,-122.4180,18
   a,2024-01-01 08:02:00,37.7772,-122.4166,24
   a,2024-01-01 08:03:00,37.7784,-122.4152,21
   b,2024-01-01 08:00:30,37.7690,-122.4300,9
   b,2024-01-01 08:01:30,37.7702,-122.4286,15
   b,2024-01-01 08:02:30,37.7714,-122.4272,27
   b,2024-01-01 08:03:30,37.7726,-122.4258,30
   ```

2. Open the demo app and drop the file in. kepler.gl creates a Point layer and a
   **Trip** layer in table column mode. Hide the Point layer so the trail is what you see.
3. Go to **Filters → Add Filter** and pick the `timestamp` column.
4. The notification above appears and the Trip layer is disabled. Pressing play
   draws nothing.

With this change the Trip layer keeps drawing and the time slider animates it.

### Cause

`getFilterValueAccessor` calls the accessor a layer hands it as
`getData(dataContainer, feature, fieldIndex)` — the data container first
(`src/table/src/gpu-filter-utils.ts`). Both layers hand over an accessor that takes
the feature alone:

- `src/layers/src/trip-layer/trip-layer.ts` — `_getColumnModeValueAccessor = feature => …`
- `src/layers/src/geojson-layer/geojson-layer.ts` — `getTableModeValueAccessor = feature => …`

So the data container lands in `feature`, `feature.properties` is `undefined`, and
deck.gl throws while updating the layer's attributes. The geojson column mode of
both layers already uses the three-argument form a few lines above, which is what
this change aligns the table mode with. Only filters kepler.gl puts on the GPU reach
this path, which is why categorical filters are unaffected.

### Change

Both accessors now take `(dataContainer, feature)`. The data container is genuinely
unused: the feature carries its own materialised rows in `properties.values`.

### Tests

A `formatLayerData` case in `trip-layer-specs.js` and in `geojson-layer-specs.js`
that builds the layer in table column mode over a dataset carrying a GPU filter and
reads the filter values back — one value per vertex of the trip. Both throw without
the change. They share a new `prepareTripTableDataset` in `test/helpers/layer-utils.js`,
built from the existing `test-trip-csv-data` fixture.

`yarn test-browser`, `yarn test-jest` and `tsc --noEmit` are clean.
