### PR TITLE
feat: snap annotations to 3D surfaces

### DIFF
--- a/src/components/src/annotations/annotation-overlay.tsx
+++ b/src/components/src/annotations/annotation-overlay.tsx
@@ -18,6 +18,7 @@ import AnnotationNode from './annotation-node';
 import AnnotationText from './annotation-text';
 import {
   MapViewport,
+  PickWorldPosition,
   isPointVisibleOnGlobe,
   movePoint,
   moveText,
@@ -57,6 +58,7 @@ export type AnnotationOverlayProps = {
   mapIndex: number;
   viewport: MapViewport;
   isGlobeEnabled?: boolean;
+  pickWorldPosition?: PickWorldPosition;
   updateAnnotation: ActionHandler<typeof updateAnnotation>;
   setSelectedAnnotation: ActionHandler<typeof setSelectedAnnotation>;
 };
@@ -69,6 +71,7 @@ const AnnotationOverlay: FC<AnnotationOverlayProps> = ({
   mapIndex,
   viewport,
   isGlobeEnabled,
+  pickWorldPosition,
   updateAnnotation: onUpdateAnnotation,
   setSelectedAnnotation: onSetSelectedAnnotation
 }) => {
@@ -137,10 +140,10 @@ const AnnotationOverlay: FC<AnnotationOverlayProps> = ({
       let changes: Partial<Annotation> = {};
       switch (handleKind) {
         case 'MOVE_POINT':
-          changes = movePoint(draggedAnn, ev.delta, viewport);
+          changes = movePoint(draggedAnn, ev.delta, viewport, pickWorldPosition);
           break;
         case 'MOVE_TEXT':
-          changes = moveText(draggedAnn, ev.delta, viewport);
+          changes = moveText(draggedAnn, ev.delta, viewport, pickWorldPosition);
           break;
         case 'RESIZE':
           changes = resizeCircle(draggedAnn, ev.delta, viewport);
@@ -150,7 +153,7 @@ const AnnotationOverlay: FC<AnnotationOverlayProps> = ({
         onUpdateAnnotation(annId, changes);
       }
     },
-    [viewport, onUpdateAnnotation]
+    [viewport, onUpdateAnnotation, pickWorldPosition]
   );
 
   const handleDragEnd = useCallback((_ev: DragEndEvent) => {

--- a/src/components/src/annotations/annotation-utils.ts
+++ b/src/components/src/annotations/annotation-utils.ts
@@ -14,15 +14,22 @@ import {
   textPlacementFromAngle
 } from '@kepler.gl/constants';
 
+export type LngLatAltitude = [number, number] | [number, number, number];
+
 export type MapViewport = {
-  project: (lngLat: [number, number]) => [number, number];
-  unproject: (xy: [number, number]) => [number, number];
+  project: (lngLat: ReadonlyArray<number>) => number[];
+  unproject: (xy: ReadonlyArray<number>) => number[];
   longitude: number;
   latitude: number;
   width: number;
   height: number;
   zoom: number;
 };
+
+/** Screen-space pick that returns a world position, optionally with altitude. */
+export type PickWorldPosition = (
+  screen: [number, number]
+) => ReadonlyArray<number> | null | undefined;
 
 export type BaseAnnotationMarker = {
   kind: AnnotationKind;
@@ -45,13 +52,9 @@ function degreesToRadians(degree: number): number {
   return degree * (Math.PI / 180);
 }
 
-function calcRadius(
-  viewport: MapViewport,
-  point: [number, number],
-  radiusInMeters: number
-): number {
+function calcRadius(viewport: MapViewport, point: LngLatAltitude, radiusInMeters: number): number {
   const [x, y] = viewport.project(point);
-  const shifted = addMetersToLngLat(point, [radiusInMeters, 0, 0]) as [number, number];
+  const shifted = addMetersToLngLat(point, [radiusInMeters, 0, 0]);
   const [x1, y1] = viewport.project(shifted);
   const dx = x1 - x;
   const dy = y1 - y;
@@ -154,8 +157,20 @@ export function getAnnotationTextBoxStyle(
   return style;
 }
 
+export function normalizeAnchorPoint(
+  coord: ReadonlyArray<number> | null | undefined
+): LngLatAltitude | null {
+  if (!coord || coord.length < 2 || !Number.isFinite(coord[0]) || !Number.isFinite(coord[1])) {
+    return null;
+  }
+  if (coord.length >= 3 && Number.isFinite(coord[2])) {
+    return [coord[0], coord[1], coord[2]];
+  }
+  return [coord[0], coord[1]];
+}
+
 /** Great-circle angular distance between two lng/lat points, in degrees. */
-function angularDistanceDeg(a: [number, number], b: [number, number]): number {
+function angularDistanceDeg(a: ReadonlyArray<number>, b: ReadonlyArray<number>): number {
   const toRad = Math.PI / 180;
   const phi1 = a[1] * toRad;
   const phi2 = b[1] * toRad;
@@ -183,7 +198,10 @@ const GLOBE_VISIBILITY_TOLERANCE_DEG = 0.5;
  * first and the point is occluded. This uses the real projection math, so it
  * follows the true horizon and adapts to zoom/altitude automatically.
  */
-export function isPointVisibleOnGlobe(point: [number, number], viewport: MapViewport): boolean {
+export function isPointVisibleOnGlobe(
+  point: ReadonlyArray<number>,
+  viewport: MapViewport
+): boolean {
   const projected = viewport.project(point);
   if (!projected || !Number.isFinite(projected[0]) || !Number.isFinite(projected[1])) {
     return false;
@@ -198,24 +216,31 @@ export function isPointVisibleOnGlobe(point: [number, number], viewport: MapView
 export function movePoint(
   annotation: Annotation,
   delta: {x: number; y: number},
-  viewport: MapViewport
+  viewport: MapViewport,
+  pickWorldPosition?: PickWorldPosition
 ): Partial<Annotation> {
   const {anchorPoint} = annotation;
   const [px, py] = viewport.project(anchorPoint);
-  const [lon, lat] = viewport.unproject([px + delta.x, py + delta.y]);
-  return {anchorPoint: [lon, lat]};
+  const screen: [number, number] = [px + delta.x, py + delta.y];
+  const picked = normalizeAnchorPoint(pickWorldPosition?.(screen));
+  if (picked) {
+    return {anchorPoint: picked};
+  }
+  const [lon, lat] = viewport.unproject(screen);
+  return {anchorPoint: Number.isFinite(lon) && Number.isFinite(lat) ? [lon, lat] : anchorPoint};
 }
 
 export function moveText(
   annotation: Annotation,
   delta: {x: number; y: number},
-  viewport: MapViewport
+  viewport: MapViewport,
+  pickWorldPosition?: PickWorldPosition
 ): Partial<Annotation> {
   const marker = makeMarker(annotation, viewport);
   const {kind, tx, ty} = marker;
 
   if (kind === AnnotationKind.TEXT) {
-    return movePoint(annotation, delta, viewport);
+    return movePoint(annotation, delta, viewport, pickWorldPosition);
   }
   if (!isAnnotationWithArm(annotation)) {
     return {};
@@ -252,7 +277,7 @@ export function resizeCircle(
 ): Partial<Annotation> {
   if (annotation.kind !== AnnotationKind.CIRCLE) return {};
   const {anchorPoint, radiusInMeters} = annotation;
-  const shifted = addMetersToLngLat(anchorPoint, [radiusInMeters, 0, 0]) as [number, number];
+  const shifted = addMetersToLngLat(anchorPoint, [radiusInMeters, 0, 0]);
   const [x] = viewport.project(shifted);
   const newPoint = viewport.unproject([x + delta.x, viewport.project(anchorPoint)[1]]);
   const dx = newPoint[0] - anchorPoint[0];

--- a/src/components/src/index.ts
+++ b/src/components/src/index.ts
@@ -388,9 +388,10 @@ export {
   angleForTextPlacement,
   textPlacementFromAngle,
   getAnnotationTextBoxStyle,
-  isPointVisibleOnGlobe
+  isPointVisibleOnGlobe,
+  normalizeAnchorPoint
 } from './annotations';
-export type {MapViewport, AnnotationMarker} from './annotations';
+export type {MapViewport, AnnotationMarker, PickWorldPosition, LngLatAltitude} from './annotations';
 export {default as AnnotationControlFactory} from './map/annotations/annotation-control';
 
 export {default as ColorBreaksPanelFactory} from './side-panel/layer-panel/color-breaks-panel';

--- a/src/components/src/map-container.tsx
+++ b/src/components/src/map-container.tsx
@@ -734,8 +734,8 @@ export default function MapContainerFactory(
       const mergedState = {...mapState, ...internalViewState, width, height};
       const vp = getViewportFromMapState(mergedState) as any;
       const viewport = {
-        project: (lngLat: [number, number]) => vp.project(lngLat) as [number, number],
-        unproject: (xy: [number, number]) => vp.unproject(xy) as [number, number],
+        project: (lngLat: ReadonlyArray<number>) => vp.project(lngLat),
+        unproject: (xy: ReadonlyArray<number>) => vp.unproject(xy),
         longitude,
         latitude,
         width,
@@ -745,6 +745,34 @@ export default function MapContainerFactory(
       this._annotationViewportCache = {key, viewport};
       return viewport;
     }
+
+    _pickAnnotationWorldPosition = (xy: [number, number]): number[] | null => {
+      const deck = this._deck;
+      if (!deck || typeof deck.pickObject !== 'function') {
+        return null;
+      }
+      try {
+        const info = deck.pickObject({
+          x: xy[0],
+          y: xy[1],
+          radius: 0,
+          unproject3D: true
+        });
+        const coordinate = info?.coordinate;
+        // Only accept a reconstructed 3D hit. A 2D unproject (no depth) is the
+        // same as the ground-plane fallback in movePoint.
+        if (
+          !Array.isArray(coordinate) ||
+          coordinate.length < 3 ||
+          !Number.isFinite(coordinate[2])
+        ) {
+          return null;
+        }
+        return coordinate;
+      } catch {
+        return null;
+      }
+    };
 
     _onDeckError = (error, layer) => {
       const errorMessage = error?.message || 'unknown-error';
@@ -1001,6 +1029,7 @@ export default function MapContainerFactory(
           mapboxApiAccessToken,
           mapboxApiUrl,
           layersForDeck,
+          isAnnotationMode: Boolean(mapControls?.annotation?.active),
           editorInfo: primaryMap
             ? {
                 editor,
@@ -1500,6 +1529,7 @@ export default function MapContainerFactory(
             mapIndex={index || 0}
             viewport={this._getAnnotationViewport(mapState, internalViewState)}
             isGlobeEnabled={Boolean(mapState.globe?.enabled)}
+            pickWorldPosition={this._pickAnnotationWorldPosition}
             updateAnnotation={visStateActions.updateAnnotation}
             setSelectedAnnotation={visStateActions.setSelectedAnnotation}
           />

--- a/src/deckgl-layers/src/3d-building-layer/3d-building-layer.ts
+++ b/src/deckgl-layers/src/3d-building-layer/3d-building-layer.ts
@@ -29,6 +29,7 @@ export default class ThreeDBuildingLayer extends CompositeLayer<ThreeDBuildingLa
     return [
       new DeckGLTileLayer({
         id: `${this.id}-deck-3d-building` as string,
+        pickable: this.props.pickable,
         getTileData: (tile: TileLoadProps) =>
           getTileData(this.props.mapboxApiUrl, this.props.mapboxApiAccessToken, tile),
         minZoom: 13,

--- a/src/deckgl-layers/src/3d-building-layer/types.ts
+++ b/src/deckgl-layers/src/3d-building-layer/types.ts
@@ -20,6 +20,7 @@ export type ThreeDBuildingLayerProps = {
   mapboxApiAccessToken: string;
   mapboxApiUrl: string;
   threeDBuildingColor: RGBColor;
+  pickable?: boolean;
   updateTriggers: {
     getFillColor: RGBColor;
   };

--- a/src/layers/src/geojson-layer/geojson-layer.ts
+++ b/src/layers/src/geojson-layer/geojson-layer.ts
@@ -108,7 +108,8 @@ export const geojsonVisConfigs: {
   elevationScale: {
     ...LAYER_VIS_CONFIGS.elevationScale,
     focusRange: [0, 1],
-    focusWeight: 0.3
+    focusWeight: 0.3,
+    step: 0.01
   },
   stroked: 'stroked',
   filled: 'filled',
@@ -807,7 +808,9 @@ export default class GeoJsonLayer extends Layer {
       opacity: visConfig.strokeOpacity
     };
 
-    const pickable = interactionConfig.tooltip.enabled && visConfig.allowHover;
+    const pickable =
+      (interactionConfig.tooltip.enabled && visConfig.allowHover) ||
+      Boolean(opts.experimentalContext?.isAnnotationMode && visConfig.enable3d);
     const hoverOverlayData = visConfig.enable3d ? null : this._getHoverOverlayData(objectHovered);
 
     const {data, ...props} = dataProps;

--- a/src/layers/src/tile3d-layer/tile3d-layer.ts
+++ b/src/layers/src/tile3d-layer/tile3d-layer.ts
@@ -667,7 +667,9 @@ export default class Tile3DLayer extends Layer {
         onTileUnload: this._onTileUnload,
         getPointColor: pointColor,
         pointSize: visConfig.pointSize ?? 2,
-        pickable: false,
+        // Picking is off by default (no tooltip fields). Enable it while
+        // placing annotations so snap can reconstruct XYZ from mesh depth.
+        pickable: Boolean(opts.experimentalContext?.isAnnotationMode),
         opacity: visConfig.opacity ?? 1,
         extensions: EMPTY_EXTENSIONS,
         parameters: DEPTH_TEST_PARAMS

--- a/src/reducers/src/layer-utils.ts
+++ b/src/reducers/src/layer-utils.ts
@@ -384,6 +384,7 @@ export type ComputeDeckLayersProps = {
   mapboxApiAccessToken?: string;
   mapboxApiUrl?: string;
   primaryMap?: boolean;
+  isAnnotationMode?: boolean;
   layersForDeck?: {[key: string]: boolean};
   editorInfo?: {
     editor: Editor;
@@ -430,6 +431,7 @@ function computeDeckLayersFromLayerOrder(
     animationConfig: any;
     mapLayers: any;
     hasShadowEffect: boolean;
+    isAnnotationMode?: boolean;
   },
   layerCallbacks?: any
 ): any[] {
@@ -441,7 +443,8 @@ function computeDeckLayersFromLayerOrder(
     interactionConfig,
     animationConfig,
     mapLayers,
-    hasShadowEffect
+    hasShadowEffect,
+    isAnnotationMode
   } = renderProps;
   return layerOrder
     .slice()
@@ -489,7 +492,8 @@ function computeDeckLayersFromLayerOrder(
           animationConfig,
           mapLayers,
           experimentalContext: {
-            hasShadowEffect
+            hasShadowEffect,
+            isAnnotationMode
           }
         },
         bindedLayerCallbacks
@@ -518,8 +522,15 @@ export function computeDeckLayers(
     splitMaps
   } = visState;
 
-  const {mapIndex, mapboxApiAccessToken, mapboxApiUrl, primaryMap, layersForDeck, editorInfo} =
-    options || {};
+  const {
+    mapIndex,
+    mapboxApiAccessToken,
+    mapboxApiUrl,
+    primaryMap,
+    layersForDeck,
+    editorInfo,
+    isAnnotationMode
+  } = options || {};
 
   let dataLayers: any[] = [];
 
@@ -555,7 +566,8 @@ export function computeDeckLayers(
                 interactionConfig,
                 animationConfig,
                 mapLayers,
-                hasShadowEffect
+                hasShadowEffect,
+                isAnnotationMode
               },
               layerCallbacks
             )
@@ -587,7 +599,8 @@ export function computeDeckLayers(
             animationConfig,
             mapLayers,
             experimentalContext: {
-              hasShadowEffect
+              hasShadowEffect,
+              isAnnotationMode
             }
           },
           bindedLayerCallbacks
@@ -612,6 +625,7 @@ export function computeDeckLayers(
         mapboxApiAccessToken,
         mapboxApiUrl,
         threeDBuildingColor: mapStyle.threeDBuildingColor,
+        pickable: Boolean(isAnnotationMode),
         updateTriggers: {
           getFillColor: mapStyle.threeDBuildingColor
         }

--- a/src/reducers/src/vis-state-merger.ts
+++ b/src/reducers/src/vis-state-merger.ts
@@ -733,7 +733,8 @@ export function mergeAnnotations<S extends VisState>(state: S, annotations: any[
         !existingIds.has(a.id) &&
         isAnnotationKind(a.kind) &&
         Array.isArray(a.anchorPoint) &&
-        a.anchorPoint.length === 2
+        (a.anchorPoint.length === 2 || a.anchorPoint.length === 3) &&
+        a.anchorPoint.every(value => Number.isFinite(value))
     )
     .map(a => ({
       isVisible: true,

--- a/src/types/annotations.d.ts
+++ b/src/types/annotations.d.ts
@@ -16,7 +16,8 @@ export type BaseAnnotation = {
   isVisible: boolean;
   autoSize: boolean;
   autoSizeY: boolean;
-  anchorPoint: [number, number];
+  /** [lng, lat] or [lng, lat, altitudeMeters]. Missing altitude is treated as 0. */
+  anchorPoint: [number, number] | [number, number, number];
   label: string;
   editorState?: Record<string, any>;
   mapIndex?: number;

--- a/test/node/reducers/annotation-merger-test.js
+++ b/test/node/reducers/annotation-merger-test.js
@@ -144,3 +144,20 @@ test('#mergeAnnotations -> should return same state when all annotations are inv
 
   t.end();
 });
+
+test('#mergeAnnotations -> should accept 3D anchorPoint', t => {
+  const state = makeState();
+  const annotations = [
+    makeAnnotation({id: 'xyz', anchorPoint: [-122.4, 37.8, 45]}),
+    makeAnnotation({id: 'too-long', anchorPoint: [1, 2, 3, 4]}),
+    makeAnnotation({id: 'nan-z', anchorPoint: [1, 2, Number.NaN]})
+  ];
+
+  const result = mergeAnnotations(state, annotations);
+
+  t.equal(result.annotations.length, 1, 'should only accept [lng, lat] or [lng, lat, alt]');
+  t.equal(result.annotations[0].id, 'xyz', 'should keep the 3D annotation');
+  t.deepEqual(result.annotations[0].anchorPoint, [-122.4, 37.8, 45], 'should keep altitude');
+
+  t.end();
+});

--- a/test/node/schemas/annotation-schema-test.js
+++ b/test/node/schemas/annotation-schema-test.js
@@ -233,3 +233,22 @@ test('#AnnotationsSchema -> saves only known properties', t => {
 
   t.end();
 });
+
+test('#AnnotationsSchema -> 3D anchorPoint round-trips', t => {
+  const original = [makePointAnnotation({anchorPoint: [-122.4, 37.8, 120]})];
+  const saved = schema.save(original);
+  const loaded = schema.load(saved.annotations);
+
+  t.deepEqual(
+    saved.annotations[0].anchorPoint,
+    [-122.4, 37.8, 120],
+    'should save [lng, lat, altitude]'
+  );
+  t.deepEqual(
+    loaded.annotations[0].anchorPoint,
+    [-122.4, 37.8, 120],
+    'should load [lng, lat, altitude]'
+  );
+
+  t.end();
+});

--- a/test/node/utils/annotation-utils-test.js
+++ b/test/node/utils/annotation-utils-test.js
@@ -12,11 +12,12 @@ import {
   isBelowOriented,
   getTextPlacement,
   getAnnotationTextBoxStyle,
-  isPointVisibleOnGlobe
+  isPointVisibleOnGlobe,
+  normalizeAnchorPoint
 } from '@kepler.gl/components';
 
 const mockViewport = {
-  project: ([lng, lat]) => [lng * 10 + 500, lat * -10 + 300],
+  project: ([lng, lat, alt = 0]) => [lng * 10 + 500, lat * -10 + 300 - alt],
   unproject: ([x, y]) => [(x - 500) / 10, (y - 300) / -10],
   longitude: 0,
   latitude: 0,
@@ -262,6 +263,54 @@ test('#movePoint -> zero delta returns same position', t => {
   const changes = movePoint(annotation, delta, mockViewport);
 
   t.deepEqual(changes.anchorPoint, [5, 10], 'should return same anchorPoint for zero delta');
+
+  t.end();
+});
+
+test('#movePoint -> uses pickWorldPosition xyz when provided', t => {
+  const annotation = makePointAnnotation({anchorPoint: [0, 0]});
+  const pickWorldPosition = () => [12.3, 45.6, 80];
+
+  const changes = movePoint(annotation, {x: 10, y: -5}, mockViewport, pickWorldPosition);
+
+  t.deepEqual(
+    changes.anchorPoint,
+    [12.3, 45.6, 80],
+    'should persist reconstructed [lng, lat, altitude]'
+  );
+
+  t.end();
+});
+
+test('#movePoint -> falls back to ground plane when pick returns no altitude', t => {
+  const annotation = makePointAnnotation({anchorPoint: [0, 0]});
+  const pickWorldPosition = () => null;
+
+  const changes = movePoint(annotation, {x: 10, y: -5}, mockViewport, pickWorldPosition);
+
+  t.equal(changes.anchorPoint.length, 2, 'fallback should be [lon, lat]');
+  t.equal(changes.anchorPoint[0], 1, 'longitude should use viewport unproject');
+  t.equal(changes.anchorPoint[1], 0.5, 'latitude should use viewport unproject');
+
+  t.end();
+});
+
+test('#normalizeAnchorPoint', t => {
+  t.deepEqual(normalizeAnchorPoint([1, 2]), [1, 2], 'keeps 2D anchors');
+  t.deepEqual(normalizeAnchorPoint([1, 2, 3]), [1, 2, 3], 'keeps 3D anchors');
+  t.deepEqual(normalizeAnchorPoint([1, 2, 0]), [1, 2, 0], 'keeps zero altitude');
+  t.equal(normalizeAnchorPoint([1]), null, 'rejects incomplete coords');
+  t.equal(normalizeAnchorPoint(null), null, 'rejects null');
+
+  t.end();
+});
+
+test('#makeMarker -> projects altitude into screen y', t => {
+  const ground = makeMarker(makePointAnnotation({anchorPoint: [10, 20]}), mockViewport);
+  const raised = makeMarker(makePointAnnotation({anchorPoint: [10, 20, 15]}), mockViewport);
+
+  t.equal(raised.x, ground.x, 'longitude projection is unchanged by altitude');
+  t.equal(raised.y, ground.y - 15, 'altitude should shift screen y');
 
   t.end();
 });


### PR DESCRIPTION
## Summary
- Annotation snap points now store `[lng, lat, altitude]` and stay on 3D surfaces when the camera pitches.
- Dragging a snap handle uses deck.gl `pickObject({unproject3D: true})` to reconstruct XYZ from the surface under the cursor (3D tiles, extruded GeoJSON, raster terrain, Mapbox 3D buildings).
- Falls back to the ground plane when nothing is picked. Existing `[lng, lat]` configs still load.

Fixes #3713

## Test plan
- [x] Add an annotation and confirm it appears at map center without moving the camera
- [x] Drag the snap point onto extruded GeoJSON / 3D tiles / raster terrain, then pitch the camera — the marker should stay on the surface
- [x] Drag into empty sky — the marker should drop back to the ground plane
- [x] Reload a saved map that still has 2D `[lng, lat]` anchors


https://github.com/user-attachments/assets/8bc462d3-836a-421d-9ec9-2bba3bf7def6



