### PR TITLE
feat: add heatmap and WMS legends to the map legend

### DIFF
--- a/docs/user-guides/c-types-of-layers/o-wms-layer.md
+++ b/docs/user-guides/c-types-of-layers/o-wms-layer.md
@@ -11,6 +11,7 @@ Use WMS Layer to render imagery from OGC Web Map Service (WMS) endpoints.
 Notes:
 
 - Feature info on click is supported for queryable layers (`queryable=true`).
+- The map legend shows a GetLegendGraphic / LegendURL image when the service provides one.
 
 Example WMS services:
 

--- a/src/components/src/common/color-legend.tsx
+++ b/src/components/src/common/color-legend.tsx
@@ -42,6 +42,31 @@ const StyledLegend = styled.div<{$disableEdit: boolean; isExpanded?: boolean}>`
   ${props => (props.$disableEdit ? inputCss : '')}
 `;
 
+const StyledHorizontalLegend = styled.div`
+  padding: 2px 0;
+`;
+
+const StyledColorRamp = styled.div`
+  display: flex;
+  height: 12px;
+  width: 100%;
+  overflow: hidden;
+`;
+
+const StyledRampSegment = styled.div<{$color: string}>`
+  flex: 1;
+  background-color: ${props => props.$color};
+`;
+
+const StyledRampLabels = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2px;
+  font-size: 9.5px;
+  line-height: 12px;
+  color: ${props => props.theme.textColor};
+`;
+
 const StyledLegendRow = styled.div`
   display: flex;
   align-items: center;
@@ -301,6 +326,8 @@ export type ColorLegendProps = {
   isFixed?: boolean;
   isExpanded?: boolean;
   onUpdateColorLegend?: (colorLegends: {[key: HexColor]: string}) => void;
+  endpointLabels?: {min: string; max: string};
+  orientation?: 'vertical' | 'horizontal';
 };
 
 export type Legend = {
@@ -323,7 +350,9 @@ function ColorLegendFactory(LegendRow: ReturnType<typeof LegendRowFactory>) {
     mapState,
     onUpdateColorLegend,
     displayLabel = true,
-    disableEdit = false
+    disableEdit = false,
+    endpointLabels,
+    orientation = 'vertical'
   }) => {
     const {colorLegends} = range || {};
 
@@ -363,22 +392,54 @@ function ColorLegendFactory(LegendRow: ReturnType<typeof LegendRowFactory>) {
       [onUpdateColorLegend, colorLegends]
     );
 
+    if (orientation === 'horizontal') {
+      return (
+        <StyledHorizontalLegend className="styled-color-legend legend--color-ramp">
+          <StyledColorRamp>
+            {legends.map((legend, i) => (
+              <StyledRampSegment
+                key={`${legend.data}-${i}`}
+                className="legend--color-ramp__segment"
+                $color={legend.data}
+              />
+            ))}
+          </StyledColorRamp>
+          {endpointLabels ? (
+            <StyledRampLabels className="legend--color-ramp__labels">
+              <span className="legend--color-ramp__min">{endpointLabels.min}</span>
+              <span className="legend--color-ramp__max">{endpointLabels.max}</span>
+            </StyledRampLabels>
+          ) : null}
+        </StyledHorizontalLegend>
+      );
+    }
+
     return (
       <StyledLegend
         className="styled-color-legend"
         $disableEdit={disableEdit}
         isExpanded={isExpanded}
       >
-        {legends.map((legend, i) => (
-          <LegendRow
-            key={`${legend.data}-${i}`}
-            label={legend.label}
-            displayLabel={displayLabel}
-            color={legend.data}
-            onUpdateLabel={!disableEdit ? onUpdateLabel : undefined}
-            onResetLabel={legend.override && !disableEdit ? onResetLabel : undefined}
-          />
-        ))}
+        {legends.map((legend, i) => {
+          const endpointLabel =
+            endpointLabels && legends.length
+              ? i === 0
+                ? endpointLabels.min
+                : i === legends.length - 1
+                ? endpointLabels.max
+                : ''
+              : undefined;
+          return (
+            <LegendRow
+              key={`${legend.data}-${i}`}
+              label={endpointLabel !== undefined ? endpointLabel : legend.label}
+              displayLabel={displayLabel}
+              color={legend.data}
+              onUpdateLabel={!disableEdit ? onUpdateLabel : undefined}
+              onResetLabel={legend.override && !disableEdit ? onResetLabel : undefined}
+            />
+          );
+        })}
       </StyledLegend>
     );
   };

