### PR TITLE
fix: cancel raster tile requests when deck.gl abandons the tile

### DIFF
--- a/src/layers/src/raster-tile/gpu-utils.ts
+++ b/src/layers/src/raster-tile/gpu-utils.ts
@@ -305,7 +305,9 @@ export async function loadNpyArray(
 
           const response = (await load(request.url, NPYLoader as Loader<NPYLoaderResponse>, {
             npy: npyOptions,
-            fetch: options?.fetch
+            // Without the signal the browser keeps downloading a tile deck.gl has
+            // already abandoned, and it queues ahead of the tiles still in view.
+            fetch: options?.fetch ?? {signal: request.options?.signal}
           })) as NPYLoaderResponse;
 
           if (!response || !response.data || request.options.signal?.aborted) {

--- a/test/browser/layer-tests/raster-tile-layer-specs.js
+++ b/test/browser/layer-tests/raster-tile-layer-specs.js
@@ -14,6 +14,7 @@ import {
 import {RasterWebGL} from '@kepler.gl/deckgl-layers';
 import {parseRasterMetadata} from '@kepler.gl/table';
 import {testCreateCases} from 'test/helpers/layer-utils';
+import {loadNpyArray} from '../../../src/layers/src/raster-tile/gpu-utils';
 
 const {RasterTileLayer} = KeplerGlLayers;
 
@@ -73,6 +74,49 @@ const createRenderOpts = (dataset, mapState = {dragRotate: false, bearing: 0, pi
   },
   mapState,
   interactionConfig: {tooltip: {enabled: true}}
+});
+
+test('#RasterTileLayer -> tile requests carry the abort signal', async t => {
+  // deck.gl aborts a tile that scrolls out of view by firing the AbortSignal it
+  // puts in the request. The signal has to reach the fetch, or the browser keeps
+  // downloading tiles nobody will draw and they queue ahead of the ones in view.
+  const controller = new AbortController();
+  const requests = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = (url, init) => {
+    requests.push(init);
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      url: String(url),
+      headers: new Map(),
+      arrayBuffer: async () => new ArrayBuffer(8)
+    });
+  };
+
+  try {
+    await loadNpyArray(
+      {
+        url: 'https://example.com/tile.npy',
+        rasterServerUrl: 'https://example.com',
+        options: {signal: controller.signal},
+        rasterServerMaxRetries: 0
+      },
+      true
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  t.equal(requests.length, 1, 'should issue one tile request');
+  t.equal(
+    requests[0]?.signal,
+    controller.signal,
+    'the tile request should carry the abort signal deck.gl provided'
+  );
+
+  t.end();
 });
 
 test('#RasterTileLayer -> constructor and basic properties', t => {


### PR DESCRIPTION
### Problem 

deck.gl aborts the tiles that leave the view and hands the layer an `AbortSignal`,
which ends up in `request.options`. `loadNpyArray` only reads that signal *after*
the response has arrived, to throw the data away — it never reaches the fetch, so
the browser downloads every abandoned tile in full.

They are not free. The browser opens six connections per origin, so obsolete tiles
queue ahead of the ones actually in view.

### Measured

Demo app, one raster tile layer over a public COG, the same scripted interaction
each time (six wheel zooms and four drags), counting `fetch` calls to
`…/tiles/….npy` from inside the page:

| | tile requests | aborted | delivered to the app |
|---|---|---|---|
| master | 33 | **0** | 16.5 MB |
| this branch | 94 | **64** | 12.0 MB |

Zero aborts on master held across every run (0 of 47, 0 of 56, 0 of 45, 0 of 33).
The totals swing run to run because the interaction races the network; what does
not swing is that nothing is ever cancelled. With the change the browser stops
paying for tiles nobody will draw, and gets further through the ones it does need
within the same interaction.

### Steps to reproduce

1. In the demo app, **Add Data → Tileset → Raster Tile**, and paste this public COG
   into *Tileset metadata URL* (kepler.gl recognises the `.tif` and wires
   `titiler.xyz` on its own, so *Raster tile servers* can stay empty):

   ```
   https://copernicus-dem-30m.s3.amazonaws.com/Copernicus_DSM_COG_10_N45_00_E006_00_DEM/Copernicus_DSM_COG_10_N45_00_E006_00_DEM.tif
   ```

2. Open the network panel, filter by `.npy`, and zoom and pan quickly around the
   Alps for a few seconds.
3. On master no request is ever cancelled: every tile the map has already given up
   on runs to completion. With this change the abandoned ones show up as cancelled.

### Cause

`loadNpyArray(request, split, options?)` declares a third parameter whose `fetch`
is the only route by which the signal would reach the request
(`src/layers/src/raster-tile/gpu-utils.ts`). Both call sites — in
`loadSingleAssetSTAC` and `loadMultiAssetSTAC` — pass two arguments, so `options`
is `undefined` and the loader is handed `fetch: undefined`. The same file already
uses the right shape on the terrain path, `fetch: {signal}`.

### Change

Fall back to the signal the request already carries. One line, and an explicit
`options.fetch` stays the override it already was.

### Tests

A case in `raster-tile-layer-specs.js` that swaps in a fake `fetch`, calls
`loadNpyArray` with a request carrying a signal, and asserts the request receives
that same signal — which also pins that loaders.gl honours `fetch: {signal}`. It
fails on master with `undefined`.

`yarn test-browser` (3618 assertions), `yarn test-jest` and `tsc --noEmit` are clean.