--- a/src/components/src/map/map-legend.tsx
+++ b/src/components/src/map/map-legend.tsx
@@ -72,6 +72,19 @@ export const StyledMapControlLegend = styled.div<StyledMapControlLegendProps>`
   .legend--layer_color-legend {
     margin-top: 6px;
   }
+
+  .legend--layer_image-wrap {
+    max-height: 240px;
+    overflow: auto;
+    background: #fff;
+    border-radius: 2px;
+  }
+
+  .legend--layer_image {
+    display: block;
+    max-width: 100%;
+    height: auto;
+  }
 `;
 
 const StyledLegendHeaderRow = styled.div`
@@ -225,6 +238,7 @@ export function LayerColorLegendFactory(
       },
       [layer, onLayerVisConfigChange, colorRange, range]
     );
+    const isHeatmap = layer.type === 'heatmap';
     const [isExpanded, setIsExpanded] = useState(isExport);
     const handleToggleExpanded = () => setIsExpanded(!isExpanded);
     return (
@@ -234,7 +248,7 @@ export function LayerColorLegendFactory(
             {enableColorBy ? (
               <div className="legend--layer_size-title-row">
                 <VisualChannelMetric name={enableColorBy} />
-                {!isExport ? (
+                {!isExport && !isHeatmap ? (
                   <PanelHeaderAction
                     id="legend-collapse-button"
                     onClick={handleToggleExpanded}
@@ -257,6 +271,15 @@ export function LayerColorLegendFactory(
                   disableEdit={disableEdit || Boolean(isExport)}
                   isFixed={isFixed}
                   mapState={mapState}
+                  orientation={isHeatmap ? 'horizontal' : 'vertical'}
+                  endpointLabels={
+                    isHeatmap
+                      ? {
+                          min: intl.formatMessage({id: 'mapLegend.min', defaultMessage: 'Min'}),
+                          max: intl.formatMessage({id: 'mapLegend.max', defaultMessage: 'Max'})
+                        }
+                      : undefined
+                  }
                   labelFormat={
                     colorField?.displayFormat ? d3Format(colorField?.displayFormat) : null
                   }
@@ -445,6 +468,18 @@ const defaultActionIcons = {
   collapsed: ArrowRight
 };
 
+const LayerImageLegend: React.FC<{src: string; alt: string}> = ({src, alt}) => {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return null;
+  }
+  return (
+    <div className="legend--layer_image-wrap">
+      <img className="legend--layer_image" src={src} alt={alt} onError={() => setFailed(true)} />
+    </div>
+  );
+};
+
 export type LayerLegendContentProps = {
   layer: Layer;
   containerW: number;
@@ -470,6 +505,7 @@ export function LayerLegendContentFactory(
     actionIcons
   }) => {
     const visualChannels = layer.getLegendVisualChannels();
+    const legendImageUrl = layer.getLegendImageUrl();
     const channelKeys = Object.values(visualChannels);
     const colorChannels = channelKeys.filter(isColorChannel) as VisualChannel[];
     const nonColorChannels = channelKeys.filter(vc => !isColorChannel(vc));
@@ -489,6 +525,13 @@ export function LayerLegendContentFactory(
     }
     return (
       <>
+        {legendImageUrl ? (
+          <LayerImageLegend
+            key={legendImageUrl}
+            src={legendImageUrl}
+            alt={layer.config.label || 'Layer legend'}
+          />
+        ) : null}
         {colorChannelToRender.map(colorChannel => (
           <LayerColorLegend
             key={colorChannel.key}

--- a/src/components/src/modals/tilesets-modals/tileset-wms-form.tsx
+++ b/src/components/src/modals/tilesets-modals/tileset-wms-form.tsx
@@ -7,7 +7,11 @@ import {WMSCapabilities} from '@loaders.gl/wms';
 
 import {validateUrl} from '@kepler.gl/common-utils';
 import {DatasetType, REMOTE_TILE, RemoteTileFormat, WMSDatasetMetadata} from '@kepler.gl/constants';
-import {getWMSCapabilities, wmsCapabilitiesToDatasetMetadata} from '@kepler.gl/table';
+import {
+  getWMSCapabilities,
+  wmsCapabilitiesToDatasetMetadata,
+  buildWmsGetCapabilitiesUrl
+} from '@kepler.gl/table';
 import {getApplicationConfig} from '@kepler.gl/utils';
 
 import {MetaResponse} from './common';
@@ -135,7 +139,7 @@ const TilesetWMSForm: React.FC<WMSTileFormProps> = ({setResponse}) => {
 
         const data = await getWMSCapabilities(newWmsUrl);
 
-        const datasetMetadata = wmsCapabilitiesToDatasetMetadata(data);
+        const datasetMetadata = wmsCapabilitiesToDatasetMetadata(data, newWmsUrl);
 
         // Extract name or title from GetCapabilities response
         const serviceTitle = data?.title || data?.name;
@@ -167,7 +171,8 @@ const TilesetWMSForm: React.FC<WMSTileFormProps> = ({setResponse}) => {
           type: REMOTE_TILE,
           remoteTileFormat: RemoteTileFormat.WMS,
           tilesetDataUrl: wmsUrl,
-          tilesetMetadataUrl: `${wmsUrl}?service=WMS&request=GetCapabilities`,
+          tilesetMetadataUrl:
+            buildWmsGetCapabilitiesUrl(wmsUrl) || `${wmsUrl}?service=WMS&request=GetCapabilities`,
           layers: wmsData?.layers || [],
           version: wmsData?.version || '1.3.0'
         }

--- a/src/constants/src/dataset.ts
+++ b/src/constants/src/dataset.ts
@@ -220,13 +220,21 @@ export type RasterTileMetadataSourceType = {
 export type RasterTileDatasetMetadata = (RasterTileLocalMetadata | RasterTileRemoteMetadata) &
   RasterTileMetadataSourceType;
 
+export type WMSServiceLayer = {
+  name: string;
+  title: string;
+  boundingBox: number[] | null;
+  queryable?: boolean;
+  legendUrl?: string | null;
+};
+
 export type WMSDatasetMetadata = {
   type: typeof REMOTE_TILE;
   remoteTileFormat: RemoteTileFormat.WMS;
   tilesetDataUrl: string;
   tilesetMetadataUrl: string;
   version: string;
-  layers: {name: string; title: string; boundingBox: number[] | null}[];
+  layers: WMSServiceLayer[];
   label?: string;
   attribution?: string;
 };

--- a/src/layers/src/base-layer.ts
+++ b/src/layers/src/base-layer.ts
@@ -1723,6 +1723,10 @@ class Layer implements KeplerLayer {
   getLegendVisualChannels(): {[key: string]: VisualChannel} {
     return this.visualChannels;
   }
+
+  getLegendImageUrl(): string | null {
+    return null;
+  }
 }
 
 export default Layer;

--- a/src/layers/src/heatmap-layer/heatmap-layer.ts
+++ b/src/layers/src/heatmap-layer/heatmap-layer.ts
@@ -6,7 +6,8 @@ import {
   CHANNEL_SCALES,
   ALL_FIELD_TYPES,
   GEOJSON_FIELDS,
-  GEOARROW_METADATA_KEY
+  GEOARROW_METADATA_KEY,
+  SCALE_TYPES
 } from '@kepler.gl/constants';
 import Layer, {LayerBaseConfigPartial, LayerWeightConfig, VisualChannels} from '../base-layer';
 import HeatmapLayerIcon from './heatmap-layer-icon';
@@ -310,6 +311,16 @@ class HeatmapLayer extends Layer {
 
   get visualChannels(): VisualChannels {
     return {
+      color: {
+        property: 'color',
+        field: 'colorField',
+        scale: 'colorScale',
+        domain: 'colorDomain',
+        range: 'colorRange',
+        key: 'color',
+        channelScaleType: CHANNEL_SCALES.color,
+        defaultMeasure: 'property.density'
+      },
       // @ts-expect-error
       weight: {
         property: 'weight',
@@ -322,6 +333,10 @@ class HeatmapLayer extends Layer {
         channelScaleType: CHANNEL_SCALES.size
       }
     };
+  }
+
+  getLegendVisualChannels() {
+    return {color: this.visualChannels.color};
   }
 
   get layerIcon() {
@@ -369,18 +384,17 @@ class HeatmapLayer extends Layer {
   }
 
   getDefaultLayerConfig(props: LayerBaseConfigPartial): HeatmapLayerConfig {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const {colorField, colorDomain, colorScale, ...layerConfig} = {
+    // Keep colorScale / colorDomain so the map legend can render the selected
+    // color ramp. colorField stays unused: heatmap color is density, not a field.
+    return {
       ...super.getDefaultLayerConfig(props),
       columnMode: props?.columnMode ?? DEFAULT_COLUMN_MODE,
-
+      colorScale: SCALE_TYPES.quantize,
+      colorDomain: [0, 1],
       weightField: null,
       weightDomain: [0, 1],
       weightScale: 'linear'
     };
-
-    // @ts-expect-error
-    return layerConfig;
   }
 
   updateLayerMeta(dataset: KeplerTable) {

--- a/src/layers/src/heatmap-layer/heatmap-layer.ts
+++ b/src/layers/src/heatmap-layer/heatmap-layer.ts
@@ -9,7 +9,12 @@ import {
   GEOARROW_METADATA_KEY,
   SCALE_TYPES
 } from '@kepler.gl/constants';
-import Layer, {LayerBaseConfigPartial, LayerWeightConfig, VisualChannels} from '../base-layer';
+import Layer, {
+  LayerBaseConfigPartial,
+  LayerColorConfig,
+  LayerWeightConfig,
+  VisualChannels
+} from '../base-layer';
 import HeatmapLayerIcon from './heatmap-layer-icon';
 import {
   ColorRange,
@@ -73,7 +78,7 @@ export type HeatmapLayerVisConfig = {
   aggregation: string;
 };
 
-export type HeatmapLayerVisualChannelConfig = LayerWeightConfig;
+export type HeatmapLayerVisualChannelConfig = LayerWeightConfig & LayerColorConfig;
 export type HeatmapLayerConfig = Merge<
   LayerBaseConfig,
   {columns: HeatmapLayerColumnsConfig; visConfig: HeatmapLayerVisConfig}

--- a/src/layers/src/scenegraph-layer/scenegraph-layer.ts
+++ b/src/layers/src/scenegraph-layer/scenegraph-layer.ts
@@ -148,6 +148,11 @@ export default class ScenegraphLayer extends Layer {
     return ScenegraphLayerIcon;
   }
 
+  // Mesh appearance comes from the GLTF, not layer fill/stroke encoding
+  getLegendVisualChannels() {
+    return {};
+  }
+
   get layerInfoModal() {
     return {
       id: 'scenegraphInfo',

--- a/src/layers/src/wms-layer/wms-layer.ts
+++ b/src/layers/src/wms-layer/wms-layer.ts
@@ -4,7 +4,7 @@
 import {notNullorUndefined} from '@kepler.gl/common-utils';
 import {DatasetType, WMSDatasetMetadata, LAYER_TYPES} from '@kepler.gl/constants';
 import {WMSLayer as DeckWMSLayer} from '@kepler.gl/deckgl-layers';
-import {KeplerTable as KeplerDataset} from '@kepler.gl/table';
+import {KeplerTable as KeplerDataset, buildWmsGetLegendGraphicUrl} from '@kepler.gl/table';
 import {
   AnimationConfig,
   Field,
@@ -43,6 +43,7 @@ export type WMSLayerVisConfig = {
     title: string;
     boundingBox: number[][];
     queryable: boolean;
+    legendUrl?: string | null;
   } | null;
 };
 
@@ -122,6 +123,28 @@ export default class WMSLayer extends AbstractTileLayer<WMSTile, any[]> {
     return [DatasetType.WMS_TILE];
   }
 
+  // Image overlay has no fill/stroke encoding to show in the map legend
+  getLegendVisualChannels() {
+    return {};
+  }
+
+  getLegendImageUrl(): string | null {
+    const serviceLayer = this._getCurrentServiceLayer();
+    if (!serviceLayer?.name) {
+      return null;
+    }
+    if (serviceLayer.legendUrl) {
+      return serviceLayer.legendUrl;
+    }
+    const tilesetDataUrl = this.meta?.tilesetDataUrl;
+    if (typeof tilesetDataUrl === 'string' && tilesetDataUrl) {
+      return buildWmsGetLegendGraphicUrl(tilesetDataUrl, serviceLayer.name, {
+        version: this.meta?.wmsVersion
+      });
+    }
+    return null;
+  }
+
   protected initTileDataset() {
     // Provide dummy accessors for raster/WMS
     return new TileDataset<WMSTile, any[]>({
@@ -173,6 +196,12 @@ export default class WMSLayer extends AbstractTileLayer<WMSTile, any[]> {
     }
 
     const metadata = dataset.metadata as WMSDatasetMetadata | undefined;
+    if (metadata?.tilesetDataUrl) {
+      this.updateMeta({
+        tilesetDataUrl: metadata.tilesetDataUrl,
+        wmsVersion: metadata.version
+      });
+    }
     if (metadata?.attribution) {
       this.updateMeta({
         attribution: {title: metadata.attribution, url: metadata.tilesetDataUrl || ''}

--- a/src/localization/src/translations/en.ts
+++ b/src/localization/src/translations/en.ts
@@ -862,6 +862,8 @@ ${'```'}
   Save: 'Save',
   Share: 'Share',
   mapLegend: {
+    min: 'Min',
+    max: 'Max',
     layers: {
       line: {
         singleColor: {

--- a/src/table/src/dataset-utils.ts
+++ b/src/table/src/dataset-utils.ts
@@ -34,6 +34,7 @@ import {
   getFieldsFromTile,
   VectorTileMetadata
 } from './tileset/vector-tile-utils';
+import {buildWmsGetCapabilitiesUrl, wmsCapabilitiesToDatasetMetadata} from './tileset/wms-utils';
 
 // apply a color for each dataset
 // to use as label colors
@@ -262,7 +263,7 @@ async function refreshWMSMetadata(datasetInfo: CreateTableProps): Promise<any | 
 
   try {
     const data = await getWMSCapabilities(tilesetDataUrl);
-    return wmsCapabilitiesToDatasetMetadata(data);
+    return wmsCapabilitiesToDatasetMetadata(data, tilesetDataUrl);
   } catch (err) {
     // ignore for now, and use old metadata
   }
@@ -270,42 +271,8 @@ async function refreshWMSMetadata(datasetInfo: CreateTableProps): Promise<any | 
 }
 
 export async function getWMSCapabilities(wsmUrl: string): Promise<WMSCapabilities> {
-  return (await load(
-    `${wsmUrl}?service=WMS&request=GetCapabilities`,
-    WMSCapabilitiesLoader
-  )) as WMSCapabilities;
-}
-
-export function wmsCapabilitiesToDatasetMetadata(capabilities: WMSCapabilities): any | null {
-  // Flatten layers if they are nested
-  const layers = capabilities.layers.flatMap(layer => {
-    if (layer.layers && layer.layers.length > 0) {
-      return layer.layers;
-    }
-    return layer;
-  });
-
-  let availableLayers: WMSDatasetMetadata['layers'] = [];
-  if (Array.isArray(layers)) {
-    availableLayers = layers.map((layer: any) => {
-      const bb = layer.geographicBoundingBox;
-
-      let boundingBox: number[] | null = null;
-      if (Array.isArray(bb) && Array.isArray(bb[0]) && Array.isArray(bb[1])) {
-        boundingBox = [bb[0][0], bb[0][1], bb[1][0], bb[1][1]];
-      }
-
-      return {
-        name: layer.name,
-        title: layer.title || layer.name,
-        boundingBox,
-        queryable: layer.queryable
-      };
-    });
-  }
-
-  return {
-    layers: availableLayers,
-    version: capabilities.version || '1.3.0'
-  };
+  const capabilitiesUrl = buildWmsGetCapabilitiesUrl(wsmUrl) || wsmUrl;
+  return (await load(capabilitiesUrl, WMSCapabilitiesLoader, {
+    wms: {includeRawJSON: true}
+  })) as WMSCapabilities;
 }

--- a/src/table/src/index.ts
+++ b/src/table/src/index.ts
@@ -23,6 +23,7 @@ export type {
 } from './kepler-table';
 export * from './gpu-filter-utils';
 export * from './dataset-utils';
+export * from './tileset/wms-utils';
 export * from './tileset/tileset-utils';
 export * from './tileset/vector-tile-utils';
 export * from './tileset/raster-tile-utils';

--- a/src/table/src/tileset/wms-utils.ts
+++ b/src/table/src/tileset/wms-utils.ts
@@ -34,6 +34,27 @@ function decodeXmlEntities(value: string): string {
   return value.replace(/&amp;/g, '&').replace(/&quot;/g, '"');
 }
 
+/**
+ * LegendURL may be a relative URI. Resolve it against the WMS service URL so
+ * `<img src>` does not load it from the Kepler app origin.
+ */
+export function resolveWmsLegendUrl(href: string, serviceUrl?: string): string | null {
+  if (!href) {
+    return null;
+  }
+  try {
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) {
+      return href;
+    }
+    if (!serviceUrl) {
+      return href;
+    }
+    return new URL(href, serviceUrl).toString();
+  } catch {
+    return href;
+  }
+}
+
 function getHref(node: unknown): string | null {
   if (!node) {
     return null;
@@ -112,7 +133,14 @@ export function collectWmsLegendUrlsFromRawJson(json: unknown): Record<string, s
     }
   };
 
-  visit(json);
+  const root =
+    json && typeof json === 'object' && !Array.isArray(json)
+      ? (json as Record<string, unknown>).WMS_Capabilities ||
+        (json as Record<string, unknown>).WMT_MS_Capabilities ||
+        json
+      : json;
+
+  visit(root);
   return urls;
 }
 
@@ -213,8 +241,10 @@ export function wmsCapabilitiesToDatasetMetadata(
     }
 
     const layerName = layer.name;
+    const advertisedLegendUrl =
+      typeof layerName === 'string' ? legendUrlsFromCapabilities[layerName] : undefined;
     const legendUrl =
-      (typeof layerName === 'string' && legendUrlsFromCapabilities[layerName]) ||
+      (advertisedLegendUrl && resolveWmsLegendUrl(advertisedLegendUrl, serviceUrl)) ||
       (typeof layerName === 'string' && serviceUrl
         ? buildWmsGetLegendGraphicUrl(serviceUrl, layerName, {version})
         : null);

--- a/src/table/src/tileset/wms-utils.ts
+++ b/src/table/src/tileset/wms-utils.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+const WMS_PARAM_KEYS_TO_REPLACE = new Set([
+  'service',
+  'request',
+  'version',
+  'layers',
+  'layer',
+  'styles',
+  'style',
+  'format',
+  'crs',
+  'srs',
+  'bbox',
+  'width',
+  'height',
+  'transparent',
+  'bgcolor',
+  'exceptions',
+  'sld',
+  'sld_version',
+  'legend_options'
+]);
+
+function asArray<T>(value: T | T[] | undefined | null): T[] {
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(/&amp;/g, '&').replace(/&quot;/g, '"');
+}
+
+function getHref(node: unknown): string | null {
+  if (!node) {
+    return null;
+  }
+  if (typeof node === 'string') {
+    return decodeXmlEntities(node) || null;
+  }
+  if (typeof node !== 'object') {
+    return null;
+  }
+  const obj = node as Record<string, unknown>;
+  const candidates = [obj['xlink:href'], obj.href, obj.Href, obj['@_xlink:href'], obj['@_href']];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate) {
+      return decodeXmlEntities(candidate);
+    }
+  }
+  return null;
+}
+
+function extractLegendUrlFromLayerNode(layerNode: Record<string, unknown>): string | null {
+  const styles = asArray(layerNode.Style ?? layerNode.style);
+  for (const style of styles) {
+    if (!style || typeof style !== 'object') {
+      continue;
+    }
+    const legendUrls = asArray(
+      (style as Record<string, unknown>).LegendURL ?? (style as Record<string, unknown>).LegendUrl
+    );
+    for (const legend of legendUrls) {
+      if (!legend || typeof legend !== 'object') {
+        continue;
+      }
+      const legendObj = legend as Record<string, unknown>;
+      const href = getHref(legendObj) ?? getHref(legendObj.OnlineResource);
+      if (href) {
+        return href;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk raw GetCapabilities JSON (from loaders.gl `includeRawJSON`) and collect
+ * Style/LegendURL OnlineResource hrefs keyed by layer name.
+ */
+export function collectWmsLegendUrlsFromRawJson(json: unknown): Record<string, string> {
+  const urls: Record<string, string> = {};
+
+  const visit = (node: unknown) => {
+    if (!node) {
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (typeof node !== 'object') {
+      return;
+    }
+    const obj = node as Record<string, unknown>;
+    const name = obj.Name ?? obj.name;
+    const legendUrl = extractLegendUrlFromLayerNode(obj);
+    if (typeof name === 'string' && name && legendUrl) {
+      urls[name] = legendUrl;
+    }
+    if ('Layer' in obj) {
+      visit(obj.Layer);
+    }
+    if ('layer' in obj) {
+      visit(obj.layer);
+    }
+    if ('Capability' in obj) {
+      visit(obj.Capability);
+    }
+  };
+
+  visit(json);
+  return urls;
+}
+
+/**
+ * Replace WMS request parameters on a service URL while keeping vendor query params.
+ */
+export function buildWmsRequestUrl(
+  serviceUrl: string,
+  params: Record<string, string | undefined>
+): string | null {
+  if (!serviceUrl) {
+    return null;
+  }
+  try {
+    const url = new URL(serviceUrl);
+    for (const key of [...url.searchParams.keys()]) {
+      if (WMS_PARAM_KEYS_TO_REPLACE.has(key.toLowerCase())) {
+        url.searchParams.delete(key);
+      }
+    }
+    for (const [key, value] of Object.entries(params)) {
+      if (value !== undefined && value !== '') {
+        url.searchParams.set(key, value);
+      }
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+export function buildWmsGetCapabilitiesUrl(serviceUrl: string): string | null {
+  return buildWmsRequestUrl(serviceUrl, {
+    SERVICE: 'WMS',
+    REQUEST: 'GetCapabilities'
+  });
+}
+
+export function buildWmsGetLegendGraphicUrl(
+  serviceUrl: string,
+  layerName: string,
+  options?: {version?: string; format?: string; style?: string}
+): string | null {
+  if (!serviceUrl || !layerName) {
+    return null;
+  }
+  return buildWmsRequestUrl(serviceUrl, {
+    SERVICE: 'WMS',
+    REQUEST: 'GetLegendGraphic',
+    VERSION: options?.version || '1.3.0',
+    LAYER: layerName,
+    FORMAT: options?.format || 'image/png',
+    STYLE: options?.style,
+    TRANSPARENT: 'TRUE',
+    SLD_VERSION: '1.1.0'
+  });
+}
+
+export function wmsCapabilitiesToDatasetMetadata(
+  capabilities: {
+    layers?: Array<{
+      name?: string;
+      title?: string;
+      geographicBoundingBox?: unknown;
+      queryable?: boolean;
+      layers?: any[];
+    }>;
+    json?: unknown;
+    version?: string;
+  },
+  serviceUrl?: string
+): {
+  layers: Array<{
+    name: string;
+    title: string;
+    boundingBox: number[] | null;
+    queryable?: boolean;
+    legendUrl?: string | null;
+  }>;
+  version: string;
+} {
+  const layers = (capabilities.layers || []).flatMap(layer => {
+    if (layer.layers && layer.layers.length > 0) {
+      return layer.layers;
+    }
+    return layer;
+  });
+
+  const legendUrlsFromCapabilities = collectWmsLegendUrlsFromRawJson(capabilities.json);
+  const version = capabilities.version || '1.3.0';
+
+  const availableLayers = layers.map((layer: any) => {
+    const bb = layer.geographicBoundingBox;
+
+    let boundingBox: number[] | null = null;
+    if (Array.isArray(bb) && Array.isArray(bb[0]) && Array.isArray(bb[1])) {
+      boundingBox = [bb[0][0], bb[0][1], bb[1][0], bb[1][1]];
+    }
+
+    const layerName = layer.name;
+    const legendUrl =
+      (typeof layerName === 'string' && legendUrlsFromCapabilities[layerName]) ||
+      (typeof layerName === 'string' && serviceUrl
+        ? buildWmsGetLegendGraphicUrl(serviceUrl, layerName, {version})
+        : null);
+
+    return {
+      name: layerName,
+      title: layer.title || layer.name,
+      boundingBox,
+      queryable: layer.queryable,
+      legendUrl: legendUrl || null
+    };
+  });
+
+  return {
+    layers: availableLayers,
+    version
+  };
+}

--- a/test/browser/components/map/map-legend-test.js
+++ b/test/browser/components/map/map-legend-test.js
@@ -26,7 +26,7 @@ import {
 } from 'test/helpers/mock-state';
 import {IntlWrapper, mountWithTheme} from 'test/helpers/component-utils';
 import {KeplerGlLayers} from '@kepler.gl/layers';
-const {PointLayer} = KeplerGlLayers;
+const {PointLayer, WMSLayer, HeatmapLayer} = KeplerGlLayers;
 
 const MapLegend = appInjector.get(MapLegendFactory);
 const LayerColorLegend = appInjector.get(LayerColorLegendFactory);
@@ -272,6 +272,100 @@ test('Components -> MapLegend.render -> with colorLegends', t => {
     onLayerVisConfigChange.args[0][1].colorRange.colorLegends,
     {},
     'second arg should be empty'
+  );
+
+  t.end();
+});
+
+test('Components -> MapLegend.render -> WMS legend image', t => {
+  const wmsLayer = new WMSLayer({
+    id: 'wms-legend',
+    dataId: 'wms-dataset',
+    label: 'WMS legend layer',
+    isVisible: true
+  });
+  wmsLayer.updateLayerVisConfig({
+    wmsLayer: {
+      name: 'OSM-WMS',
+      title: 'OpenStreetMap',
+      boundingBox: [
+        [-180, -90],
+        [180, 90]
+      ],
+      queryable: true,
+      legendUrl: 'https://example.com/legend.png'
+    }
+  });
+
+  let wrapper;
+  t.doesNotThrow(() => {
+    wrapper = mountWithTheme(
+      <IntlWrapper>
+        <MapLegend layers={[wmsLayer]} />
+      </IntlWrapper>
+    );
+  }, 'Should not fail with a WMS layer');
+
+  t.equal(wrapper.find(StyledMapControlLegend).length, 1, 'should render 1 layer legend');
+  t.equal(
+    wrapper.find('.legend--layer_name').at(0).text(),
+    'WMS legend layer',
+    'should render WMS layer label'
+  );
+  t.equal(wrapper.find('img.legend--layer_image').length, 1, 'should render WMS legend image');
+  t.equal(
+    wrapper.find('img.legend--layer_image').at(0).props().src,
+    'https://example.com/legend.png',
+    'should use GetLegendGraphic / LegendURL'
+  );
+  t.equal(wrapper.find(LayerColorLegend).length, 0, 'should not render fill color legend for WMS');
+
+  t.end();
+});
+
+test('Components -> MapLegend.render -> heatmap color scale', t => {
+  const heatmapLayer = new HeatmapLayer({
+    id: 'heatmap-legend',
+    dataId: 'heatmap-dataset',
+    label: 'Heatmap legend layer',
+    isVisible: true
+  });
+  heatmapLayer.updateLayerConfig({
+    columns: {
+      lat: {value: 'lat', fieldIdx: 0},
+      lng: {value: 'lng', fieldIdx: 1}
+    }
+  });
+
+  let wrapper;
+  t.doesNotThrow(() => {
+    wrapper = mountWithTheme(
+      <IntlWrapper>
+        <MapLegend layers={[heatmapLayer]} />
+      </IntlWrapper>
+    );
+  }, 'Should not fail with a heatmap layer');
+
+  t.equal(wrapper.find(StyledMapControlLegend).length, 1, 'should render 1 layer legend');
+  t.equal(wrapper.find(LayerColorLegend).length, 1, 'should render heatmap color legend');
+  t.equal(
+    wrapper.find('.legend--layer_color_field').at(0).text().toLowerCase(),
+    'density',
+    'should label heatmap legend as density'
+  );
+  t.ok(
+    wrapper.find('.legend--color-ramp__segment').length >= 2,
+    'should render a horizontal color ramp'
+  );
+  t.equal(
+    wrapper.find('.legend--color-ramp__min').at(0).text(),
+    'Min',
+    'left end of the ramp should be labeled Min'
+  );
+  t.equal(
+    wrapper.find('.legend--color-ramp__max').at(0).text(),
+    'Max',
+    'right end of the ramp should be labeled Max'
   );
 
   t.end();

--- a/test/browser/layer-tests/heatmap-layer-specs.js
+++ b/test/browser/layer-tests/heatmap-layer-specs.js
@@ -44,6 +44,14 @@ test('#HeatmapLayer -> contructor', t => {
           t.ok(layer.isAggregated === true, 'heatmaplayer is aggregated');
           t.ok(layer.config.label === 'test heatmap layer', 'label should be correct');
           t.ok(Object.keys(layer.columnPairs).length, 'should have columnPairs');
+          t.equal(layer.config.colorScale, 'quantize', 'heatmap legend should use quantize scale');
+          t.deepEqual(layer.config.colorDomain, [0, 1], 'heatmap legend domain should be 0-1');
+          t.ok(layer.visualChannels.color, 'should expose a color channel for the legend');
+          t.deepEqual(
+            Object.keys(layer.getLegendVisualChannels()),
+            ['color'],
+            'legend should show the color ramp, not weight'
+          );
         }
       }
     ]

--- a/test/browser/layer-tests/scenegraph-layer-specs.js
+++ b/test/browser/layer-tests/scenegraph-layer-specs.js
@@ -37,6 +37,11 @@ test('#ScenegraphLayer -> constructor', t => {
           t.ok(layer.isAggregated === false, 'ScenegraphLayer is not aggregated');
           t.ok(layer.config.label === 'test 3d layer', 'label should be correct');
           t.ok(Object.keys(layer.columnPairs).length, 'should have columnPairs');
+          t.deepEqual(
+            layer.getLegendVisualChannels(),
+            {},
+            'should expose no legend channels (mesh has no fill color)'
+          );
         }
       }
     ]

--- a/test/browser/layer-tests/wms-layer-specs.js
+++ b/test/browser/layer-tests/wms-layer-specs.js
@@ -129,6 +129,53 @@ test('#WMSLayer -> constructor', t => {
   t.end();
 });
 
+test('#WMSLayer -> legend visual channels', t => {
+  const layer = createWMSLayer();
+
+  t.deepEqual(
+    layer.getLegendVisualChannels(),
+    {},
+    'should expose no legend channels (WMS has no fill color)'
+  );
+
+  t.end();
+});
+
+test('#WMSLayer -> getLegendImageUrl', t => {
+  const layer = createWMSLayer({
+    visConfig: {
+      wmsLayer: {
+        ...MOCK_WMS_LAYER_CONFIG,
+        legendUrl: 'https://example.com/legend.png'
+      }
+    }
+  });
+
+  t.equal(
+    layer.getLegendImageUrl(),
+    'https://example.com/legend.png',
+    'should use LegendURL stored on the selected WMS layer'
+  );
+
+  const layerWithoutLegend = createWMSLayer();
+  t.equal(
+    layerWithoutLegend.getLegendImageUrl(),
+    null,
+    'should return null before dataset meta has a service URL'
+  );
+
+  layerWithoutLegend.updateLayerMeta(MOCK_WMS_DATASET);
+  const constructed = layerWithoutLegend.getLegendImageUrl();
+  t.ok(constructed, 'should construct GetLegendGraphic from dataset URL');
+  t.ok(
+    constructed.includes('GetLegendGraphic'),
+    'constructed legend URL should request GetLegendGraphic'
+  );
+  t.ok(constructed.includes('test_layer'), 'constructed legend URL should include layer name');
+
+  t.end();
+});
+
 test('WMSLayer -> basic layer functionality', t => {
   const layer = createWMSLayer();
 

--- a/test/node/utils/index.js
+++ b/test/node/utils/index.js
@@ -30,6 +30,7 @@ import './timeline-zoom-test';
 import './plot-test';
 import './composer-helpers-test';
 import './dom-to-image';
+import './wms-utils-test';
 import './effect-utils-test';
 import './duckdb-utils-test';
 import './annotation-utils-test';

--- a/test/node/utils/wms-utils-test.js
+++ b/test/node/utils/wms-utils-test.js
@@ -51,6 +51,31 @@ test('WMS utils -> buildWmsGetCapabilitiesUrl', t => {
   t.end();
 });
 
+test('WMS utils -> collectWmsLegendUrlsFromRawJson unwraps WMS_Capabilities', t => {
+  const rawJson = {
+    WMS_Capabilities: {
+      Capability: {
+        Layer: {
+          Name: 'OSM-WMS',
+          Style: {
+            LegendURL: {
+              OnlineResource: {
+                'xlink:href': 'https://example.com/legend.png'
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  t.deepEqual(collectWmsLegendUrlsFromRawJson(rawJson), {
+    'OSM-WMS': 'https://example.com/legend.png'
+  });
+
+  t.end();
+});
+
 test('WMS utils -> collectWmsLegendUrlsFromRawJson', t => {
   const rawJson = {
     Capability: {
@@ -130,6 +155,37 @@ test('WMS utils -> wmsCapabilitiesToDatasetMetadata prefers LegendURL', t => {
   t.equal(metadata.layers[0].name, 'OSM-WMS');
   t.equal(metadata.layers[0].legendUrl, 'https://example.com/legend.png');
   t.deepEqual(metadata.layers[0].boundingBox, [-180, -90, 180, 90]);
+
+  t.end();
+});
+
+test('WMS utils -> wmsCapabilitiesToDatasetMetadata resolves relative LegendURL', t => {
+  const capabilities = {
+    version: '1.3.0',
+    layers: [
+      {
+        name: 'OSM-WMS',
+        title: 'OpenStreetMap'
+      }
+    ],
+    json: {
+      Capability: {
+        Layer: {
+          Name: 'OSM-WMS',
+          Style: {
+            LegendURL: {
+              OnlineResource: {
+                'xlink:href': '/legends/osm.png'
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const metadata = wmsCapabilitiesToDatasetMetadata(capabilities, 'https://example.com/wms');
+  t.equal(metadata.layers[0].legendUrl, 'https://example.com/legends/osm.png');
 
   t.end();
 });

--- a/test/node/utils/wms-utils-test.js
+++ b/test/node/utils/wms-utils-test.js
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// Copyright contributors to the kepler.gl project
+
+import test from 'tape';
+import {
+  buildWmsGetCapabilitiesUrl,
+  buildWmsGetLegendGraphicUrl,
+  collectWmsLegendUrlsFromRawJson,
+  wmsCapabilitiesToDatasetMetadata
+} from '../../../src/table/src/tileset/wms-utils';
+
+test('WMS utils -> buildWmsGetLegendGraphicUrl', t => {
+  const url = buildWmsGetLegendGraphicUrl('https://example.com/wms', 'OSM-WMS', {
+    version: '1.3.0'
+  });
+  const parsed = new URL(url);
+
+  t.equal(parsed.origin + parsed.pathname, 'https://example.com/wms');
+  t.equal(parsed.searchParams.get('SERVICE'), 'WMS');
+  t.equal(parsed.searchParams.get('REQUEST'), 'GetLegendGraphic');
+  t.equal(parsed.searchParams.get('LAYER'), 'OSM-WMS');
+  t.equal(parsed.searchParams.get('FORMAT'), 'image/png');
+  t.equal(parsed.searchParams.get('VERSION'), '1.3.0');
+  t.equal(parsed.searchParams.get('TRANSPARENT'), 'TRUE');
+
+  t.end();
+});
+
+test('WMS utils -> buildWmsRequestUrl replaces existing WMS params', t => {
+  const url = buildWmsGetLegendGraphicUrl(
+    'https://example.com/wms?service=WMS&request=GetCapabilities&map=/data/map.map',
+    'roads'
+  );
+  const parsed = new URL(url);
+
+  t.equal(parsed.searchParams.get('REQUEST'), 'GetLegendGraphic');
+  t.equal(parsed.searchParams.get('map'), '/data/map.map', 'keeps vendor query params');
+  t.equal(parsed.searchParams.get('LAYER'), 'roads');
+
+  t.end();
+});
+
+test('WMS utils -> buildWmsGetCapabilitiesUrl', t => {
+  const url = buildWmsGetCapabilitiesUrl(
+    'https://example.com/wms?service=WMS&request=GetMap&layers=x'
+  );
+  const parsed = new URL(url);
+  t.equal(parsed.searchParams.get('REQUEST'), 'GetCapabilities');
+  t.equal(parsed.searchParams.get('SERVICE'), 'WMS');
+  t.notOk(parsed.searchParams.get('layers'));
+  t.end();
+});
+
+test('WMS utils -> collectWmsLegendUrlsFromRawJson', t => {
+  const rawJson = {
+    Capability: {
+      Layer: {
+        Title: 'root',
+        Layer: [
+          {
+            Name: 'OSM-WMS',
+            Title: 'OpenStreetMap',
+            Style: {
+              Name: 'default',
+              LegendURL: {
+                OnlineResource: {
+                  'xlink:href':
+                    'https://example.com/wms?request=GetLegendGraphic&layer=OSM-WMS&format=image/png'
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  };
+
+  t.deepEqual(collectWmsLegendUrlsFromRawJson(rawJson), {
+    'OSM-WMS': 'https://example.com/wms?request=GetLegendGraphic&layer=OSM-WMS&format=image/png'
+  });
+
+  t.end();
+});
+
+test('WMS utils -> wmsCapabilitiesToDatasetMetadata prefers LegendURL', t => {
+  const capabilities = {
+    version: '1.3.0',
+    name: 'WMS',
+    keywords: [],
+    requests: {},
+    layers: [
+      {
+        title: 'root',
+        keywords: [],
+        layers: [
+          {
+            name: 'OSM-WMS',
+            title: 'OpenStreetMap',
+            keywords: [],
+            geographicBoundingBox: [
+              [-180, -90],
+              [180, 90]
+            ],
+            queryable: true
+          }
+        ]
+      }
+    ],
+    json: {
+      Capability: {
+        Layer: {
+          Layer: {
+            Name: 'OSM-WMS',
+            Style: {
+              LegendURL: {
+                OnlineResource: {
+                  'xlink:href': 'https://example.com/legend.png'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  };
+
+  const metadata = wmsCapabilitiesToDatasetMetadata(capabilities, 'https://example.com/wms');
+
+  t.equal(metadata.layers.length, 1);
+  t.equal(metadata.layers[0].name, 'OSM-WMS');
+  t.equal(metadata.layers[0].legendUrl, 'https://example.com/legend.png');
+  t.deepEqual(metadata.layers[0].boundingBox, [-180, -90, 180, 90]);
+
+  t.end();
+});
+
+test('WMS utils -> wmsCapabilitiesToDatasetMetadata constructs GetLegendGraphic', t => {
+  const capabilities = {
+    version: '1.1.1',
+    name: 'WMS',
+    keywords: [],
+    requests: {},
+    layers: [
+      {
+        name: 'radar',
+        title: 'Radar',
+        keywords: [],
+        queryable: false
+      }
+    ]
+  };
+
+  const metadata = wmsCapabilitiesToDatasetMetadata(capabilities, 'https://example.com/wms');
+  const legendUrl = new URL(metadata.layers[0].legendUrl);
+
+  t.equal(legendUrl.searchParams.get('REQUEST'), 'GetLegendGraphic');
+  t.equal(legendUrl.searchParams.get('LAYER'), 'radar');
+  t.equal(legendUrl.searchParams.get('VERSION'), '1.1.1');
+
+  t.end();
+});


### PR DESCRIPTION
## Summary
- Heatmap layers show a horizontal color ramp with Min/Max labels instead of no legend.
- WMS layers show a GetLegendGraphic / LegendURL image when the service provides one.
- WMS and 3D mesh no longer show a misleading Fill color swatch.

## Test plan
- [x] Add a heatmap layer and confirm the legend shows the selected palette as a horizontal ramp with Min / Max.
- [x] Add a WMS tileset (e.g. terrestris OSM) and confirm the legend shows the service legend image, plus name and visibility controls.
- [x] Confirm 3D mesh still shows name + visibility only (no Fill color).
- [x] Confirm other layer legends (point, geojson, hexagon) are unchanged.

<img width="1014" height="665" alt="Screenshot 2026-09-11 at 1 55 45 AM" src="https://github.com/user-attachments/assets/a06157be-1605-43dd-a554-56d8dea18bc8" />
<img width="1056" height="665" alt="Screenshot 2026-09-11 at 1 56 09 AM" src="https://github.com/user-attachments/assets/da5bbfb0-8350-41bd-9960-1ab380479d40" />
<img width="995" height="730" alt="Screenshot 2026-09-11 at 2 43 22 AM" src="https://github.com/user-attachments/assets/aaf8361b-ab9c-4ca7-ba5a-4e738203dfa5" />
